### PR TITLE
chore: rename ceresdbx to ceresdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,18 +547,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "ceresdbproto"
-version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdbproto.git#dc8eb387ca66347c2ea9d5b00924ae63e7360be3"
-dependencies = [
- "futures",
- "grpcio 0.9.1",
- "protobuf",
- "protobuf-builder",
-]
-
-[[package]]
-name = "ceresdbx"
+name = "ceresdb"
 version = "0.1.0"
 dependencies = [
  "analytic_engine",
@@ -575,6 +564,17 @@ dependencies = [
  "tracing_util",
  "udf",
  "vergen",
+]
+
+[[package]]
+name = "ceresdbproto"
+version = "0.1.0"
+source = "git+https://github.com/CeresDB/ceresdbproto.git#dc8eb387ca66347c2ea9d5b00924ae63e7360be3"
+dependencies = [
+ "futures",
+ "grpcio 0.9.1",
+ "protobuf",
+ "protobuf-builder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ceresdbx"
+name = "ceresdb"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdb@service.alipay.com>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ceresdbx
+# ceresdb
 
 ## Building
 Install clang (for rocksdb)

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -73,7 +73,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            data_path: String::from("/tmp/ceresdbx"),
+            data_path: String::from("/tmp/ceresdb"),
             replay_batch_size: 500,
             max_replay_tables_per_batch: 64,
             write_group_worker_num: 8,

--- a/arrow_deps/src/lib.rs
+++ b/arrow_deps/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! This crate exists to add a dependency on (likely as yet
 //! unpublished) versions of arrow / datafusion so we can
-//! manage the version used by ceresdbx in a single crate.
+//! manage the version used by ceresdb in a single crate.
 
 pub mod display;
 pub mod util;

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -9,7 +9,7 @@ todo
 A config template can be found in `config/bench.toml`.
 
 ## Run benchmarks
-In root directory of `ceresdbx` (not this directory `ceresdbx/benchmarks`), run the following command:
+In root directory of `ceresdb` (not this directory `ceresdb/benchmarks`), run the following command:
 ```bash
 ANALYTIC_BENCH_CONFIG_PATH=/path/to/bench.toml cargo bench -p benchmarks
 ```

--- a/benchmarks/bench.toml
+++ b/benchmarks/bench.toml
@@ -1,8 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 [sst_bench]
-store_path = "/Users/chunshao.rcs/Desktop/work/gitlab/ceresdbx/1/1"
-# store_path = "/Users/yingwen.yyw/data/antmonitor_mid_table_4022"
+store_path = "/tmp/ceresdb/1/1"
 sst_file_name = "37.sst"
 runtime_thread_num = 1
 bench_measurement_time = "30s"
@@ -18,7 +17,7 @@ start_time_ms = 1632985200000
 end_time_ms = 1632985800000
 
 [merge_sst_bench]
-store_path = "/Users/chunshao.rcs/Desktop/work/gitlab/ceresdbx"
+store_path = "/tmp/ceresdb"
 space_id = 1
 table_id = 1
 sst_file_ids = [ 34, 37 ]
@@ -34,7 +33,7 @@ end_time_ms = 0
 # end_time_ms = 1632985800000
 
 [scan_memtable_bench]
-store_path = "/Users/chunshao.rcs/Desktop/work/gitlab/ceresdbx/1/1"
+store_path = "/tmp/ceresdb/1/1"
 sst_file_name = "37.sst"
 runtime_thread_num = 1
 max_projections = 5

--- a/benchmarks/config/sst.toml
+++ b/benchmarks/config/sst.toml
@@ -2,32 +2,29 @@
 
 runtime_thread_num = 4
 
- [rebuild_sst]
- store_path = "/Users/chunshao.rcs/Desktop/work/gitlab/ceresdb/neo/ceresdb/ceresdbx/benchmarks"
- input_file_name = "898.sst"
- # read_batch_row_num = 500
- # read_batch_row_num = 4096
-  read_batch_row_num = 8192
-# read_batch_row_num = 16384
- output_file_name = "tt_t.sst"
- num_rows_per_row_group = 8192
+[rebuild_sst]
+store_path = "/tmp/ceresdb/benchmarks"
+input_file_name = "898.sst"
+read_batch_row_num = 8192
+output_file_name = "tt_t.sst"
+num_rows_per_row_group = 8192
 compression = "SNAPPY"
 
- [rebuild_sst.predicate]
- start_time_ms = 0
- end_time_ms = 0
+[rebuild_sst.predicate]
+start_time_ms = 0
+end_time_ms = 0
 
-#[merge_sst]
-#store_path = "/Users/chunshao.rcs/Desktop/work/gitlab/ceresdb/neo/ceresdb/ceresdbx/benchmarks/2199023255564"
-#space_id = 1
-#table_id = 1
-#sst_file_ids = [1, 17, 19, 24, 31, 37, 43, 45, 9, 14, 18, 21, 27, 34, 40, 44, 5]
-#dedup = true
-#read_batch_row_num = 16384
-#output_store_path = "/Users/yingwen.yyw/data/1/1"
-#output_file_name = "16384-all.sst"
-#num_rows_per_row_group = 16384
-#
-#[merge_sst.predicate]
-#start_time_ms = 0
-#end_time_ms = 0
+[merge_sst]
+store_path = "/tmp/ceresdb/benchmarks/2199023255564"
+space_id = 1
+table_id = 1
+sst_file_ids = [1, 17, 19, 24, 31, 37, 43, 45, 9, 14, 18, 21, 27, 34, 40, 44, 5]
+dedup = true
+read_batch_row_num = 16384
+output_store_path = "/tmp/ceresdb/data/1/1"
+output_file_name = "16384-all.sst"
+num_rows_per_row_group = 16384
+
+[merge_sst.predicate]
+start_time_ms = 0
+end_time_ms = 0

--- a/docker/supervisor/conf.d/ceresdb.conf
+++ b/docker/supervisor/conf.d/ceresdb.conf
@@ -1,4 +1,4 @@
-[program:ceresdbx]
+[program:ceresdb]
 command=sh /usr/bin/ceresdb-start.sh
 autostart=true
 startsecs=3

--- a/docs/example.toml
+++ b/docs/example.toml
@@ -5,7 +5,7 @@ log_level = "info"
 enable_cluster = true
 
 [analytic]
-data_path = "/tmp/ceresdbx"
+data_path = "/tmp/ceresdb"
 sst_data_cache_cap = 10000
 sst_meta_cache_cap = 10000
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -73,7 +73,7 @@ impl Default for Config {
             log_level: "debug".to_string(),
             enable_async_log: true,
             async_log_channel_len: 102400,
-            tracing_log_dir: String::from("/tmp/ceresdbx"),
+            tracing_log_dir: String::from("/tmp/ceresdb"),
             tracing_log_name: String::from("tracing"),
             tracing_level: String::from("info"),
             meta_client: MetaClientConfig {

--- a/server/src/consts.rs
+++ b/server/src/consts.rs
@@ -3,6 +3,6 @@
 //! Common constants
 
 /// Header of catalog name
-pub const CATALOG_HEADER: &str = "x-ceresdbx-catalog";
+pub const CATALOG_HEADER: &str = "x-ceresdb-catalog";
 /// Header of tenant name
-pub const TENANT_HEADER: &str = "x-ceresdbx-access-tenant";
+pub const TENANT_HEADER: &str = "x-ceresdb-access-tenant";

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -459,12 +459,12 @@ impl<'a> Parser<'a> {
         {
             Ok(Some(ColumnOption::Unique { is_primary: true }))
         } else if self.consume_token(TAG) {
-            // Support TAG for ceresdbx
+            // Support TAG for ceresdb
             Ok(Some(ColumnOption::DialectSpecific(vec![
                 Token::make_keyword(TAG),
             ])))
         } else if self.consume_token(UNSIGN) {
-            // Support unsign for ceresdbx
+            // Support unsign for ceresdb
             Ok(Some(ColumnOption::DialectSpecific(vec![
                 Token::make_keyword(UNSIGN),
             ])))

--- a/src/bin/ceresdb-server.rs
+++ b/src/bin/ceresdb-server.rs
@@ -6,7 +6,7 @@
 
 use std::env;
 
-use ceresdbx::setup;
+use ceresdb::setup;
 use clap::{App, Arg};
 use common_util::{panic, toml};
 use log::info;

--- a/src/docs/config.toml
+++ b/src/docs/config.toml
@@ -6,7 +6,7 @@ grpc_port = 8831
 log_level = "debug"
 
 [analytic]
-data_path = "/tmp/ceresdbx/"
+data_path = "/tmp/ceresdb/"
 
 [analytic.table_opts]
 arena_block_size = 128

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-//! ceresdbx
+//! ceresdb
 
 pub mod setup;
 mod signal_handler;


### PR DESCRIPTION
Rename all the words `ceresdbx` to `ceresdb` across the codebase.