### PR TITLE
chore(deps): switch to rust-rocksdb master branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.2#23bd00d50c79b40b6a32c11446c86f0714fa7844"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=773784178a0e8e5fdad81f4fd85448a3014a3700#773784178a0e8e5fdad81f4fd85448a3014a3700"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.2#23bd00d50c79b40b6a32c11446c86f0714fa7844"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=773784178a0e8e5fdad81f4fd85448a3014a3700#773784178a0e8e5fdad81f4fd85448a3014a3700"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -3143,7 +3143,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?branch=tikv-5.2#23bd00d50c79b40b6a32c11446c86f0714fa7844"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=773784178a0e8e5fdad81f4fd85448a3014a3700#773784178a0e8e5fdad81f4fd85448a3014a3700"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -20,5 +20,5 @@ futures = { version = "0.3", features = ["async-await"] }
 
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
-branch = "tikv-5.2"
+rev = "773784178a0e8e5fdad81f4fd85448a3014a3700"
 features = ["portable"]


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #34 

# Rationale for this change
 
We are using an outdated branch (`tikv-5.2`, which is updated around 7 months ago) of `rust-rocksdb`. It brings lots of compile errors either in upgrading other dependencies #26 or in new toolchains #34.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Switch to the master branch.

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?
no
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No?
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
