### PR TITLE
refactor: Simplify and optimize `should_limit` method in Limiter

### DIFF
--- a/server/src/limiter.rs
+++ b/server/src/limiter.rs
@@ -22,19 +22,12 @@ impl Default for Limiter {
 impl Limiter {
     pub fn should_limit(&self, plan: &Plan) -> bool {
         match plan {
-            Plan::Query(query) => {
-                let read_reject_list = self.read_reject_list.read().unwrap().clone();
-                for table in read_reject_list {
-                    if query
-                        .tables
-                        .get(TableReference::from(table.as_str()))
-                        .is_some()
-                    {
-                        return true;
-                    }
-                }
-                false
-            }
+            Plan::Query(query) => self.read_reject_list.read().unwrap().iter().any(|table| {
+                query
+                    .tables
+                    .get(TableReference::from(table.as_str()))
+                    .is_some()
+            }),
             Plan::Insert(insert) => self
                 .write_reject_list
                 .read()


### PR DESCRIPTION
# Rationale for this change

<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This MR simplifies the `Plan::Query` case to improve the performance and readability.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

There are 2 changes:
1. Remove inefficient `clone()` which can be expensive and simply iterate over values holding the lock.
2. Refactor `for` loop into `.iter().any(...)` which can be potentially faster than `for` loop as compiler could optimize it.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

No

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

Run limiter tests.