### PR TITLE
feat: new flush policy - purge flush

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -178,7 +178,9 @@ pub struct TableFlushRequest {
 pub enum TableFlushPolicy {
     /// Dump memtable to sst file.
     Dump,
+    // TODO: use this policy and remove "allow(dead_code)"
     /// Drop memtables.
+    #[allow(dead_code)]
     Purge,
 }
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -167,6 +167,18 @@ pub struct TableFlushRequest {
     pub table_data: TableDataRef,
     /// Max id of memtable to flush (inclusive).
     pub max_memtable_id: MemTableId,
+    /// Max sequence number to flush (inclusive).
+    pub max_sequence: SequenceNumber,
+    /// Flush policy.
+    pub policy: TableFlushPolicy,
+}
+
+/// Policy of how to perform flush operation.
+pub enum TableFlushPolicy {
+    /// Dump memtable to sst file.
+    Dump,
+    /// Drop memtables.
+    Purge,
 }
 
 impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
@@ -305,6 +317,8 @@ where
         Ok(TableFlushRequest {
             table_data: table_data.clone(),
             max_memtable_id: table_data.last_memtable_id(),
+            max_sequence: last_sequence,
+            policy: TableFlushPolicy::Dump,
         })
     }
 
@@ -370,6 +384,8 @@ where
         let TableFlushRequest {
             table_data,
             max_memtable_id,
+            max_sequence,
+            policy,
         } = flush_req;
 
         let current_version = table_data.current_version();

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -391,9 +391,7 @@ where
         } = flush_req;
 
         let current_version = table_data.current_version();
-        let mut mems_to_flush = FlushableMemTables::default();
-
-        current_version.pick_memtables_to_flush(*max_memtable_id, &mut mems_to_flush);
+        let mems_to_flush = current_version.pick_memtables_to_flush(*max_sequence);
 
         if mems_to_flush.is_empty() {
             return Ok(());

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -380,12 +380,12 @@ where
         }
     }
 
-    /// Caller should guarantee flush of single table is sequential
+    /// Each table can only have one running flush job.
     pub(crate) async fn flush_memtables(&self, flush_req: &TableFlushRequest) -> Result<()> {
-        // TODO(yingwen): Record memtables num to flush as statistics
         let TableFlushRequest {
             table_data,
-            max_memtable_id,
+            // TODO: consider deprecate this field,
+            max_memtable_id: _,
             max_sequence,
             policy,
         } = flush_req;
@@ -405,6 +405,7 @@ where
 
         // Start flush duration timer.
         let local_metrics = table_data.metrics.local_flush_metrics();
+        local_metrics.observe_memtables_num(mems_to_flush.len());
         let _timer = local_metrics.flush_duration_histogram.start_timer();
 
         match policy {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -393,13 +393,11 @@ where
                                 table: &table_data.name,
                                 table_id: table_data.id,
                             })?;
-                        self.flush_memtables_to_outputs(&flush_req)
-                            .await
-                            .context(FlushTable {
-                                space_id: table_data.space_id,
-                                table: &table_data.name,
-                                table_id: table_data.id,
-                            })?;
+                        self.flush_memtables(&flush_req).await.context(FlushTable {
+                            space_id: table_data.space_id,
+                            table: &table_data.name,
+                            table_id: table_data.id,
+                        })?;
                     }
                 }
             }

--- a/analytic_engine/src/table/metrics.rs
+++ b/analytic_engine/src/table/metrics.rs
@@ -111,6 +111,7 @@ pub struct Metrics {
     pub flush_duration_histogram: Histogram,
     flush_sst_num_histogram: Histogram,
     flush_sst_size_histogram: Histogram,
+    flush_memtables_num_histogram: Histogram,
 
     pub compaction_duration_histogram: Histogram,
     compaction_sst_num_histogram: Histogram,
@@ -135,6 +136,8 @@ impl Metrics {
                 .with_label_values(&[table_name]),
             flush_sst_num_histogram: TABLE_FLUSH_SST_NUM_HISTOGRAM.with_label_values(&[table_name]),
             flush_sst_size_histogram: TABLE_FLUSH_SST_SIZE_HISTOGRAM
+                .with_label_values(&[table_name]),
+            flush_memtables_num_histogram: TABLE_FLUSH_SST_NUM_HISTOGRAM
                 .with_label_values(&[table_name]),
 
             compaction_duration_histogram: TABLE_COMPACT_DURATION_HISTOGRAM
@@ -181,6 +184,7 @@ impl Metrics {
             flush_duration_histogram: self.flush_duration_histogram.local(),
             flush_sst_num_histogram: self.flush_sst_num_histogram.local(),
             flush_sst_size_histogram: self.flush_sst_size_histogram.local(),
+            flush_memtables_num_histogram: self.flush_memtables_num_histogram.local(),
         }
     }
 
@@ -215,6 +219,7 @@ pub struct LocalFlushMetrics {
     pub flush_duration_histogram: LocalHistogram,
     flush_sst_num_histogram: LocalHistogram,
     flush_sst_size_histogram: LocalHistogram,
+    flush_memtables_num_histogram: LocalHistogram,
 }
 
 impl LocalFlushMetrics {
@@ -225,5 +230,9 @@ impl LocalFlushMetrics {
     pub fn observe_sst_size(&self, sst_size: u64) {
         // Convert bytes to KB.
         self.flush_sst_size_histogram.observe(sst_size as f64 / KB);
+    }
+
+    pub fn observe_memtables_num(&self, num: usize) {
+        self.flush_memtables_num_histogram.observe(num as f64);
     }
 }

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -312,19 +312,12 @@ impl MemTableView {
         }
     }
 
-    /// Returns the memtables that needs to be flushed.
-    /// - Id of returned memtables are no greater than `max_memtable_id`.
-    /// - The last sequences of the returned memtables are continuous and can be
-    ///   used as flushed sequence.
-    /// - All memTables with same last sequence must be picked to the same
-    ///   MemTableVec, so we can update flushed sequence safely (The
-    ///   `max_memtable_id` should also guarantee this).
-    /// - If freezed memtable exists, that memtable will be return if memtable
-    ///   id is no greater than `max_memtable_id` (The memtable id should always
-    ///   less than `max_memtable_id`).
+    /// Returns memtables need to be flushed. Only sampling memtable and
+    /// immutables will be considered. And only memtables which `last_sequence`
+    /// less or equal to the given [SequenceNumber] will be picked.
     ///
-    /// Now the returned memtables are also ordered by memtable id, but this may
-    /// change in the future.
+    /// This method assumes that one sequence number will not exist in multiple
+    /// memtables.
     fn pick_memtables_to_flush(&self, last_sequence: SequenceNumber) -> FlushableMemTables {
         let mut mems = FlushableMemTables::default();
 

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -229,6 +229,10 @@ impl FlushableMemTables {
 
         memtable_ids
     }
+
+    pub fn len(&self) -> usize {
+        self.sampling_mem.as_ref().map_or(0, |_| 1) + self.memtables.len()
+    }
 }
 
 /// Vec to store memtables

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -310,7 +310,7 @@ impl MemTableView {
 
     /// Returns the memtables that needs to be flushed.
     /// - Id of returned memtables are no greater than `max_memtable_id`.
-    /// - The last sequences of the returned memtables are continuous and can
+    /// - The last sequences of the returned memtables are continuous and can be
     ///   used as flushed sequence.
     /// - All memTables with same last sequence must be picked to the same
     ///   MemTableVec, so we can update flushed sequence safely (The


### PR DESCRIPTION
# Which issue does this PR close?

Closes #68 

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Implement `Purge` flush policy. Detailed in #68.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

- new flush option `TableFlushPolicy`
- new field in `TableFlushRequest`: `max_sequence` and `policy`
- change `MemTableView::pick_memtables_to_flush` to pick memtable based on sequence number rather than memtable id

# Are there any user-facing changes?
no
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
By existing UT