### PR TITLE
chore: set timeout for CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   linux-build-lib:
     name: Build Libraries with Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         rust: [1.59.0]
@@ -70,6 +71,7 @@ jobs:
     name: Libraries Style Check
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         rust: [1.59.0]
@@ -96,6 +98,7 @@ jobs:
     name: Clippy
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         rust: [1.59.0]
@@ -141,6 +144,7 @@ jobs:
     name: Test Workspace with Rust ${{ matrix.rust }}
     needs: [linux-build-lib]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         rust: [1.59.0]


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Sometimes CI can get stuck for a day:
https://github.com/CeresDB/ceresdb/runs/7129006500?check_suite_focus=true


# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

Set timeout params to kill dead CI. Build jobs have 30 mins and non-build job has 10 mins

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

no

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

no need