### PR TITLE
chore: bump rocksdb to branch tikv-6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?rev=6f263ec5638835eda5911a34046fc303bc307dc7#6f263ec5638835eda5911a34046fc303bc307dc7"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7e4d1901cbe3f2782c5c63cb7af628bac"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?rev=6f263ec5638835eda5911a34046fc303bc307dc7#6f263ec5638835eda5911a34046fc303bc307dc7"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7e4d1901cbe3f2782c5c63cb7af628bac"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -4226,7 +4226,7 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?rev=6f263ec5638835eda5911a34046fc303bc307dc7#6f263ec5638835eda5911a34046fc303bc307dc7"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7e4d1901cbe3f2782c5c63cb7af628bac"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -26,5 +26,5 @@ env_logger = "0.6"
 
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
-rev = "6f263ec5638835eda5911a34046fc303bc307dc7"
+rev = "084102f7e4d1901cbe3f2782c5c63cb7af628bac" # at branch tikv-6.1
 features = ["portable"]


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #16

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Bump rocksdb (again) to make it able to compile under gcc 12 with release mode

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

Bump rocksdb. The branch is `tikv-6.1` which may be more stable (https://github.com/tikv/rust-rocksdb/pull/704#issuecomment-1171999478)

# Are there any user-facing changes?

no
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

`cargo build --release` with `gcc (GCC) 12.1.0`
