### PR TITLE
fix: Query fields are sorted by creation

### DIFF
--- a/server/src/handlers/sql.rs
+++ b/server/src/handlers/sql.rs
@@ -2,14 +2,15 @@
 
 //! SQL request handler
 
-use std::collections::HashMap;
-
 use arrow_deps::arrow::error::Result as ArrowResult;
-use common_types::{datum::Datum, request_id::RequestId};
+use common_types::{
+    datum::{Datum, DatumKind},
+    request_id::RequestId,
+};
 use interpreters::{context::Context as InterpreterContext, factory::Factory, interpreter::Output};
 use log::info;
 use query_engine::executor::RecordBatchVec;
-use serde_derive::Serialize;
+use serde::Serialize;
 use snafu::ensure;
 use sql::{
     frontend::{Context as SqlContext, Frontend},
@@ -21,15 +22,11 @@ use crate::handlers::{
     prelude::*,
 };
 
+type ResponseRows = Vec<ResponseRow>;
+
 #[derive(Debug, Deserialize)]
 pub struct Request {
     query: String,
-}
-
-impl From<String> for Request {
-    fn from(query: String) -> Self {
-        Self { query }
-    }
 }
 
 // TODO(yingwen): Improve serialize performance
@@ -37,7 +34,27 @@ impl From<String> for Request {
 #[serde(rename_all = "snake_case")]
 pub enum Response {
     AffectedRows(usize),
-    Rows(Vec<HashMap<String, Datum>>),
+    #[serde(with = "http_format")]
+    Rows(ResponseRows),
+}
+
+pub struct ResponseRow {
+    pub column_names: Vec<ResponseColumn>,
+    pub data: Vec<Vec<Datum>>,
+}
+
+pub struct ResponseColumn {
+    pub name: String,
+    pub data_type: DatumKind,
+}
+
+#[derive(Serialize)]
+struct Row(#[serde(with = "row_format")] Vec<(String, Datum)>);
+
+impl From<String> for Request {
+    fn from(query: String) -> Self {
+        Self { query }
+    }
 }
 
 pub async fn handle_sql<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
@@ -128,26 +145,100 @@ fn convert_output(output: Output) -> ArrowResult<Response> {
 }
 
 fn convert_records(records: RecordBatchVec) -> ArrowResult<Response> {
-    let total_rows = records.iter().map(|v| v.num_rows()).sum();
-    let mut resp = Vec::with_capacity(total_rows);
+    // let total_rows = records.iter().map(|v| v.num_rows()).sum();
+    // let mut resp = Vec::with_capacity(total_rows);
+
+    let mut response_rows = Vec::new();
     for record_batch in records {
         let num_cols = record_batch.num_columns();
         let num_rows = record_batch.num_rows();
         let schema = record_batch.schema();
 
+        let mut column_names = Vec::with_capacity(num_cols);
+        let mut column_data = Vec::with_capacity(num_rows);
+
+        for col_idx in 0..num_cols {
+            let column_schema = schema.column(col_idx).clone();
+            column_names.push(ResponseColumn {
+                name: column_schema.name,
+                data_type: column_schema.data_type,
+            });
+        }
+
         for row_idx in 0..num_rows {
-            let mut row = HashMap::with_capacity(num_cols);
+            let mut row_data = Vec::with_capacity(num_cols);
             for col_idx in 0..num_cols {
                 let column = record_batch.column(col_idx);
                 let column = column.datum(row_idx);
 
-                let column_name = schema.column(col_idx).name.clone();
-                row.insert(column_name, column);
+                row_data.push(column);
             }
 
-            resp.push(row);
+            column_data.push(row_data);
         }
+
+        response_rows.push(ResponseRow {
+            column_names,
+            data: column_data,
+        })
     }
 
-    Ok(Response::Rows(resp))
+    Ok(Response::Rows(response_rows))
+}
+
+mod http_format {
+    use serde::{
+        ser::SerializeSeq,
+        Serializer,
+    };
+
+    use super::Row;
+    use crate::handlers::sql::ResponseRows;
+
+    pub fn serialize<S>(records: &ResponseRows, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let total_count = records.iter().map(|row| row.data.len()).sum();
+        let mut seq = serializer.serialize_seq(Some(total_count))?;
+
+        for record in records {
+            let column_names = &record.column_names;
+            // let mut map = seq.serialize_map(Some(column_names.len()))?;
+
+            for rows in &record.data {
+                let data = rows
+                    .iter()
+                    .enumerate()
+                    .map(|(col_idx, datum)| {
+                        let column_name = &column_names[col_idx].name.clone();
+                        (column_name.clone(), datum.clone())
+                    })
+                    .collect::<Vec<_>>();
+                let row = Row(data);
+                seq.serialize_element(&row)?;
+            }
+        }
+
+        seq.end()
+    }
+}
+
+mod row_format {
+    use common_types::datum::Datum;
+    use serde::{
+        ser::SerializeMap,
+        Serializer,
+    };
+
+    pub fn serialize<S>(rows: &[(String, Datum)], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(rows.len()))?;
+        for (key, value) in rows {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
 }

--- a/server/src/mysql/writer.rs
+++ b/server/src/mysql/writer.rs
@@ -1,11 +1,12 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use std::collections::HashMap;
-
-use common_types::datum::Datum;
+use common_types::datum::{Datum, DatumKind};
 use opensrv_mysql::{Column, ColumnFlags, ColumnType, OkResponse, QueryResultWriter};
 
-use crate::{handlers::sql::Response, mysql::error::Result};
+use crate::{
+    handlers::sql::{Response, ResponseColumn, ResponseRow},
+    mysql::error::Result,
+};
 
 pub struct MysqlQueryResultWriter<'a, W: std::io::Write> {
     inner: Option<QueryResultWriter<'a, W>>,
@@ -35,72 +36,99 @@ impl<'a, W: std::io::Write> MysqlQueryResultWriter<'a, W> {
         Ok(())
     }
 
-    fn write_rows(
+    fn write_response_row(
         writer: QueryResultWriter<'a, W>,
-        rows: Vec<HashMap<String, Datum>>,
+        response_row: &ResponseRow,
     ) -> Result<()> {
         let default_response = OkResponse::default();
-        if rows.is_empty() {
+        if response_row.column_names.is_empty() {
             writer.completed(default_response)?;
             return Ok(());
         }
 
-        let columns = &rows[0]
+        let columns = &response_row
+            .column_names
             .iter()
-            .map(|(k, v)| make_column_by_field(k, v))
+            .map(make_column_by_field)
             .collect::<Vec<_>>();
         let mut row_writer = writer.start(columns)?;
 
-        for row in &rows {
-            for column in columns {
-                let key = &column.column;
-                if let Some(val) = row.get(key) {
-                    let data_type = convert_field_type(val);
-                    let re = match (data_type, val) {
-                        (_, Datum::Varbinary(_)) => row_writer.write_col("[Varbinary]"),
-                        (_, Datum::Null) => row_writer.write_col(None::<u8>),
-                        (ColumnType::MYSQL_TYPE_LONG, Datum::Timestamp(t)) => {
-                            row_writer.write_col(t.as_i64())
-                        }
-                        (ColumnType::MYSQL_TYPE_VARCHAR, v) => {
-                            row_writer.write_col(v.as_str().map_or("", |s| s))
-                        }
-                        (ColumnType::MYSQL_TYPE_LONG, v) => {
-                            row_writer.write_col(v.as_u64().map_or(0, |v| v))
-                        }
-                        (ColumnType::MYSQL_TYPE_SHORT, Datum::Boolean(b)) => {
-                            row_writer.write_col(*b as i8)
-                        }
-                        (ColumnType::MYSQL_TYPE_DOUBLE, v) => {
-                            row_writer.write_col(v.as_f64().map_or(0.0, |v| v))
-                        }
-                        (ColumnType::MYSQL_TYPE_FLOAT, v) => {
-                            row_writer.write_col(v.as_f64().map_or(0.0, |v| v))
-                        }
-                        (_, v) => Err(std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("Unsupported column type, val: {:?}", v),
-                        )),
-                    };
-                    re?;
-                } else {
-                    row_writer.write_col(None::<u8>)?;
-                }
+        for row in &response_row.data {
+            for val in row {
+                let data_type = convert_field_type(val);
+                let re = match (data_type, val) {
+                    (_, Datum::Varbinary(v)) => row_writer.write_col(v.as_ref()),
+                    (_, Datum::Null) => row_writer.write_col(None::<u8>),
+                    (ColumnType::MYSQL_TYPE_LONG, Datum::Timestamp(t)) => {
+                        row_writer.write_col(t.as_i64())
+                    }
+                    (ColumnType::MYSQL_TYPE_VARCHAR, v) => {
+                        row_writer.write_col(v.as_str().map_or("", |s| s))
+                    }
+                    (ColumnType::MYSQL_TYPE_LONG, v) => {
+                        row_writer.write_col(v.as_u64().map_or(0, |v| v))
+                    }
+                    (ColumnType::MYSQL_TYPE_SHORT, Datum::Boolean(b)) => {
+                        row_writer.write_col(*b as i8)
+                    }
+                    (ColumnType::MYSQL_TYPE_DOUBLE, v) => {
+                        row_writer.write_col(v.as_f64().map_or(0.0, |v| v))
+                    }
+                    (ColumnType::MYSQL_TYPE_FLOAT, v) => {
+                        row_writer.write_col(v.as_f64().map_or(0.0, |v| v))
+                    }
+                    (_, v) => Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("Unsupported column type, val: {:?}", v),
+                    )),
+                };
+                re?;
             }
             row_writer.end_row()?;
         }
 
         Ok(())
     }
+
+    fn write_rows(writer: QueryResultWriter<'a, W>, rows: Vec<ResponseRow>) -> Result<()> {
+        let default_response = OkResponse::default();
+        if rows.is_empty() {
+            writer.completed(default_response)?;
+            return Ok(());
+        }
+
+        let row = &rows[0];
+        Self::write_response_row(writer, row)
+    }
 }
 
-fn make_column_by_field(k: &str, v: &Datum) -> Column {
-    let column_type = convert_field_type(v);
+fn make_column_by_field(column: &ResponseColumn) -> Column {
+    let column_type = conver_datum_kind_type(&column.data_type);
     Column {
         table: "".to_string(),
-        column: k.to_string(),
+        column: column.name.clone(),
         coltype: column_type,
         colflags: ColumnFlags::empty(),
+    }
+}
+
+fn conver_datum_kind_type(data_type: &DatumKind) -> ColumnType {
+    match data_type {
+        DatumKind::Timestamp => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::Double => ColumnType::MYSQL_TYPE_DOUBLE,
+        DatumKind::Float => ColumnType::MYSQL_TYPE_FLOAT,
+        DatumKind::Varbinary => ColumnType::MYSQL_TYPE_LONG_BLOB,
+        DatumKind::String => ColumnType::MYSQL_TYPE_VARCHAR,
+        DatumKind::UInt64 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::UInt32 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::UInt16 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::UInt8 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::Int64 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::Int32 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::Int16 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::Int8 => ColumnType::MYSQL_TYPE_LONG,
+        DatumKind::Boolean => ColumnType::MYSQL_TYPE_SHORT,
+        DatumKind::Null => ColumnType::MYSQL_TYPE_NULL,
     }
 }
 
@@ -126,14 +154,15 @@ fn convert_field_type(field: &Datum) -> ColumnType {
 
 #[cfg(test)]
 mod tests {
-    use common_types::{datum::Datum, time::Timestamp};
+    use common_types::{
+        datum::DatumKind,
+    };
     use opensrv_mysql::{Column, ColumnFlags, ColumnType};
 
-    use crate::mysql::writer::make_column_by_field;
+    use crate::{handlers::sql::ResponseColumn, mysql::writer::make_column_by_field};
 
     struct MakeColumnTest {
-        k: &'static str,
-        v: Datum,
+        column: ResponseColumn,
         target_type: ColumnType,
     }
 
@@ -141,28 +170,38 @@ mod tests {
     fn test_make_column_by_field() {
         let tests = [
             MakeColumnTest {
-                k: "id",
-                v: Datum::UInt64(1),
+                column: ResponseColumn {
+                    name: "id".to_string(),
+                    data_type: DatumKind::Int32,
+                },
                 target_type: ColumnType::MYSQL_TYPE_LONG,
             },
             MakeColumnTest {
-                k: "name",
-                v: Datum::String("Bob".into()),
+                column: ResponseColumn {
+                    name: "name".to_string(),
+                    data_type: DatumKind::String,
+                },
                 target_type: ColumnType::MYSQL_TYPE_VARCHAR,
             },
             MakeColumnTest {
-                k: "birthday",
-                v: Datum::Timestamp(Timestamp::now()),
+                column: ResponseColumn {
+                    name: "birthday".to_string(),
+                    data_type: DatumKind::Timestamp,
+                },
                 target_type: ColumnType::MYSQL_TYPE_LONG,
             },
             MakeColumnTest {
-                k: "is_show",
-                v: Datum::Boolean(true),
+                column: ResponseColumn {
+                    name: "is_show".to_string(),
+                    data_type: DatumKind::Boolean,
+                },
                 target_type: ColumnType::MYSQL_TYPE_SHORT,
             },
             MakeColumnTest {
-                k: "money",
-                v: Datum::Double(12.25),
+                column: ResponseColumn {
+                    name: "money".to_string(),
+                    data_type: DatumKind::Double,
+                },
                 target_type: ColumnType::MYSQL_TYPE_DOUBLE,
             },
         ];
@@ -170,11 +209,11 @@ mod tests {
         for test in tests {
             let target_column = Column {
                 table: "".to_string(),
-                column: test.k.to_string(),
+                column: test.column.name.clone(),
                 coltype: test.target_type,
                 colflags: ColumnFlags::default(),
             };
-            assert_eq!(target_column, make_column_by_field(test.k, &test.v));
+            assert_eq!(target_column, make_column_by_field(&test.column));
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #60 

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->
This PR modifies the Response data structure in ceresdb/server/src/handlers/sql.rs. 
* ResponseRow: one record with response
* ResponseRows: type of Vec<ResponseRow>
* ResponseColumn: column struct, for keep column type and name
* Row: Helper type that is convenient for http serialize, this is one map
* mod http_format: ResponseRow in custom format by Serializer
* mod row_format: Row in custom format by Serializer

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->
not

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

