### PR TITLE
refactor: remove `Store` type param in `Instance`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3283,6 +3283,8 @@ dependencies = [
  "lru",
  "object_store 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "oss-rust-sdk",
+ "serde",
+ "serde_derive",
  "snafu 0.6.10",
  "tempfile",
  "tokio 1.19.2",

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -20,7 +20,6 @@ use common_util::{
     runtime::{JoinHandle, Runtime},
 };
 use log::{debug, error, info, warn};
-use object_store::ObjectStore;
 use serde_derive::Deserialize;
 use snafu::{ResultExt, Snafu};
 use table_engine::table::TableId;
@@ -299,7 +298,7 @@ impl OngoingTask {
     }
 }
 
-struct ScheduleWorker<Wal, Meta, Store, Fa> {
+struct ScheduleWorker<Wal, Meta, Fa> {
     sender: Sender<ScheduleTask>,
     receiver: Receiver<ScheduleTask>,
     space_store: Arc<SpaceStore<Wal, Meta, Fa>>,
@@ -323,9 +322,8 @@ async fn schedule_table_compaction(sender: Sender<ScheduleTask>, request: TableC
 impl<
         Wal: Send + Sync + 'static,
         Meta: Manifest + Send + Sync + 'static,
-        Store: ObjectStore + Send + Sync + 'static,
         Fa: Factory + Send + Sync + 'static,
-    > ScheduleWorker<Wal, Meta, Store, Fa>
+    > ScheduleWorker<Wal, Meta, Fa>
 {
     async fn schedule_loop(&mut self) {
         while self.running.load(Ordering::Relaxed) {

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -224,10 +224,9 @@ impl SchedulerImpl {
     pub fn new<
         Wal: Send + Sync + 'static,
         Meta: Manifest + Send + Sync + 'static,
-        Store: ObjectStore + Send + Sync + 'static,
         Fa: Factory + Send + Sync + 'static,
     >(
-        space_store: Arc<SpaceStore<Wal, Meta, Store, Fa>>,
+        space_store: Arc<SpaceStore<Wal, Meta, Fa>>,
         runtime: Arc<Runtime>,
         config: SchedulerConfig,
     ) -> Self {
@@ -303,7 +302,7 @@ impl OngoingTask {
 struct ScheduleWorker<Wal, Meta, Store, Fa> {
     sender: Sender<ScheduleTask>,
     receiver: Receiver<ScheduleTask>,
-    space_store: Arc<SpaceStore<Wal, Meta, Store, Fa>>,
+    space_store: Arc<SpaceStore<Wal, Meta, Fa>>,
     runtime: Arc<Runtime>,
     schedule_interval: Duration,
     picker_manager: PickerManager,

--- a/analytic_engine/src/engine.rs
+++ b/analytic_engine/src/engine.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::info;
-use object_store::ObjectStore;
 use snafu::ResultExt;
 use table_engine::{
     engine::{
@@ -29,12 +28,12 @@ use crate::{
 };
 
 /// TableEngine implementation
-pub struct TableEngineImpl<Wal, Meta, Store, Fa> {
+pub struct TableEngineImpl<Wal, Meta, Fa> {
     /// Instance of the table engine
-    instance: InstanceRef<Wal, Meta, Store, Fa>,
+    instance: InstanceRef<Wal, Meta, Fa>,
 }
 
-impl<Wal, Meta, Store, Fa> Clone for TableEngineImpl<Wal, Meta, Store, Fa> {
+impl<Wal, Meta, Fa> Clone for TableEngineImpl<Wal, Meta, Fa> {
     fn clone(&self) -> Self {
         Self {
             instance: self.instance.clone(),
@@ -42,19 +41,15 @@ impl<Wal, Meta, Store, Fa> Clone for TableEngineImpl<Wal, Meta, Store, Fa> {
     }
 }
 
-impl<
-        Wal: WalManager + Send + Sync + 'static,
-        Meta: Manifest + Send + Sync + 'static,
-        Store: ObjectStore,
-        Fa,
-    > TableEngineImpl<Wal, Meta, Store, Fa>
+impl<Wal: WalManager + Send + Sync + 'static, Meta: Manifest + Send + Sync + 'static, Fa>
+    TableEngineImpl<Wal, Meta, Fa>
 {
-    pub fn new(instance: InstanceRef<Wal, Meta, Store, Fa>) -> Self {
+    pub fn new(instance: InstanceRef<Wal, Meta, Fa>) -> Self {
         Self { instance }
     }
 }
 
-impl<Wal, Meta, Store, Fa> Drop for TableEngineImpl<Wal, Meta, Store, Fa> {
+impl<Wal, Meta, Fa> Drop for TableEngineImpl<Wal, Meta, Fa> {
     fn drop(&mut self) {
         info!("Table engine dropped");
     }
@@ -64,9 +59,8 @@ impl<Wal, Meta, Store, Fa> Drop for TableEngineImpl<Wal, Meta, Store, Fa> {
 impl<
         Wal: WalManager + Send + Sync + 'static,
         Meta: Manifest + Send + Sync + 'static,
-        Store: ObjectStore,
         Fa: Factory + Send + Sync + 'static,
-    > TableEngine for TableEngineImpl<Wal, Meta, Store, Fa>
+    > TableEngine for TableEngineImpl<Wal, Meta, Fa>
 {
     fn engine_type(&self) -> &str {
         ANALYTIC_ENGINE_TYPE
@@ -170,11 +164,9 @@ impl<
 }
 
 /// Reference to instance based on rocksdb wal.
-pub(crate) type RocksInstanceRef<Store> =
-    InstanceRef<RocksImpl, ManifestImpl<RocksImpl>, Store, FactoryImpl>;
+pub(crate) type RocksInstanceRef = InstanceRef<RocksImpl, ManifestImpl<RocksImpl>, FactoryImpl>;
 /// Reference to instance replicating data by obkv wal.
-pub(crate) type ReplicatedInstanceRef<Store> =
-    InstanceRef<ObkvWal, ManifestImpl<ObkvWal>, Store, FactoryImpl>;
+pub(crate) type ReplicatedInstanceRef = InstanceRef<ObkvWal, ManifestImpl<ObkvWal>, FactoryImpl>;
 
 /// Generate the space id from the schema id with assumption schema id is unique
 /// globally.

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -5,7 +5,6 @@
 use std::{collections::HashMap, sync::Arc};
 
 use log::info;
-use object_store::ObjectStore;
 use snafu::{ensure, ResultExt};
 use table_engine::table::AlterSchemaRequest;
 use tokio::sync::oneshot;
@@ -32,11 +31,10 @@ use crate::{
     table_options,
 };
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     // Alter schema need to be handled by write worker.

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use log::{info, warn};
-use object_store::ObjectStore;
 use snafu::ResultExt;
 use table_engine::engine::CloseTableRequest;
 use tokio::sync::oneshot;
@@ -23,11 +22,10 @@ use crate::{
     sst::factory::Factory,
 };
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     /// Close table need to be handled by write worker.

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use log::info;
-use object_store::ObjectStore;
 use snafu::ResultExt;
 use table_engine::engine::CreateTableRequest;
 use tokio::sync::oneshot;
@@ -27,11 +26,10 @@ use crate::{
     table_options,
 };
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     /// Create table need to be handled by write worker.

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use log::{info, warn};
-use object_store::ObjectStore;
 use snafu::ResultExt;
 use table_engine::engine::DropTableRequest;
 use tokio::sync::oneshot;
@@ -26,11 +25,10 @@ use crate::{
     sst::factory::Factory,
 };
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     /// Drop a table under given space

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use common_types::schema::Version;
 use common_util::define_result;
-use object_store::ObjectStore;
 use snafu::{Backtrace, OptionExt, Snafu};
 use table_engine::{
     engine::{CloseTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest},
@@ -207,11 +206,10 @@ impl From<Error> for table_engine::engine::Error {
     }
 }
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     /// Find space by name, create if the space is not exists

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -19,7 +19,6 @@ use futures::{
     stream, SinkExt, TryStreamExt,
 };
 use log::{error, info};
-use object_store::ObjectStore;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::{predicate::Predicate, table::Result as TableResult};
 use tokio::sync::oneshot;
@@ -182,11 +181,10 @@ pub enum TableFlushPolicy {
     Purge,
 }
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     /// Flush this table.
@@ -768,7 +766,7 @@ where
     }
 }
 
-impl<Wal, Meta: Manifest, Store: ObjectStore, Fa: Factory> SpaceStore<Wal, Meta, Store, Fa> {
+impl<Wal, Meta: Manifest, Fa: Factory> SpaceStore<Wal, Meta, Fa> {
     pub(crate) async fn compact_table(
         &self,
         runtime: Arc<Runtime>,

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -25,7 +25,7 @@ use std::{
 use common_util::{define_result, runtime::Runtime};
 use log::info;
 use mem_collector::MemUsageCollector;
-use object_store::ObjectStore;
+use object_store::ObjectStoreRef;
 use parquet::{DataCacheRef, MetaCacheRef};
 use snafu::{ResultExt, Snafu};
 use table_engine::engine::EngineRuntimes;
@@ -93,7 +93,7 @@ pub struct SpaceStore<Wal, Meta, Fa> {
     /// Wal of all tables
     wal_manager: Wal,
     /// Sst storage.
-    store: Arc<dyn ObjectStore>,
+    store: ObjectStoreRef,
     /// Sst factory.
     sst_factory: Fa,
 
@@ -120,7 +120,7 @@ impl<Wal, Meta, Fa> SpaceStore<Wal, Meta, Fa> {
 }
 
 impl<Wal, Meta, Fa> SpaceStore<Wal, Meta, Fa> {
-    fn store_ref(&self) -> &dyn ObjectStore {
+    fn store_ref(&self) -> &ObjectStoreRef {
         &self.store
     }
 

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -85,7 +85,7 @@ impl Spaces {
     }
 }
 
-pub struct SpaceStore<Wal, Meta, Store, Fa> {
+pub struct SpaceStore<Wal, Meta, Fa> {
     /// All spaces of the engine.
     spaces: RwLock<Spaces>,
     /// Manifest (or meta) stores meta data of the engine instance.
@@ -93,7 +93,7 @@ pub struct SpaceStore<Wal, Meta, Store, Fa> {
     /// Wal of all tables
     wal_manager: Wal,
     /// Sst storage.
-    store: Arc<Store>,
+    store: Arc<dyn ObjectStore>,
     /// Sst factory.
     sst_factory: Fa,
 
@@ -101,13 +101,13 @@ pub struct SpaceStore<Wal, Meta, Store, Fa> {
     data_cache: Option<DataCacheRef>,
 }
 
-impl<Wal, Meta, Store, Fa> Drop for SpaceStore<Wal, Meta, Store, Fa> {
+impl<Wal, Meta, Fa> Drop for SpaceStore<Wal, Meta, Fa> {
     fn drop(&mut self) {
         info!("SpaceStore dropped");
     }
 }
 
-impl<Wal, Meta, Store, Fa> SpaceStore<Wal, Meta, Store, Fa> {
+impl<Wal, Meta, Fa> SpaceStore<Wal, Meta, Fa> {
     async fn close(&self) -> Result<()> {
         let spaces = self.spaces.read().unwrap().list_all_spaces();
         for space in spaces {
@@ -119,9 +119,9 @@ impl<Wal, Meta, Store, Fa> SpaceStore<Wal, Meta, Store, Fa> {
     }
 }
 
-impl<Wal, Meta, Store, Fa> SpaceStore<Wal, Meta, Store, Fa> {
-    fn store_ref(&self) -> &Store {
-        &*self.store
+impl<Wal, Meta, Fa> SpaceStore<Wal, Meta, Fa> {
+    fn store_ref(&self) -> &dyn ObjectStore {
+        &self.store
     }
 
     /// List all tables of all spaces
@@ -142,9 +142,9 @@ impl<Wal, Meta, Store, Fa> SpaceStore<Wal, Meta, Store, Fa> {
 ///
 /// Manages all spaces, also contains needed resources shared across all table
 // TODO(yingwen): Track memory usage of all tables (or tables of space)
-pub struct Instance<Wal, Meta, Store, Fa> {
+pub struct Instance<Wal, Meta, Fa> {
     /// Space storage
-    space_store: Arc<SpaceStore<Wal, Meta, Store, Fa>>,
+    space_store: Arc<SpaceStore<Wal, Meta, Fa>>,
     /// Runtime to execute async tasks.
     runtimes: Arc<EngineRuntimes>,
     /// Global table options, overwrite mutable options in each table's
@@ -170,7 +170,7 @@ pub struct Instance<Wal, Meta, Store, Fa> {
     pub(crate) replay_batch_size: usize,
 }
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa> {
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa> {
     /// Close the instance gracefully.
     pub async fn close(&self) -> Result<()> {
         self.file_purger.stop().await.context(StopFilePurger)?;
@@ -185,9 +185,7 @@ impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa> {
 }
 
 // TODO(yingwen): Instance builder
-impl<Wal: WalManager + Send + Sync, Meta: Manifest, Store: ObjectStore, Fa>
-    Instance<Wal, Meta, Store, Fa>
-{
+impl<Wal: WalManager + Send + Sync, Meta: Manifest, Fa> Instance<Wal, Meta, Fa> {
     /// Find space using read lock
     fn get_space_by_read_lock(&self, space: SpaceId) -> Option<SpaceRef> {
         let spaces = self.space_store.spaces.read().unwrap();
@@ -224,4 +222,4 @@ impl<Wal: WalManager + Send + Sync, Meta: Manifest, Store: ObjectStore, Fa>
 }
 
 /// Instance reference
-pub type InstanceRef<Wal, Meta, Store, Fa> = Arc<Instance<Wal, Meta, Store, Fa>>;
+pub type InstanceRef<Wal, Meta, Fa> = Arc<Instance<Wal, Meta, Fa>>;

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -9,7 +9,7 @@ use std::{
 
 use common_types::schema::IndexInWriterSchema;
 use log::{debug, error, info, trace, warn};
-use object_store::ObjectStore;
+use object_store::ObjectStoreRef;
 use snafu::ResultExt;
 use table_engine::table::TableId;
 use tokio::sync::oneshot;
@@ -50,10 +50,9 @@ where
         ctx: OpenContext,
         manifest: Meta,
         wal_manager: Wal,
-        store: Arc<dyn ObjectStore>,
+        store: ObjectStoreRef,
         sst_factory: Fa,
     ) -> Result<Arc<Self>> {
-        let store = Arc::new(store);
         let space_store = Arc::new(SpaceStore {
             spaces: RwLock::new(Spaces::default()),
             manifest,

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -39,11 +39,10 @@ use crate::{
     table::data::{TableData, TableDataRef},
 };
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     /// Open a new instance
@@ -51,7 +50,7 @@ where
         ctx: OpenContext,
         manifest: Meta,
         wal_manager: Wal,
-        store: Store,
+        store: Arc<dyn ObjectStore>,
         sst_factory: Fa,
     ) -> Result<Arc<Self>> {
         let store = Arc::new(store);

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -15,7 +15,6 @@ use common_types::{
 use common_util::{define_result, runtime::Runtime};
 use futures::stream::Stream;
 use log::{debug, error, trace};
-use object_store::ObjectStore;
 use snafu::{ResultExt, Snafu};
 use table_engine::{
     stream::{
@@ -76,9 +75,7 @@ fn need_merge_sort_streams(table_options: &TableOptions, read_request: &ReadRequ
     table_options.need_dedup() || read_request.order.is_in_order()
 }
 
-impl<Wal: WalManager + Send + Sync, Meta: Manifest, Store: ObjectStore, Fa: Factory>
-    Instance<Wal, Meta, Store, Fa>
-{
+impl<Wal: WalManager + Send + Sync, Meta: Manifest, Fa: Factory> Instance<Wal, Meta, Fa> {
     /// Read data in multiple time range from table, and return
     /// `read_parallelism` output streams.
     pub async fn partitioned_read_from_table(

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -11,7 +11,6 @@ use common_types::{
 };
 use common_util::{codec::row, define_result};
 use log::{debug, error, info, trace, warn};
-use object_store::ObjectStore;
 use proto::table_requests;
 use smallvec::SmallVec;
 use snafu::{ensure, Backtrace, ResultExt, Snafu};

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -142,11 +142,10 @@ impl EncodeContext {
     }
 }
 
-impl<Wal, Meta, Store, Fa> Instance<Wal, Meta, Store, Fa>
+impl<Wal, Meta, Fa> Instance<Wal, Meta, Fa>
 where
     Wal: WalManager + Send + Sync + 'static,
     Meta: Manifest + Send + Sync + 'static,
-    Store: ObjectStore,
     Fa: Factory + Send + Sync + 'static,
 {
     /// Write data to the table under give space.

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -21,7 +21,7 @@ use common_types::{
 use common_util::define_result;
 use futures::StreamExt;
 use log::{debug, info, trace};
-use object_store::ObjectStore;
+use object_store::ObjectStoreRef;
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use table_engine::{predicate::PredicateRef, table::TableId};
 
@@ -84,7 +84,7 @@ define_result!(Error);
 
 /// Required parameters to construct the [MergeBuilder]
 #[derive(Debug)]
-pub struct MergeConfig<'a, S, Fa> {
+pub struct MergeConfig<'a, Fa> {
     pub request_id: RequestId,
     pub space_id: SpaceId,
     pub table_id: TableId,
@@ -98,7 +98,7 @@ pub struct MergeConfig<'a, S, Fa> {
     pub sst_reader_options: SstReaderOptions,
     pub sst_factory: Fa,
     /// Sst storage
-    pub store: &'a S,
+    pub store: &'a ObjectStoreRef,
 
     pub merge_iter_options: IterOptions,
 
@@ -108,8 +108,8 @@ pub struct MergeConfig<'a, S, Fa> {
 
 /// Builder for building merge stream from memtables and sst files.
 #[must_use]
-pub struct MergeBuilder<'a, S, Fa> {
-    config: MergeConfig<'a, S, Fa>,
+pub struct MergeBuilder<'a, Fa> {
+    config: MergeConfig<'a, Fa>,
 
     /// Sampling memtable to read.
     sampling_mem: Option<SamplingMemTable>,
@@ -119,8 +119,8 @@ pub struct MergeBuilder<'a, S, Fa> {
     ssts: Vec<Vec<FileHandle>>,
 }
 
-impl<'a, S: ObjectStore, Fa: Factory> MergeBuilder<'a, S, Fa> {
-    pub fn new(config: MergeConfig<'a, S, Fa>) -> Self {
+impl<'a, Fa: Factory> MergeBuilder<'a, Fa> {
+    pub fn new(config: MergeConfig<'a, Fa>) -> Self {
         Self {
             config,
             sampling_mem: None,

--- a/analytic_engine/src/row_iter/record_batch_stream.rs
+++ b/analytic_engine/src/row_iter/record_batch_stream.rs
@@ -8,7 +8,7 @@ use common_types::{
 use common_util::define_result;
 use futures::stream::{self, Stream, StreamExt};
 use log::{error, trace};
-use object_store::ObjectStore;
+use object_store::ObjectStoreRef;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::{
     predicate::{filter_record_batch::RecordBatchFilter, Predicate},
@@ -199,17 +199,16 @@ pub fn stream_from_memtable(
 
 /// Build the filtered by `sst_read_options.predicate`
 /// [SequencedRecordBatchStream] from a sst.
-pub async fn filtered_stream_from_sst_file<Fa, S>(
+pub async fn filtered_stream_from_sst_file<Fa>(
     space_id: SpaceId,
     table_id: TableId,
     sst_file: &FileHandle,
     sst_factory: &Fa,
     sst_reader_options: &SstReaderOptions,
-    store: &S,
+    store: &ObjectStoreRef,
 ) -> Result<SequencedRecordBatchStream>
 where
     Fa: sst::factory::Factory,
-    S: ObjectStore,
 {
     stream_from_sst_file(
         space_id,
@@ -224,17 +223,16 @@ where
 }
 
 /// Build the [SequencedRecordBatchStream] from a sst.
-pub async fn stream_from_sst_file<Fa, S>(
+pub async fn stream_from_sst_file<Fa>(
     space_id: SpaceId,
     table_id: TableId,
     sst_file: &FileHandle,
     sst_factory: &Fa,
     sst_reader_options: &SstReaderOptions,
-    store: &S,
+    store: &ObjectStoreRef,
 ) -> Result<SequencedRecordBatchStream>
 where
     Fa: sst::factory::Factory,
-    S: ObjectStore,
 {
     sst_file.read_meter().mark();
     let path = sst_util::new_sst_file_path(space_id, table_id, sst_file.id());

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -6,7 +6,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use common_types::projected_schema::ProjectedSchema;
 use common_util::runtime::Runtime;
-use object_store::{ObjectStore, Path};
+use object_store::{ObjectStoreRef, Path};
 use parquet::{DataCacheRef, MetaCacheRef};
 use table_engine::predicate::PredicateRef;
 
@@ -20,18 +20,18 @@ use crate::{
 };
 
 pub trait Factory: Clone {
-    fn new_sst_reader<'a, S: ObjectStore>(
+    fn new_sst_reader<'a>(
         &self,
         options: &SstReaderOptions,
         path: &'a Path,
-        storage: &'a S,
+        storage: &'a ObjectStoreRef,
     ) -> Option<Box<dyn SstReader + Send + 'a>>;
 
-    fn new_sst_builder<'a, S: ObjectStore>(
+    fn new_sst_builder<'a>(
         &self,
         options: &SstBuilderOptions,
         path: &'a Path,
-        storage: &'a S,
+        storage: &'a ObjectStoreRef,
     ) -> Option<Box<dyn SstBuilder + Send + 'a>>;
 }
 
@@ -63,22 +63,22 @@ pub struct SstBuilderOptions {
 pub struct FactoryImpl;
 
 impl Factory for FactoryImpl {
-    fn new_sst_reader<'a, S: ObjectStore>(
+    fn new_sst_reader<'a>(
         &self,
         options: &SstReaderOptions,
         path: &'a Path,
-        storage: &'a S,
+        storage: &'a ObjectStoreRef,
     ) -> Option<Box<dyn SstReader + Send + 'a>> {
         match options.sst_type {
             SstType::Parquet => Some(Box::new(ParquetSstReader::new(path, storage, options))),
         }
     }
 
-    fn new_sst_builder<'a, S: ObjectStore>(
+    fn new_sst_builder<'a>(
         &self,
         options: &SstBuilderOptions,
         path: &'a Path,
-        storage: &'a S,
+        storage: &'a ObjectStoreRef,
     ) -> Option<Box<dyn SstBuilder + Send + 'a>> {
         match options.sst_type {
             SstType::Parquet => Some(Box::new(ParquetSstBuilder::new(path, storage, options))),

--- a/analytic_engine/src/storage_options.rs
+++ b/analytic_engine/src/storage_options.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+use object_store::cache::CachedStoreConfig;
 use serde::Deserialize;
 
 /// Options for storage backend
@@ -8,6 +9,7 @@ use serde::Deserialize;
 pub enum StorageOptions {
     Local(LocalOptions),
     Aliyun(AliyunOptions),
+    Cache(CacheOptions),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -21,4 +23,11 @@ pub struct AliyunOptions {
     pub key_secret: String,
     pub endpoint: String,
     pub bucket: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CacheOptions {
+    pub local_store: Box<StorageOptions>,
+    pub remote_store: Box<StorageOptions>,
+    pub cache_opts: CachedStoreConfig,
 }

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -38,19 +38,19 @@ pub mod version_edit;
 // TODO(yingwen): How to handle drop table?
 
 /// Table trait implementation
-pub struct TableImpl<Wal, Meta, Store, Fa> {
+pub struct TableImpl<Wal, Meta, Fa> {
     /// Space and table info
     space_table: SpaceAndTable,
     /// Instance
-    instance: InstanceRef<Wal, Meta, Store, Fa>,
+    instance: InstanceRef<Wal, Meta, Fa>,
     /// Engine type
     engine_type: String,
 }
 
-impl<Wal, Meta, Store, Fa> TableImpl<Wal, Meta, Store, Fa> {
+impl<Wal, Meta, Fa> TableImpl<Wal, Meta, Fa> {
     pub fn new(
         space_table: SpaceAndTable,
-        instance: InstanceRef<Wal, Meta, Store, Fa>,
+        instance: InstanceRef<Wal, Meta, Fa>,
         engine_type: String,
     ) -> Self {
         Self {
@@ -61,7 +61,7 @@ impl<Wal, Meta, Store, Fa> TableImpl<Wal, Meta, Store, Fa> {
     }
 }
 
-impl<Wal, Meta, Store, Fa> fmt::Debug for TableImpl<Wal, Meta, Store, Fa> {
+impl<Wal, Meta, Fa> fmt::Debug for TableImpl<Wal, Meta, Fa> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TableImpl")
             .field("space_table", &self.space_table)
@@ -73,9 +73,8 @@ impl<Wal, Meta, Store, Fa> fmt::Debug for TableImpl<Wal, Meta, Store, Fa> {
 impl<
         Wal: WalManager + Send + Sync + 'static,
         Meta: Manifest + Send + Sync + 'static,
-        Store: ObjectStore,
         Fa: Factory + Send + Sync + 'static,
-    > Table for TableImpl<Wal, Meta, Store, Fa>
+    > Table for TableImpl<Wal, Meta, Fa>
 {
     fn name(&self) -> &str {
         &self.space_table.table_data().name

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -8,7 +8,6 @@ use arrow_deps::datafusion::logical_plan::{Column, Expr};
 use async_trait::async_trait;
 use common_types::{row::Row, schema::Schema, time::TimeRange};
 use futures::TryStreamExt;
-use object_store::ObjectStore;
 use snafu::{ensure, OptionExt, ResultExt};
 use table_engine::{
     predicate::Predicate,

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -27,14 +27,14 @@ use common_types::{
 };
 use common_util::runtime::Runtime;
 use log::info;
-use object_store::LocalFileSystem;
+use object_store::{LocalFileSystem, ObjectStoreRef};
 use parquet::{DataCacheRef, MetaCacheRef};
 use table_engine::{predicate::Predicate, table::TableId};
 
 use crate::{config::MergeMemTableBenchConfig, util};
 
 pub struct MergeMemTableBench {
-    store: LocalFileSystem,
+    store: ObjectStoreRef,
     memtables: MemTableVec,
     max_projections: usize,
     schema: Schema,
@@ -50,7 +50,7 @@ impl MergeMemTableBench {
     pub fn new(config: MergeMemTableBenchConfig) -> Self {
         assert!(!config.sst_file_ids.is_empty());
 
-        let store = LocalFileSystem::new_with_prefix(config.store_path).unwrap();
+        let store = Arc::new(LocalFileSystem::new_with_prefix(config.store_path).unwrap()) as _;
         let runtime = Arc::new(util::new_runtime(config.runtime_thread_num));
         let space_id = config.space_id;
         let table_id = config.table_id;

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -22,7 +22,7 @@ use analytic_engine::{
 use common_types::{projected_schema::ProjectedSchema, request_id::RequestId, schema::Schema};
 use common_util::runtime::Runtime;
 use log::info;
-use object_store::LocalFileSystem;
+use object_store::{LocalFileSystem, ObjectStoreRef};
 use parquet::{DataCacheRef, MetaCacheRef};
 use table_engine::{predicate::Predicate, table::TableId};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
@@ -30,7 +30,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver};
 use crate::{config::MergeSstBenchConfig, util};
 
 pub struct MergeSstBench {
-    store: LocalFileSystem,
+    store: ObjectStoreRef,
     max_projections: usize,
     schema: Schema,
     sst_reader_options: SstReaderOptions,
@@ -46,7 +46,7 @@ impl MergeSstBench {
     pub fn new(config: MergeSstBenchConfig) -> Self {
         assert!(!config.sst_file_ids.is_empty());
 
-        let store = LocalFileSystem::new_with_prefix(config.store_path).unwrap();
+        let store = Arc::new(LocalFileSystem::new_with_prefix(config.store_path).unwrap()) as _;
         let runtime = Arc::new(util::new_runtime(config.runtime_thread_num));
         let space_id = config.space_id;
         let table_id = config.table_id;

--- a/benchmarks/src/parquet_bench.rs
+++ b/benchmarks/src/parquet_bench.rs
@@ -11,14 +11,14 @@ use arrow_deps::parquet::{
 use common_types::schema::Schema;
 use common_util::runtime::Runtime;
 use log::info;
-use object_store::{LocalFileSystem, ObjectStore, Path};
+use object_store::{LocalFileSystem, ObjectStoreRef, Path};
 use parquet::{DataCacheRef, MetaCacheRef};
 use table_engine::predicate::PredicateRef;
 
 use crate::{config::SstBenchConfig, util};
 
 pub struct ParquetBench {
-    store: LocalFileSystem,
+    store: ObjectStoreRef,
     pub sst_file_name: String,
     max_projections: usize,
     projection: Vec<usize>,
@@ -30,7 +30,7 @@ pub struct ParquetBench {
 
 impl ParquetBench {
     pub fn new(config: SstBenchConfig) -> Self {
-        let store = LocalFileSystem::new_with_prefix(config.store_path).unwrap();
+        let store = Arc::new(LocalFileSystem::new_with_prefix(config.store_path).unwrap()) as _;
 
         let runtime = util::new_runtime(config.runtime_thread_num);
 

--- a/benchmarks/src/scan_memtable_bench.rs
+++ b/benchmarks/src/scan_memtable_bench.rs
@@ -25,7 +25,7 @@ pub struct ScanMemTableBench {
 
 impl ScanMemTableBench {
     pub fn new(config: ScanMemTableBenchConfig) -> Self {
-        let store = LocalFileSystem::new_with_prefix(config.store_path).unwrap();
+        let store = Arc::new(LocalFileSystem::new_with_prefix(config.store_path).unwrap()) as _;
 
         let runtime = Arc::new(util::new_runtime(config.runtime_thread_num));
         let meta_cache: Option<MetaCacheRef> = None;

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -9,7 +9,7 @@ use common_types::{projected_schema::ProjectedSchema, schema::Schema};
 use common_util::runtime::Runtime;
 use futures::stream::StreamExt;
 use log::info;
-use object_store::{LocalFileSystem, Path};
+use object_store::{LocalFileSystem, ObjectStoreRef, Path};
 use parquet::{
     cache::{LruDataCache, LruMetaCache},
     DataCacheRef, MetaCacheRef,
@@ -18,7 +18,7 @@ use parquet::{
 use crate::{config::SstBenchConfig, util};
 
 pub struct SstBench {
-    store: LocalFileSystem,
+    store: ObjectStoreRef,
     pub sst_file_name: String,
     max_projections: usize,
     schema: Schema,
@@ -30,7 +30,7 @@ impl SstBench {
     pub fn new(config: SstBenchConfig) -> Self {
         let runtime = Arc::new(util::new_runtime(config.runtime_thread_num));
 
-        let store = LocalFileSystem::new_with_prefix(config.store_path).unwrap();
+        let store = Arc::new(LocalFileSystem::new_with_prefix(config.store_path).unwrap()) as _;
         let sst_path = Path::from(config.sst_file_name.clone());
         let meta_cache: Option<MetaCacheRef> =
             if let Some(sst_meta_cache_cap) = config.sst_meta_cache_cap {

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -22,7 +22,7 @@ use common_types::{
 };
 use common_util::runtime::{self, Runtime};
 use futures::stream::StreamExt;
-use object_store::{LocalFileSystem, Path};
+use object_store::{ObjectStoreRef, Path};
 use parquet::{DataCacheRef, MetaCacheRef};
 use table_engine::{predicate::Predicate, table::TableId};
 
@@ -36,7 +36,7 @@ pub fn new_runtime(thread_num: usize) -> Runtime {
 }
 
 pub async fn meta_from_sst(
-    store: &LocalFileSystem,
+    store: &ObjectStoreRef,
     sst_path: &Path,
     meta_cache: &Option<MetaCacheRef>,
     data_cache: &Option<DataCacheRef>,
@@ -49,7 +49,7 @@ pub async fn meta_from_sst(
 }
 
 pub async fn schema_from_sst(
-    store: &LocalFileSystem,
+    store: &ObjectStoreRef,
     sst_path: &Path,
     meta_cache: &Option<MetaCacheRef>,
     data_cache: &Option<DataCacheRef>,
@@ -74,7 +74,7 @@ pub fn projected_schema_by_number(
 }
 
 pub async fn load_sst_to_memtable(
-    store: &LocalFileSystem,
+    store: &ObjectStoreRef,
     sst_path: &Path,
     schema: &Schema,
     memtable: &MemTableRef,
@@ -117,7 +117,7 @@ pub async fn load_sst_to_memtable(
 }
 
 pub async fn file_handles_from_ssts(
-    store: &LocalFileSystem,
+    store: &ObjectStoreRef,
     space_id: SpaceId,
     table_id: TableId,
     sst_file_ids: &[FileId],

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2018"
 async-trait = "0.1.53"
 bytes = "1.0"
 futures = "0.3"
-upstream = { package = "object_store", version =  "0.1.0" }
+upstream = { package = "object_store", version = "0.1.0" }
 oss-rust-sdk = "0.4.0"
+serde = "1.0"
+serde_derive = "1.0"
 snafu = { version = "0.6.10", features = ["backtraces"] }
 lru = "0.7.6"
 chrono = "0.4.19"

--- a/components/object_store/src/cache.rs
+++ b/components/object_store/src/cache.rs
@@ -56,9 +56,10 @@ use bytes::Bytes;
 use chrono::MIN_DATETIME;
 use futures::{future::try_join_all, lock::Mutex, stream::BoxStream, TryStreamExt};
 use lru::LruCache;
+use serde::Deserialize;
 use upstream::{path::Path, GetResult, ListResult, ObjectMeta, ObjectStore, Result};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 pub struct CachedStoreConfig {
     pub max_cache_size: usize,
 }

--- a/components/object_store/src/cache.rs
+++ b/components/object_store/src/cache.rs
@@ -49,7 +49,7 @@
 //! To ensure the total size of `LocalStore` is always less than the threshold,
 //! [CachedStore] will first purge enough space for the incoming new objects.
 
-use std::{fmt::Display, ops::Range};
+use std::{fmt::Display, ops::Range, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -65,15 +65,15 @@ pub struct CachedStoreConfig {
 
 #[derive(Debug)]
 pub struct CachedStore {
-    local_store: Box<dyn ObjectStore>,
-    remote_store: Box<dyn ObjectStore>,
+    local_store: Arc<dyn ObjectStore>,
+    remote_store: Arc<dyn ObjectStore>,
     state: Mutex<CacheState>,
 }
 
 impl CachedStore {
     pub async fn init(
-        local_store: Box<dyn ObjectStore>,
-        remote_store: Box<dyn ObjectStore>,
+        local_store: Arc<dyn ObjectStore>,
+        remote_store: Arc<dyn ObjectStore>,
         config: CachedStoreConfig,
     ) -> Result<Self> {
         let local_list: Vec<ObjectMeta> = local_store.list(None).await?.try_collect().await?;
@@ -324,8 +324,8 @@ mod test {
         let local_path = tempdir().unwrap();
         let remote_path = tempdir().unwrap();
 
-        let local_store = Box::new(LocalFileSystem::new_with_prefix(local_path.path()).unwrap());
-        let remote_store = Box::new(LocalFileSystem::new_with_prefix(remote_path.path()).unwrap());
+        let local_store = Arc::new(LocalFileSystem::new_with_prefix(local_path.path()).unwrap());
+        let remote_store = Arc::new(LocalFileSystem::new_with_prefix(remote_path.path()).unwrap());
         let config = CachedStoreConfig { max_cache_size };
 
         CachedStore::init(local_store, remote_store, config)
@@ -404,8 +404,8 @@ mod test {
         let local_path = tempdir().unwrap();
         let remote_path = tempdir().unwrap();
 
-        let local_store = Box::new(LocalFileSystem::new_with_prefix(local_path.path()).unwrap());
-        let remote_store = Box::new(LocalFileSystem::new_with_prefix(remote_path.path()).unwrap());
+        let local_store = Arc::new(LocalFileSystem::new_with_prefix(local_path.path()).unwrap());
+        let remote_store = Arc::new(LocalFileSystem::new_with_prefix(remote_path.path()).unwrap());
         let config = CachedStoreConfig {
             max_cache_size: 4096,
         };

--- a/components/object_store/src/lib.rs
+++ b/components/object_store/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Re-export of [object_store] crate.
 
+use std::sync::Arc;
+
 pub use upstream::{
     local::LocalFileSystem, path::Path, Error as ObjectStoreError, GetResult, ListResult,
     ObjectMeta, ObjectStore,
@@ -9,3 +11,5 @@ pub use upstream::{
 
 pub mod aliyun;
 pub mod cache;
+
+pub type ObjectStoreRef = Arc<dyn ObjectStore + Send + Sync>;

--- a/docs/example.toml
+++ b/docs/example.toml
@@ -10,8 +10,19 @@ sst_data_cache_cap = 10000
 sst_meta_cache_cap = 10000
 
 [analytic.storage]
+type = "Cache"
+cache_opts = { max_cache_size = 10000000 }
+
+[analytic.storage.local_store]
 type = "Local"
 data_path = "/tmp/ceresdb"
+
+[analytic.storage.remote_store]
+type = "Aliyun"
+key_id = "key_id"
+key_secret = "key_secret"
+endpoint = "endpoint"
+bucket = "bucket"
 
 [[meta_client.cluster_view.schema_shards]]
 schema = 'public'


### PR DESCRIPTION
# Which issue does this PR close?

Related to #72 and #13

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

We support various `ObjectStore` implements to be assembled in a recursive way. Like `CachedStore` -> `LocalStore` + `RemoteStore`. The existing type param way that requires fully specifying a type would be hard to implement. For simplicity and feasibility, I change this type param to a trait object. A related discussion can be found at https://github.com/CeresDB/ceresdb/issues/72.

The `CachedStore` has been implemented but the corresponding config is not added yet. This PR also provides a way to config a storage cache layer. Example config has been updated to `docs/example.toml`

# What changes are included in this PR?

This PR contains two changes:

- refactor: remove `Store` type param in `Instance`
- feat: add config for `CachedStore`

Maybe I need to separate it into two PRs

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?

The config file has changed. 

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

The refactor is tested by the compiler. New config is tested manually.