### PR TITLE
fix: fix compile error on arm platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,28 +1617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "fasthash"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032213946b4eaae09117ec63f020322b78ca7a31d8aa2cf64df3032e1579690f"
-dependencies = [
- "cfg-if 0.1.10",
- "fasthash-sys",
- "num-traits",
- "seahash",
- "xoroshiro128",
-]
-
-[[package]]
-name = "fasthash-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6de941abfe2e715cdd34009d90546f850597eb69ca628ddfbf616e53dda28f8"
-dependencies = [
- "gcc",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,6 +2946,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "murmur2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb585ade2549a017db2e35978b77c319214fa4b37cede841e27954dd6e8f3ca8"
+
+[[package]]
 name = "murmur3"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,17 +3296,17 @@ dependencies = [
 [[package]]
 name = "obkv-table-client-rs"
 version = "0.1.0"
-source = "git+https://github.com/oceanbase/obkv-table-client-rs.git?rev=d525c6d7d8919d98be9a2590bbfa8c417dda6584#d525c6d7d8919d98be9a2590bbfa8c417dda6584"
+source = "git+https://github.com/oceanbase/obkv-table-client-rs.git?rev=318907f35de51404c05180c65440c9516fd1e10f#318907f35de51404c05180c65440c9516fd1e10f"
 dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "chrono",
  "crossbeam",
- "fasthash",
  "futures 0.1.31",
  "futures-cpupool",
  "lazy_static",
  "log",
+ "murmur2",
  "mysql",
  "net2",
  "prometheus 0.7.0",
@@ -4521,12 +4505,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "seahash"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f57ca1d128a43733fd71d583e837b1f22239a37ebea09cde11d8d9a9080f47"
 
 [[package]]
 name = "security-framework"
@@ -6292,15 +6270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "xoroshiro128"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0eeda34baec49c4f1eb2c04d59b761582fd6330010f9330ca696ca1a355dfcd"
-dependencies = [
- "rand 0.4.6",
 ]
 
 [[package]]

--- a/components/table_kv/Cargo.toml
+++ b/components/table_kv/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 common_util = { path = "../../common_util" }
 log = "0.4"
-obkv-table-client-rs = { git = "https://github.com/oceanbase/obkv-table-client-rs.git", rev = "d525c6d7d8919d98be9a2590bbfa8c417dda6584" }
+obkv-table-client-rs = { git = "https://github.com/oceanbase/obkv-table-client-rs.git", rev = "318907f35de51404c05180c65440c9516fd1e10f" }
 serde = "1.0"
 serde_derive = "1.0"
 snafu = { version = "0.6.10", features = ["backtraces"] }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #95 

# Rationale for this change
 
Support arm platform

# What changes are included in this PR?

Upgrade the dependency crate obkv-table-client-rs. Its old version cannot be compiled on arm platform

# Are there any user-facing changes?

Users who uses mac M1 cannot build ceresdb.

# How does this change test

Build shoud be successful on arm platforms
