### PR TITLE
fix: table name with quote

### DIFF
--- a/sql/src/ast.rs
+++ b/sql/src/ast.rs
@@ -26,6 +26,32 @@ pub enum Statement {
     Exists(ExistsTable),
 }
 
+#[derive(Debug, PartialEq)]
+pub struct TableName(ObjectName);
+
+impl TableName {
+    pub fn is_empty(&self) -> bool {
+        self.0 .0.is_empty()
+    }
+}
+
+impl ToString for TableName {
+    fn to_string(&self) -> String {
+        self.0
+             .0
+            .iter()
+            .map(|ident| ident.value.as_str())
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+}
+
+impl From<ObjectName> for TableName {
+    fn from(object_name: ObjectName) -> Self {
+        Self(object_name)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ShowCreateObject {
@@ -37,7 +63,7 @@ pub struct CreateTable {
     /// Create if not exists
     pub if_not_exists: bool,
     /// Table name
-    pub name: ObjectName,
+    pub table_name: TableName,
     pub columns: Vec<ColumnDef>,
     pub engine: String,
     pub constraints: Vec<TableConstraint>,
@@ -48,35 +74,63 @@ pub struct CreateTable {
 #[derive(Debug, PartialEq)]
 pub struct DropTable {
     /// Table name
-    pub name: ObjectName,
+    pub table_name: TableName,
     pub if_exists: bool,
     pub engine: String,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct DescribeTable {
-    pub table_name: ObjectName,
+    pub table_name: TableName,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct AlterModifySetting {
-    pub table_name: ObjectName,
+    pub table_name: TableName,
     pub options: Vec<SqlOption>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct AlterAddColumn {
-    pub table_name: ObjectName,
+    pub table_name: TableName,
     pub columns: Vec<ColumnDef>,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ShowCreate {
     pub obj_type: ShowCreateObject,
-    pub obj_name: ObjectName,
+    pub table_name: TableName,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ExistsTable {
-    pub table_name: ObjectName,
+    pub table_name: TableName,
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlparser::ast::Ident;
+
+    use super::*;
+
+    #[test]
+    fn test_table_name() {
+        let testcases = vec![
+            (
+                ObjectName(vec![
+                    Ident::with_quote('`', "schema"),
+                    Ident::with_quote('`', "table"),
+                ]),
+                "schema.table",
+            ),
+            (
+                ObjectName(vec![Ident::new("schema"), Ident::new("table")]),
+                "schema.table",
+            ),
+        ];
+
+        for (object_name, expected) in testcases {
+            assert_eq!(TableName::from(object_name).to_string(), expected);
+        }
+    }
 }

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -236,11 +236,11 @@ impl<'a> Parser<'a> {
             ))),
         }?;
 
-        let obj_name = self.parser.parse_object_name()?;
+        let table_name = self.parser.parse_object_name()?.into();
 
         Ok(Statement::ShowCreate(ShowCreate {
             obj_type,
-            table_name: obj_name.into(),
+            table_name,
         }))
     }
 
@@ -769,11 +769,11 @@ mod tests {
         assert_eq!(statements.len(), 1);
         match &statements[0] {
             Statement::Drop(DropTable {
-                table_name: name,
+                table_name,
                 if_exists,
                 engine,
             }) => {
-                assert_eq!(name.to_string(), "test_ttl".to_string());
+                assert_eq!(table_name.to_string(), "test_ttl".to_string());
                 assert!(!if_exists);
                 assert_eq!(*engine, ANALYTIC_ENGINE_TYPE.to_string());
             }
@@ -785,11 +785,11 @@ mod tests {
         assert_eq!(statements.len(), 1);
         match &statements[0] {
             Statement::Drop(DropTable {
-                table_name: name,
+                table_name,
                 if_exists,
                 engine,
             }) => {
-                assert_eq!(name.to_string(), "test_ttl".to_string());
+                assert_eq!(table_name.to_string(), "test_ttl".to_string());
                 assert!(if_exists);
                 assert_eq!(*engine, ANALYTIC_ENGINE_TYPE.to_string());
             }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #113 

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Table Name (or other identifiers) with back quotes should be treated as literal token. But our interpreter will use the token with back quotes which will lead to some inconsistent behaviors like reported in #113 


# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

Replace `ObjectName` with `TableName` in parsed SQL statement to override the `ToString` implement, which will remove quotes and join every token with `.`

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->
No

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Unit test
