### PR TITLE
docs: add sql chapter for user guide

### DIFF
--- a/docs/user-guide/src/SUMMARY.md
+++ b/docs/user-guide/src/SUMMARY.md
@@ -11,7 +11,7 @@
     - [Data Types](model/data_types.md)
     - [Special Columns](model/special_columns.md)
 - [SQL Syntax](sql/README.md)
-    - [Keyword and Identifier](sql/keyword.md)
+    - [Identifier](sql/identifier.md)
     - [Data Definition Statements](sql/ddl/README.md)
         - [CREATE TABLE](sql/ddl/create_table.md)
         - [ALTER TABLE](sql/ddl/alter_table.md)

--- a/docs/user-guide/src/sql/README.md
+++ b/docs/user-guide/src/sql/README.md
@@ -1,1 +1,3 @@
 # SQL Syntax
+
+This chapter introduces the SQL interface of CeresDB.

--- a/docs/user-guide/src/sql/ddl/alter_table.md
+++ b/docs/user-guide/src/sql/ddl/alter_table.md
@@ -1,1 +1,23 @@
 # ALTER TABLE
+
+`ALTER TABLE` can change the schema or options of a table.
+
+CeresDB current supports add column.
+
+```sql
+-- create a table and add a column to it
+CREATE TABLE `t`(a int, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE = Analytic;
+ALTER TABLE `t` ADD COLUMN (b string);
+```
+
+It now becomes
+```
+-- DESCRIBE TABLE `t`;
+
+name    type        is_primary  is_nullable is_tag
+
+t       timestamp   true        false       false
+tsid    uint64      true        false       false
+a       int         false       true        false
+b       string      false       true        false
+```

--- a/docs/user-guide/src/sql/ddl/create_table.md
+++ b/docs/user-guide/src/sql/ddl/create_table.md
@@ -1,1 +1,46 @@
 # CREATE TABLE
+
+## Basic syntax
+
+Basic syntax (parts between `[]` are optional):
+```sql
+CREATE TABLE [IF NOT EXIST] 
+    table_name ( column_definitions ) 
+    ENGINE = engine_type 
+    [WITH ( table_options )];
+```
+
+Column definition syntax:
+```sql
+column_name column_type [[NOT] NULL] {[TAG] | [TIMESTAMP KEY] | [PRIMARY KEY]}
+```
+
+Table options syntax are key-value pairs. Value should be quote with quotation marks (`'`). E.g.:
+```sql
+... WITH ( enable_ttl='false' )
+```
+
+## IF NOT EXIST
+
+Add `IF NOT EXIST` to tell CeresDB to ignore errors if the table name is already occupied.
+
+## Define Column
+
+A column's definition should at least contains the name and type parts. All supported types are listed [here](../../model/data_types.md).
+
+Column is default be nullable. i.e. `NULL` keyword is implied. Adding `NOT NULL` constrains to make it required.
+```sql
+-- this definition
+a_nullable int
+-- equals to
+a_nullable int NULL
+
+-- add NOT NULL to make it required
+b_not_null NOT NULL
+```
+
+A column can be marked as [special column](../../model/special_columns.md) with related keyword.
+
+## Engine
+
+Specifies which engine this table belongs to. CeresDB current support [`Analytic`](../../analytic_engine/README.md) engine type. This attribute is immutable.

--- a/docs/user-guide/src/sql/identifier.md
+++ b/docs/user-guide/src/sql/identifier.md
@@ -1,0 +1,3 @@
+# Identifier
+
+Identifier in CeresDB can be used as table name, column name etc. It cannot be preserved keywords or start with number and punctuation symbols. CeresDB allows to quote identifiers with back quotes (\`). In this case it can be any string like `00_table` or `select`.

--- a/docs/user-guide/src/sql/keyword.md
+++ b/docs/user-guide/src/sql/keyword.md
@@ -1,1 +1,0 @@
-# Keyword and Identifier

--- a/docs/user-guide/src/sql/utility.md
+++ b/docs/user-guide/src/sql/utility.md
@@ -1,1 +1,80 @@
 # Utility Statements
+
+There are serval utilities SQL in CeresDB that can help in table manipulation or query inspection.
+
+## SHOW CREATE TABLE
+
+```sql
+SHOW CREATE TABLE table_name;
+```
+
+`SHOW CREATE TABLE` returns a `CREATE TABLE` DDL that will create a same table with the given one. Including columns, table engine and options. The schema and options shows in `CREATE TABLE` will based on the current version of the table. An example:
+
+```sql
+-- create one table
+CREATE TABLE `t` (a bigint, b int default 3, c string default 'x', d smallint null, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE = Analytic;
+-- Result: affected_rows: 0
+
+-- show how one table should be created.
+SHOW CREATE TABLE `t`;
+
+-- Result DDL:
+CREATE TABLE `t` (
+    `t` timestamp NOT NULL,
+    `tsid` uint64 NOT NULL,
+    `a` bigint,
+    `b` int,
+    `c` string,
+    `d` smallint,
+    PRIMARY KEY(t,tsid),
+    TIMESTAMP KEY(t)
+) ENGINE=Analytic WITH (
+    arena_block_size='2097152',
+    compaction_strategy='default',
+    compression='ZSTD',
+    enable_ttl='true',
+    num_rows_per_row_group='8192',
+    segment_duration='',
+    ttl='7d',
+    update_mode='OVERWRITE',
+    write_buffer_size='33554432'
+)
+```
+
+## DESCRIBE
+
+```sql
+DESCRIBE table_name;
+```
+
+`DESCRIBE` will show a detailed schema of one table. The attributes include column name and type, whether it is tag and primary key (todo: ref) and whether it's nullable. The auto created column `tsid` will also be included (todo: ref).
+
+Example:
+
+```sql
+CREATE TABLE `t`(a int, b string, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE = Analytic;
+
+DESCRIBE TABLE `t`;
+```
+
+The result is:
+```
+name    type        is_primary  is_nullable is_tag
+
+t       timestamp   true        false       false
+tsid    uint64      true        false       false
+a       int         false       true        false
+b       string      false       true        false
+```
+
+## EXPLAIN
+
+```sql
+EXPLAIN query;
+```
+
+`EXPLAIN` shows how a query will be executed. Add it to the beginning of a query like
+
+```sql
+EXPLAIN SELECT
+```


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #135

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
>CeresDB supports a subset of SQL with some custom extension. We should provide a concrete reference for it.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

Provides a basic user guide of our SQL interface. DML section is not included in this PR.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->
no

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
run
```
mdbook build
```
under `docs/user-guide`