### PR TITLE
feat: persist `AlterSchema` and `AlterOptions` to data WAL

### DIFF
--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-//! Alter schema logic of instance
+//! Alter [Schema] and [TableOptions] logic of instance.
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -17,7 +17,7 @@ use crate::{
     instance::{
         engine::{
             AlterDroppedTable, FlushTable, InvalidOptions, InvalidPreVersion, InvalidSchemaVersion,
-            OperateByWriteWorker, Result, StoreVersionEdit, WriteManifest, WriteWal,
+            OperateByWriteWorker, Result, WriteManifest, WriteWal,
         },
         flush_compaction::TableFlushOptions,
         write_worker,
@@ -25,7 +25,7 @@ use crate::{
         Instance,
     },
     meta::{
-        meta_update::{AlterOptionsMeta, AlterSchemaMeta, MetaUpdate, VersionEditMeta},
+        meta_update::{AlterOptionsMeta, AlterSchemaMeta, MetaUpdate},
         Manifest,
     },
     payload::WritePayload,
@@ -85,13 +85,16 @@ where
         // Validate alter schema request.
         self.validate_before_alter(table_data, &request)?;
 
+        // Now we can persist and update the schema, since this function is called by
+        // write worker, so there is no other concurrent writer altering the
+        // schema.
+
+        // First trigger a flush before alter schema, to ensure ensure all wal entries
+        // with old schema are flushed
         let opts = TableFlushOptions {
             block_on_write_thread: true,
             ..Default::default()
         };
-        // We are in write thread now and there is no write request being processed, but
-        // we need to trigger a flush to ensure all wal entries with old schema
-        // are flushed, so we won't need to handle them during replaying wal.
         self.flush_table_in_worker(worker_local, table_data, opts)
             .await
             .context(FlushTable {
@@ -100,24 +103,21 @@ where
                 table_id: table_data.id,
             })?;
 
-        // Now we can persist and update the schema, since this function is called by
-        // write worker, so there is no other concurrent writer altering the
-        // schema.
-        let meta_update = AlterSchemaMeta {
+        // Build alter op
+        let manifest_update = AlterSchemaMeta {
             space_id: space_table.space().id,
             table_id: table_data.id,
             schema: request.schema.clone(),
             pre_schema_version: request.pre_schema_version,
-        }
-        .into_pb();
-        let payload = WritePayload::AlterSchema(&meta_update);
+        };
+
+        // Write AlterSchema to Data Wal
+        let alter_schema_pb = manifest_update.clone().into_pb();
+        let payload = WritePayload::AlterSchema(&alter_schema_pb);
         let mut log_batch = LogWriteBatch::new(space_table.table_data().wal_region_id());
         log_batch.push(LogWriteEntry { payload: &payload });
-
-        // Write AlterSchema record to WAL
         let write_ctx = WriteContext::default();
-        let sequence_id = self
-            .space_store
+        self.space_store
             .wal_manager
             .write(&write_ctx, &log_batch)
             .await
@@ -133,23 +133,18 @@ where
             request.schema
         );
 
-        // todo: update Manifest
-
-        // Step sequence id
-        let edit_meta = VersionEditMeta {
-            space_id: table_data.space_id,
-            table_id: table_data.id,
-            flushed_sequence: sequence_id,
-            files_to_add: vec![],
-            files_to_delete: vec![],
-        };
-        let meta_update = MetaUpdate::VersionEdit(edit_meta);
+        // Write to Manifest
+        let update = MetaUpdate::AlterSchema(manifest_update);
         self.space_store
             .manifest
-            .store_update(meta_update)
+            .store_update(update)
             .await
             .map_err(|e| Box::new(e) as _)
-            .context(StoreVersionEdit)?;
+            .context(WriteManifest {
+                space_id: space_table.space().id,
+                table: &table_data.name,
+                table_id: table_data.id,
+            })?;
 
         // Update schema in memory.
         table_data.set_schema(request.schema);
@@ -242,6 +237,9 @@ where
             }
         );
 
+        // AlterOptions doesn't need a flush.
+
+        // Generate options after alter op
         let current_table_options = table_data.table_options();
         info!(
             "Instance alter options, space_id:{}, tables:{:?}, old_table_opts:{:?}, options:{:?}",
@@ -259,15 +257,35 @@ where
                     table_id: table_data.id,
                 })?;
         table_opts.sanitize();
+        let manifest_update = AlterOptionsMeta {
+            space_id: space_table.space().id,
+            table_id: table_data.id,
+            options: table_opts.clone(),
+        };
 
         // Now we can persist and update the options, since this function is called by
         // write worker, so there is no other concurrent writer altering the
         // options.
-        let meta_update = MetaUpdate::AlterOptions(AlterOptionsMeta {
-            space_id: space_table.space().id,
-            table_id: table_data.id,
-            options: table_opts.clone(),
-        });
+
+        // Write AlterOptions to Data Wal
+        let alter_options_pb = manifest_update.clone().into_pb();
+        let payload = WritePayload::AlterOption(&alter_options_pb);
+        let mut log_batch = LogWriteBatch::new(space_table.table_data().wal_region_id());
+        log_batch.push(LogWriteEntry { payload: &payload });
+        let write_ctx = WriteContext::default();
+        self.space_store
+            .wal_manager
+            .write(&write_ctx, &log_batch)
+            .await
+            .map_err(|e| Box::new(e) as _)
+            .context(WriteWal {
+                space_id: space_table.space().id,
+                table: &table_data.name,
+                table_id: table_data.id,
+            })?;
+
+        // Write to Manifest
+        let meta_update = MetaUpdate::AlterOptions(manifest_update);
         self.space_store
             .manifest
             .store_update(meta_update)
@@ -279,6 +297,7 @@ where
                 table_id: table_data.id,
             })?;
 
+        // Update memory status
         table_data.set_table_options(worker_local, table_opts);
         Ok(())
     }

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -187,6 +187,11 @@ pub enum Error {
         backtrace
     ))]
     AlterDroppedTable { table: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to store version edit, err:{}", source))]
+    StoreVersionEdit {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 define_result!(Error);
@@ -213,7 +218,8 @@ impl From<Error> for table_engine::engine::Error {
             | Error::ReadWal { .. }
             | Error::ApplyMemTable { .. }
             | Error::OperateByWriteWorker { .. }
-            | Error::FlushTable { .. } => Self::Unexpected {
+            | Error::FlushTable { .. }
+            | Error::StoreVersionEdit { .. } => Self::Unexpected {
                 source: Box::new(err),
             },
         }

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -112,6 +112,20 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Failed to persist meta update to WAL, space_id:{}, table:{}, table_id:{}, err:{}",
+        space_id,
+        table,
+        table_id,
+        source
+    ))]
+    WriteWal {
+        space_id: SpaceId,
+        table: String,
+        table_id: TableId,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    #[snafu(display(
         "Invalid options, space_id:{}, table:{}, table_id:{}, err:{}",
         space_id,
         table,
@@ -189,7 +203,8 @@ impl From<Error> for table_engine::engine::Error {
             Error::WriteManifest { .. } => Self::WriteMeta {
                 source: Box::new(err),
             },
-            Error::InvalidSchemaVersion { .. }
+            Error::WriteWal { .. }
+            | Error::InvalidSchemaVersion { .. }
             | Error::InvalidPreVersion { .. }
             | Error::CreateTableData { .. }
             | Error::AlterDroppedTable { .. }

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -391,6 +391,7 @@ where
                             })?;
                     }
                 }
+                ReadPayload::AlterSchema { .. } => unimplemented!(),
             }
         }
 

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -391,7 +391,12 @@ where
                             })?;
                     }
                 }
-                ReadPayload::AlterSchema { .. } => unimplemented!(),
+                ReadPayload::AlterSchema { .. } | ReadPayload::AlterOptions { .. } => {
+                    // Ignore records except Data.
+                    //
+                    // - DDL (AlterSchema and AlterOptions) should be recovered
+                    //   from Manifest on start.
+                }
             }
         }
 

--- a/analytic_engine/src/meta/meta_update.rs
+++ b/analytic_engine/src/meta/meta_update.rs
@@ -359,7 +359,7 @@ pub struct AlterSchemaMeta {
 }
 
 impl AlterSchemaMeta {
-    fn into_pb(self) -> meta_pb::AlterSchemaMeta {
+    pub(crate) fn into_pb(self) -> meta_pb::AlterSchemaMeta {
         let mut target = meta_pb::AlterSchemaMeta::new();
         target.set_space_id(self.space_id);
         target.set_table_id(self.table_id.as_u64());

--- a/analytic_engine/src/meta/meta_update.rs
+++ b/analytic_engine/src/meta/meta_update.rs
@@ -394,7 +394,7 @@ pub struct AlterOptionsMeta {
 }
 
 impl AlterOptionsMeta {
-    fn into_pb(self) -> meta_pb::AlterOptionsMeta {
+    pub(crate) fn into_pb(self) -> meta_pb::AlterOptionsMeta {
         let mut target = meta_pb::AlterOptionsMeta::new();
         target.set_space_id(self.space_id);
         target.set_table_id(self.table_id.as_u64());

--- a/analytic_engine/src/payload.rs
+++ b/analytic_engine/src/payload.rs
@@ -114,7 +114,7 @@ impl<'a> Payload for WritePayload<'a> {
                     .map_err(Box::new)?;
             }
             WritePayload::AlterSchema(req) => {
-                write_header(Header::Write, buf)?;
+                write_header(Header::AlterSchema, buf)?;
                 let mut writer = Writer::new(buf);
                 req.write_to_writer(&mut writer).context(EncodeBody)?;
             }
@@ -160,7 +160,16 @@ impl ReadPayload {
     }
 
     fn decode_alter_schema_from_pb(buf: &[u8]) -> Result<Self> {
-        todo!()
+        let mut alter_schema_meta_pb: meta_update::AlterSchemaMeta =
+            Message::parse_from_bytes(buf).context(DecodeBody)?;
+
+        // Consume and convert schema in pb
+        let schema: Schema = alter_schema_meta_pb
+            .take_schema()
+            .try_into()
+            .context(DecodeSchema)?;
+
+        Ok(Self::AlterSchema { schema })
     }
 }
 

--- a/analytic_engine/src/payload.rs
+++ b/analytic_engine/src/payload.rs
@@ -74,6 +74,8 @@ impl Header {
     pub fn from_u8(value: u8) -> Option<Self> {
         match value {
             value if value == Self::Write as u8 => Some(Self::Write),
+            value if value == Self::AlterSchema as u8 => Some(Self::AlterSchema),
+            value if value == Self::AlterOption as u8 => Some(Self::AlterOption),
             _ => None,
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #82

# Rationale for this change
 
quote from #82:
>`AlterSchema` and `AlterOption` are now persisted in the manifest. It would be better to keep manifest simple (only contains SST file information, sequence number, etc.). And schema modification is related to data, putting them in two separate places may bring some problems.

This PR focus on the second target -- put DDL (altering schema and options) together with data WAL.

A more detailed reason is that in distributed mode, we have a writer node and serval reader nodes. Where the writer serves all the related write requests, including writing data and altering schema/options. And readers sync new data from their writer. They communicate with data WAL. However, the data WAL used only contains the data logs. This is problematic when for example, the schema is changing. Readers don't know at which point the schema has changed, and therefore cannot handle their memory status correctly.

After this patch readers can know when to update their schema and/or options. Those DDL records are associated with data records.

Besides this, those DDL records still exist in the Manifest. I.e. this PR doesn't touch the Manifest. I haven't found a better place to put those metadata. This kind of data changes frequently thus OSS is not a good choice.

# What changes are included in this PR?

Duplicate `AlterSchema` and `AlterOptions` to data WAL

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->


No, all changes are internal.

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Unit test