### PR TITLE
fix:select system.public.tables will return error

### DIFF
--- a/system_catalog/src/tables.rs
+++ b/system_catalog/src/tables.rs
@@ -138,8 +138,8 @@ impl<M: Manager> SystemTable for Tables<M> {
             .all_catalogs()
             .map_err(|e| Box::new(e) as _)
             .context(table_engine::table::Scan { table: self.name() })?;
-        let mut builder =
-            RecordBatchWithKeyBuilder::new(self.schema.clone().to_record_schema_with_key());
+        let record_schema_key = request.projected_schema.to_record_schema_with_key();
+        let mut builder = RecordBatchWithKeyBuilder::new(record_schema_key);
 
         let projector = request
             .projected_schema

--- a/system_catalog/src/tables.rs
+++ b/system_catalog/src/tables.rs
@@ -138,8 +138,8 @@ impl<M: Manager> SystemTable for Tables<M> {
             .all_catalogs()
             .map_err(|e| Box::new(e) as _)
             .context(table_engine::table::Scan { table: self.name() })?;
-        let record_schema_key = request.projected_schema.to_record_schema_with_key();
-        let mut builder = RecordBatchWithKeyBuilder::new(record_schema_key);
+        let projected_record_schema = request.projected_schema.to_record_schema_with_key();
+        let mut builder = RecordBatchWithKeyBuilder::new(projected_record_schema);
 
         let projector = request
             .projected_schema

--- a/tests/cases/01_system/system_tables.result
+++ b/tests/cases/01_system/system_tables.result
@@ -8,7 +8,9 @@ affected_rows: 0
 
 SELECT    `timestamp`,    `catalog`,    `schema`,    `table_name`,    `engine`FROM    system.public.tablesWHERE    table_name = '01_system_table1';
 
-Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to execute interpreter, query: SELECT     `timestamp`,     `catalog`,     `schema`,     `table_name`,     `engine` FROM     system.public.tables WHERE     table_name = '01_system_table1';. Caused by: Failed to execute select, err:Failed to execute logical plan, err:Failed to collect record batch stream, err:Stream error, msg:Convert from arrow record batch, err:External error: Execution error: Failed to read table, partition:3, err:Failed to scan table, table:tables, err:Failed to append datum, err:Data type conflict, expect:UInt64, given:String." })
+timestamp,catalog,schema,table_name,engine,
+Timestamp(Timestamp(0)),String(StringBytes(b"ceresdb")),String(StringBytes(b"public")),String(StringBytes(b"01_system_table1")),String(StringBytes(b"Analytic")),
+
 
 SHOW TABLES `name` LIKE '01_system_table1';
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #129 

# Rationale for this change
 
select system.public.tables will return error

# What changes are included in this PR?

I modified the creation method of record_schema_with_key. The original creation method cannot create a RecordBatch of the corresponding capacity according to the request parameters in the request, resulting in an error when filling the data

https://github.com/CeresDB/ceresdb/blob/main/system_catalog/src/tables.rs#141 

However, I found that when I executed the following statement, the returned `RecordBatchVec` was empty,I will find the reason for this problem later
```
SELECT
    `timestamp`,
    `catalog`
FROM
    system.public.tables
WHERE
    table_name = '01_system_table1';
```

# Are there any user-facing changes?

none

# How does this change test

none
