### PR TITLE
chore: bump rust toolchain edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,7 @@
 name = "ceresdb"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
-resolver = "2"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "analytic_engine"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchmarks"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/catalog/Cargo.toml
+++ b/catalog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "catalog"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/catalog_impls/Cargo.toml
+++ b/catalog_impls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "catalog_impls"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ceresdbproto_deps/Cargo.toml
+++ b/ceresdbproto_deps/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ceresdbproto_deps"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -2,7 +2,7 @@
 name = "common_types"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common_util/Cargo.toml
+++ b/common_util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "common_util"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/arena/Cargo.toml
+++ b/components/arena/Cargo.toml
@@ -2,7 +2,7 @@
 name = "arena"
 version = "0.1.0"
 authors = ["Ruihang Xia <xrh262829@antgroup.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/bytes/Cargo.toml
+++ b/components/bytes/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bytes"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/logger/Cargo.toml
+++ b/components/logger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "logger"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -2,7 +2,7 @@
 name = "object_store"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 async-trait = "0.1.53"

--- a/components/parquet/Cargo.toml
+++ b/components/parquet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "parquet"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -2,7 +2,7 @@
 name = "profile"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/components/skiplist/Cargo.toml
+++ b/components/skiplist/Cargo.toml
@@ -2,7 +2,7 @@
 name = "skiplist"
 version = "0.1.0"
 authors = ["Jay Lee <busyjaylee@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 rand = "0.7"

--- a/components/tracing/Cargo.toml
+++ b/components/tracing/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tracing"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/tracing_examples/Cargo.toml
+++ b/components/tracing_examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "trace_examples"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/tracing_util/Cargo.toml
+++ b/components/tracing_util/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies] # In alphabetical order
 lazy_static = "1.4.0"

--- a/df_operator/Cargo.toml
+++ b/df_operator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "df_operator"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/grpcio/Cargo.toml
+++ b/grpcio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "grpcio"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/interpreters/Cargo.toml
+++ b/interpreters/Cargo.toml
@@ -2,7 +2,7 @@
 name = "interpreters"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/meta_client/Cargo.toml
+++ b/meta_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "meta_client"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proto"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/query_engine/Cargo.toml
+++ b/query_engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "query_engine"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "server"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sql"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/system_catalog/Cargo.toml
+++ b/system_catalog/Cargo.toml
@@ -2,7 +2,7 @@
 name = "system_catalog"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/table_engine/Cargo.toml
+++ b/table_engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "table_engine"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wal"
 version = "0.1.0"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

# Which issue does this PR close?

Closes #143

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Some of our crates (like client-rs) have bumped to edition 2021.

Besides that, I want to default to "resolver 2" for conditionally enable feature gate for `dev-dependencies` (https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2)

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

bump edition for all sub-crates.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

no

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
I can build and run all test after this change.
