### PR TITLE
feat: setup in different deployment mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4835,6 +4835,7 @@ dependencies = [
  "avro-rs",
  "catalog",
  "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=2c10152d021cd5a26b9c870cdede6a0317adca3d)",
+ "cluster",
  "common_types 0.1.0",
  "common_util",
  "df_operator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=2c10152d021cd5a26b9c870cdede6a0317adca3d#2c10152d021cd5a26b9c870cdede6a0317adca3d"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=12a0ee8e45883056f275c707518fa9ed508676d1#12a0ee8e45883056f275c707518fa9ed508676d1"
 dependencies = [
  "futures 0.3.21",
  "grpcio 0.9.1",
@@ -812,7 +812,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=ec5404e0f60fc748d3e8b68a592e2926ac1e84de#ec5404e0f60fc748d3e8b68a592e2926ac1e84de"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=2c10152d021cd5a26b9c870cdede6a0317adca3d#2c10152d021cd5a26b9c870cdede6a0317adca3d"
 dependencies = [
  "futures 0.3.21",
  "grpcio 0.9.1",
@@ -824,7 +824,7 @@ dependencies = [
 name = "ceresdbproto_deps"
 version = "0.1.0"
 dependencies = [
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=ec5404e0f60fc748d3e8b68a592e2926ac1e84de)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=12a0ee8e45883056f275c707518fa9ed508676d1)",
 ]
 
 [[package]]
@@ -4834,7 +4834,7 @@ dependencies = [
  "async-trait",
  "avro-rs",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=2c10152d021cd5a26b9c870cdede6a0317adca3d)",
+ "ceresdbproto_deps",
  "cluster",
  "common_types 0.1.0",
  "common_util",
@@ -5163,7 +5163,7 @@ version = "0.1.0"
 dependencies = [
  "arrow_deps 0.1.0",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=2c10152d021cd5a26b9c870cdede6a0317adca3d)",
+ "ceresdbproto_deps",
  "common_types 0.1.0",
  "common_util",
  "df_operator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,13 +757,16 @@ name = "ceresdb"
 version = "0.1.0"
 dependencies = [
  "analytic_engine",
+ "async-trait",
  "catalog",
  "catalog_impls",
  "clap",
+ "cluster",
  "common_util",
  "df_operator",
  "log",
  "logger",
+ "meta_client_v2",
  "query_engine",
  "server",
  "signal-hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,16 @@ path = "src/bin/ceresdb-server.rs"
 [dependencies]
 # Workspace dependencies, in alphabetical order
 analytic_engine = { path = "analytic_engine" }
+async-trait = "0.1.53"
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
 clap = "2.0"
+cluster = { path = "cluster" }
 common_util = { path = "common_util" }
 df_operator = { path = "df_operator" }
 log = "0.4"
 logger = { path = "components/logger" }
+meta_client_v2 = { path = "meta_client_v2" }
 query_engine = { path = "query_engine" }
 server = { path = "server" }
 table_engine = { path = "table_engine" }

--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -726,7 +726,7 @@ mod tests {
         }
 
         fn alloc_table_id(&self) -> TableId {
-            TableId::new(
+            TableId::with_seq(
                 self.schema_id,
                 self.table_seq_gen.alloc_table_seq().unwrap(),
             )

--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -730,6 +730,7 @@ mod tests {
                 self.schema_id,
                 self.table_seq_gen.alloc_table_seq().unwrap(),
             )
+            .unwrap()
         }
 
         fn table_name_from_id(table_id: TableId) -> String {
@@ -934,7 +935,7 @@ mod tests {
 
     #[test]
     fn test_manifest_add_table() {
-        let ctx = TestContext::new("add_table", SchemaId::new(0).unwrap());
+        let ctx = TestContext::new("add_table", SchemaId::from_u32(0));
         run_basic_manifest_test(ctx, |ctx, table_id, manifest_data_builder| {
             Box::pin(async move {
                 ctx.add_table(table_id, manifest_data_builder).await;
@@ -944,7 +945,7 @@ mod tests {
 
     #[test]
     fn test_manifest_drop_table() {
-        let ctx = TestContext::new("drop_table", SchemaId::new(0).unwrap());
+        let ctx = TestContext::new("drop_table", SchemaId::from_u32(0));
         run_basic_manifest_test(ctx, |ctx, table_id, manifest_data_builder| {
             Box::pin(async move {
                 ctx.add_table(table_id, manifest_data_builder).await;
@@ -955,7 +956,7 @@ mod tests {
 
     #[test]
     fn test_manifest_version_edit() {
-        let ctx = TestContext::new("version_edit", SchemaId::new(0).unwrap());
+        let ctx = TestContext::new("version_edit", SchemaId::from_u32(0));
         run_basic_manifest_test(ctx, |ctx, table_id, manifest_data_builder| {
             Box::pin(async move {
                 ctx.add_table(table_id, manifest_data_builder).await;
@@ -967,7 +968,7 @@ mod tests {
 
     #[test]
     fn test_manifest_alter_options() {
-        let ctx = TestContext::new("version_edit", SchemaId::new(0).unwrap());
+        let ctx = TestContext::new("version_edit", SchemaId::from_u32(0));
         run_basic_manifest_test(ctx, |ctx, table_id, manifest_data_builder| {
             Box::pin(async move {
                 ctx.add_table(table_id, manifest_data_builder).await;
@@ -979,7 +980,7 @@ mod tests {
 
     #[test]
     fn test_manifest_alter_schema() {
-        let ctx = TestContext::new("version_edit", SchemaId::new(0).unwrap());
+        let ctx = TestContext::new("version_edit", SchemaId::from_u32(0));
         run_basic_manifest_test(ctx, |ctx, table_id, manifest_data_builder| {
             Box::pin(async move {
                 ctx.add_table(table_id, manifest_data_builder).await;
@@ -991,7 +992,7 @@ mod tests {
 
     #[test]
     fn test_manifest_snapshot_one_table() {
-        let ctx = TestContext::new("snapshot_one_table", SchemaId::new(0).unwrap());
+        let ctx = TestContext::new("snapshot_one_table", SchemaId::from_u32(0));
         let runtime = ctx.runtime.clone();
         runtime.block_on(async move {
             let table_id = ctx.alloc_table_id();
@@ -1020,7 +1021,7 @@ mod tests {
 
     #[test]
     fn test_manifest_snapshot_one_table_massive_logs() {
-        let ctx = TestContext::new("snapshot_one_table_massive_logs", SchemaId::new(0).unwrap());
+        let ctx = TestContext::new("snapshot_one_table_massive_logs", SchemaId::from_u32(0));
         let runtime = ctx.runtime.clone();
         runtime.block_on(async move {
             let table_id = ctx.alloc_table_id();
@@ -1207,7 +1208,7 @@ mod tests {
     fn test_no_snapshot_logs_merge() {
         let ctx = Arc::new(TestContext::new(
             "snapshot_merge_no_snapshot",
-            SchemaId::new(0).unwrap(),
+            SchemaId::from_u32(0),
         ));
         let table_id = ctx.alloc_table_id();
         let logs: Vec<(&str, MetaUpdateLogEntry)> = vec![
@@ -1262,7 +1263,7 @@ mod tests {
     fn test_multiple_snapshot_merge_normal() {
         let ctx = Arc::new(TestContext::new(
             "snapshot_merge_normal",
-            SchemaId::new(0).unwrap(),
+            SchemaId::from_u32(0),
         ));
         let table_id = ctx.alloc_table_id();
         let logs: Vec<(&str, MetaUpdateLogEntry)> = vec![
@@ -1349,7 +1350,7 @@ mod tests {
     fn test_multiple_snapshot_merge_interleaved_snapshot() {
         let ctx = Arc::new(TestContext::new(
             "snapshot_merge_interleaved",
-            SchemaId::new(0).unwrap(),
+            SchemaId::from_u32(0),
         ));
         let table_id = ctx.alloc_table_id();
         let logs: Vec<(&str, MetaUpdateLogEntry)> = vec![
@@ -1439,7 +1440,7 @@ mod tests {
     fn test_multiple_snapshot_merge_sneaked_update() {
         let ctx = Arc::new(TestContext::new(
             "snapshot_merge_sneaked_update",
-            SchemaId::new(0).unwrap(),
+            SchemaId::from_u32(0),
         ));
         let table_id = ctx.alloc_table_id();
         let logs: Vec<(&str, MetaUpdateLogEntry)> = vec![
@@ -1502,7 +1503,7 @@ mod tests {
     fn test_multiple_snapshot_drop_table() {
         let ctx = Arc::new(TestContext::new(
             "snapshot_drop_table",
-            SchemaId::new(0).unwrap(),
+            SchemaId::from_u32(0),
         ));
         let table_id = ctx.alloc_table_id();
         let logs: Vec<(&str, MetaUpdateLogEntry)> = vec![

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -621,7 +621,7 @@ pub mod tests {
             let create_request = CreateTableRequest {
                 catalog_name: "test_catalog".to_string(),
                 schema_name: "public".to_string(),
-                schema_id: SchemaId::new(DEFAULT_SPACE_ID).unwrap(),
+                schema_id: SchemaId::from_u32(DEFAULT_SPACE_ID),
                 table_id: self.table_id,
                 table_name: self.table_name,
                 table_schema,

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -25,7 +25,7 @@ use table_engine::{
 use crate::{table_options, tests::row_util};
 
 pub fn new_table_id(schema_id: u16, table_seq: u32) -> TableId {
-    TableId::new(SchemaId::from(schema_id), TableSeq::from(table_seq))
+    TableId::new(SchemaId::from(schema_id), TableSeq::from(table_seq)).unwrap()
 }
 
 pub type RowTuple<'a> = (&'a str, Timestamp, &'a str, f64, f64, &'a str);
@@ -298,7 +298,7 @@ impl Default for Builder {
             create_request: CreateTableRequest {
                 catalog_name: "ceresdb".to_string(),
                 schema_name: "public".to_string(),
-                schema_id: SchemaId::new(2).unwrap(),
+                schema_id: SchemaId::from_u32(2),
                 table_id: new_table_id(2, 1),
                 table_name: "test_table".to_string(),
                 table_schema: FixedSchemaTable::default_schema(),

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -25,7 +25,7 @@ use table_engine::{
 use crate::{table_options, tests::row_util};
 
 pub fn new_table_id(schema_id: u16, table_seq: u32) -> TableId {
-    TableId::new(SchemaId::from(schema_id), TableSeq::from(table_seq)).unwrap()
+    TableId::with_seq(SchemaId::from(schema_id), TableSeq::from(table_seq)).unwrap()
 }
 
 pub type RowTuple<'a> = (&'a str, Timestamp, &'a str, f64, f64, &'a str);

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -374,7 +374,7 @@ impl TestEnv {
             runtimes: self.runtimes.clone(),
             builder: T::default(),
             engine: None,
-            schema_id: SchemaId::new(100).unwrap(),
+            schema_id: SchemaId::from_u32(100),
             last_table_seq: 1,
             name_to_tables: HashMap::new(),
         }

--- a/catalog/src/manager.rs
+++ b/catalog/src/manager.rs
@@ -2,6 +2,8 @@
 
 //! Catalog manager
 
+use std::sync::Arc;
+
 use snafu::Snafu;
 
 use crate::{schema::NameRef, CatalogRef};
@@ -17,7 +19,7 @@ define_result!(Error);
 // TODO(yingwen): Maybe use async trait?
 // TODO(yingwen): Provide a context
 
-pub trait Manager: Clone + Send + Sync {
+pub trait Manager: Send + Sync {
     /// Get the default catalog name
     fn default_catalog_name(&self) -> NameRef;
 
@@ -30,3 +32,5 @@ pub trait Manager: Clone + Send + Sync {
     /// All catalogs
     fn all_catalogs(&self) -> Result<Vec<CatalogRef>>;
 }
+
+pub type ManagerRef = Arc<dyn Manager>;

--- a/catalog/src/manager.rs
+++ b/catalog/src/manager.rs
@@ -21,9 +21,15 @@ define_result!(Error);
 
 pub trait Manager: Send + Sync {
     /// Get the default catalog name
+    ///
+    /// Default catalog is ensured created because no method to create catalog
+    /// is provided.
     fn default_catalog_name(&self) -> NameRef;
 
     /// Get the default schema name
+    ///
+    /// Default schema may be not created by the implementation and the caller
+    /// may need to create that by itself.
     fn default_schema_name(&self) -> NameRef;
 
     /// Find the catalog by name

--- a/catalog/src/schema.rs
+++ b/catalog/src/schema.rs
@@ -9,7 +9,7 @@ use common_types::column_schema::ColumnSchema;
 use snafu::{Backtrace, Snafu};
 use table_engine::{
     engine::{self, TableEngineRef, TableState},
-    table::{SchemaId, TableId, TableRef},
+    table::{SchemaId, TableId, TableRef, TableSeq},
 };
 
 #[derive(Debug, Snafu)]
@@ -126,6 +126,18 @@ pub enum Error {
     TooManyTable {
         schema: String,
         table: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "Invalid schema id and table seq, schema_id:{:?}, table_seq:{:?}.\nBacktrace:\n{}",
+        schema_id,
+        table_seq,
+        backtrace,
+    ))]
+    InvalidSchemaIdAndTableSeq {
+        schema_id: SchemaId,
+        table_seq: TableSeq,
         backtrace: Backtrace,
     },
 }

--- a/catalog/src/schema.rs
+++ b/catalog/src/schema.rs
@@ -9,7 +9,7 @@ use common_types::column_schema::ColumnSchema;
 use snafu::{Backtrace, Snafu};
 use table_engine::{
     engine::{self, TableEngineRef, TableState},
-    table::{SchemaId, TableId, TableRef, TableSeq},
+    table::{SchemaId, TableId, TableRef},
 };
 
 #[derive(Debug, Snafu)]
@@ -126,18 +126,6 @@ pub enum Error {
     TooManyTable {
         schema: String,
         table: String,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display(
-        "Invalid schema id and table seq, schema_id:{:?}, table_seq:{:?}.\nBacktrace:\n{}",
-        schema_id,
-        table_seq,
-        backtrace,
-    ))]
-    InvalidSchemaIdAndTableSeq {
-        schema_id: SchemaId,
-        table_seq: TableSeq,
         backtrace: Backtrace,
     },
 }

--- a/catalog_impls/src/lib.rs
+++ b/catalog_impls/src/lib.rs
@@ -56,25 +56,25 @@ impl<M: Manager> Manager for CatalogManagerImpl<M> {
 #[async_trait]
 pub trait SchemaIdAlloc: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
-    async fn alloc_schema_id(
-        &self,
-        schema_name: NameRef,
+    async fn alloc_schema_id<'a>(
+        &'a self,
+        schema_name: NameRef<'a>,
     ) -> std::result::Result<SchemaId, Self::Error>;
 }
 
 #[async_trait]
 pub trait TableIdAlloc: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
-    async fn alloc_table_id(
-        &self,
-        schema_name: NameRef,
-        table_name: NameRef,
+    async fn alloc_table_id<'a>(
+        &'a self,
+        schema_name: NameRef<'a>,
+        table_name: NameRef<'a>,
     ) -> std::result::Result<TableId, Self::Error>;
 
-    async fn invalidate_table_id(
-        &self,
-        schema_name: NameRef,
-        table_name: NameRef,
+    async fn invalidate_table_id<'a>(
+        &'a self,
+        schema_name: NameRef<'a>,
+        table_name: NameRef<'a>,
         table_id: TableId,
     ) -> std::result::Result<(), Self::Error>;
 }

--- a/catalog_impls/src/lib.rs
+++ b/catalog_impls/src/lib.rs
@@ -3,7 +3,12 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use catalog::{consts::SYSTEM_CATALOG, manager::Manager, schema::NameRef, CatalogRef};
+use catalog::{
+    consts::SYSTEM_CATALOG,
+    manager::{Manager, ManagerRef},
+    schema::NameRef,
+    CatalogRef,
+};
 use system_catalog::{tables::Tables, SystemTableAdapter};
 use table_engine::table::{SchemaId, TableId};
 
@@ -15,13 +20,13 @@ pub mod volatile;
 
 /// CatalogManagerImpl is a wrapper for system and user tables
 #[derive(Clone)]
-pub struct CatalogManagerImpl<M> {
+pub struct CatalogManagerImpl {
     system_tables: SystemTables,
-    user_catalog_manager: M,
+    user_catalog_manager: ManagerRef,
 }
 
-impl<M: Manager + 'static> CatalogManagerImpl<M> {
-    pub fn new(manager: M) -> Self {
+impl CatalogManagerImpl {
+    pub fn new(manager: ManagerRef) -> Self {
         let mut system_tables_builder = SystemTablesBuilder::new();
         system_tables_builder = system_tables_builder
             .insert_table(SystemTableAdapter::new(Tables::new(manager.clone())));
@@ -32,7 +37,7 @@ impl<M: Manager + 'static> CatalogManagerImpl<M> {
     }
 }
 
-impl<M: Manager> Manager for CatalogManagerImpl<M> {
+impl Manager for CatalogManagerImpl {
     fn default_catalog_name(&self) -> NameRef {
         self.user_catalog_manager.default_catalog_name()
     }

--- a/catalog_impls/src/lib.rs
+++ b/catalog_impls/src/lib.rs
@@ -62,7 +62,7 @@ impl Manager for CatalogManagerImpl {
 pub trait SchemaIdAlloc: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
     async fn alloc_schema_id<'a>(
-        &'a self,
+        &self,
         schema_name: NameRef<'a>,
     ) -> std::result::Result<SchemaId, Self::Error>;
 }
@@ -71,13 +71,13 @@ pub trait SchemaIdAlloc: Send + Sync {
 pub trait TableIdAlloc: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
     async fn alloc_table_id<'a>(
-        &'a self,
+        &self,
         schema_name: NameRef<'a>,
         table_name: NameRef<'a>,
     ) -> std::result::Result<TableId, Self::Error>;
 
     async fn invalidate_table_id<'a>(
-        &'a self,
+        &self,
         schema_name: NameRef<'a>,
         table_name: NameRef<'a>,
         table_id: TableId,

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -130,7 +130,7 @@ impl TableBasedManager {
 
     #[cfg(test)]
     pub fn get_engine_proxy(&self) -> TableEngineRef {
-        self.inner.engine_proxy.clone()
+        self.engine_proxy.clone()
     }
 
     /// Load all data from sys catalog table.
@@ -629,7 +629,7 @@ impl SchemaImpl {
 
         TableId::new(self.schema_id, table_seq).context(InvalidSchemaIdAndTableSeq {
             schema_id: self.schema_id,
-            table_seq: table_seq,
+            table_seq,
         })
     }
 }

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -900,9 +900,7 @@ mod tests {
         // Create catalog manager, use analytic table as backend
         TableBasedManager::new(analytic.clone(), engine_proxy.clone())
             .await
-            .unwrap_or_else(|e| {
-                panic!("Failed to create catalog manager, err:{}", e);
-            })
+            .expect("Failed to create catalog manager")
     }
 
     async fn build_default_schema_with_catalog(catalog_manager: &TableBasedManager) -> SchemaRef {

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -638,7 +638,7 @@ impl SchemaImpl {
                 table: name,
             })?;
 
-        TableId::new(self.schema_id, table_seq)
+        TableId::with_seq(self.schema_id, table_seq)
             .context(InvalidSchemaIdAndTableSeq {
                 schema_id: self.schema_id,
                 table_seq,

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -76,7 +76,6 @@ pub enum Error {
 define_result!(Error);
 
 /// Table based catalog manager
-#[derive(Clone)]
 pub struct TableBasedManager {
     /// Sys catalog table
     catalog_table: Arc<SysCatalogTable>,

--- a/catalog_impls/src/volatile.rs
+++ b/catalog_impls/src/volatile.rs
@@ -86,33 +86,11 @@ where
 {
     async fn maybe_create_default_catalog(&mut self) {
         // Try to get default catalog, create it if not exists.
-        let catalog = match self.catalogs.get(consts::DEFAULT_CATALOG) {
-            Some(v) => v.clone(),
-            None => {
-                // Default catalog is not exists, create and store it.
-                self.create_catalog(consts::DEFAULT_CATALOG.to_string())
-                    .await
-            }
+        if self.catalogs.get(consts::DEFAULT_CATALOG).is_none() {
+            // Default catalog is not exists, create and store it.
+            self.create_catalog(consts::DEFAULT_CATALOG.to_string())
+                .await;
         };
-
-        // Create default schema if not exists.
-        if !catalog.schema_exists(consts::DEFAULT_SCHEMA) {
-            // Allocate schema id.
-            let schema_id = self
-                .schema_id_alloc
-                .alloc_schema_id(consts::DEFAULT_SCHEMA)
-                .await
-                .expect("Schema id of default catalog should be valid");
-
-            self.add_schema_to_catalog(
-                consts::DEFAULT_CATALOG.to_string(),
-                consts::DEFAULT_SCHEMA.to_string(),
-                schema_id,
-                self.table_id_alloc.clone(),
-                &*catalog,
-            )
-            .await;
-        }
     }
 
     async fn create_catalog(&mut self, catalog_name: String) -> Arc<CatalogImpl<S, T>> {
@@ -126,26 +104,6 @@ where
         self.catalogs.insert(catalog_name, catalog.clone());
 
         catalog
-    }
-
-    async fn add_schema_to_catalog(
-        &mut self,
-        catalog_name: String,
-        schema_name: String,
-        schema_id: SchemaId,
-        table_id_alloc: Arc<T>,
-        catalog: &CatalogImpl<S, T>,
-    ) -> Arc<SchemaImpl<T>> {
-        let schema = Arc::new(SchemaImpl::new(
-            catalog_name,
-            schema_name,
-            schema_id,
-            table_id_alloc,
-        ));
-
-        catalog.add_schema(schema.clone());
-
-        schema
     }
 }
 
@@ -161,21 +119,6 @@ struct CatalogImpl<S, T> {
     schemas: RwLock<HashMap<SchemaName, SchemaRef>>,
     schema_id_alloc: Arc<S>,
     table_id_alloc: Arc<T>,
-}
-
-impl<S, T> CatalogImpl<S, T>
-where
-    T: TableIdAlloc + 'static,
-{
-    fn add_schema(&self, schema: Arc<SchemaImpl<T>>) {
-        let mut schemas = self.schemas.write().unwrap();
-        schemas.insert(schema.name().to_string(), schema);
-    }
-
-    fn schema_exists(&self, schema_name: &str) -> bool {
-        let schemas = self.schemas.read().unwrap();
-        schemas.get(schema_name).is_some()
-    }
 }
 
 #[async_trait]

--- a/ceresdbproto_deps/Cargo.toml
+++ b/ceresdbproto_deps/Cargo.toml
@@ -10,4 +10,4 @@ workspace = true
 
 [dependencies.ceresdbproto]
 git = "https://github.com/CeresDB/ceresdbproto.git"
-rev = "ec5404e0f60fc748d3e8b68a592e2926ac1e84de"
+rev = "12a0ee8e45883056f275c707518fa9ed508676d1"

--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -88,11 +88,11 @@ impl ClusterImpl {
 
     // Register node every 2/3 lease
     fn heartbeat_interval(&self) -> Duration {
-        Duration::from_secs(self.config.meta_client_config.lease.as_millis() * 2 / 3)
+        Duration::from_secs(self.config.meta_client.lease.as_millis() * 2 / 3)
     }
 
     fn error_wait_lease(&self) -> Duration {
-        self.config.meta_client_config.lease.0 / 2
+        self.config.meta_client.lease.0 / 2
     }
 }
 

--- a/cluster/src/config.rs
+++ b/cluster/src/config.rs
@@ -4,6 +4,7 @@ use meta_client_v2::{meta_impl::MetaClientConfig, types::NodeMetaInfo};
 use serde_derive::Deserialize;
 
 #[derive(Default, Clone, Deserialize, Debug)]
+#[serde(default)]
 pub struct ClusterConfig {
     pub node: NodeMetaInfo,
     pub cmd_channel_buffer_size: usize,

--- a/cluster/src/config.rs
+++ b/cluster/src/config.rs
@@ -1,18 +1,11 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use meta_client_v2::meta_impl::MetaClientConfig;
+use meta_client_v2::{meta_impl::MetaClientConfig, types::NodeMetaInfo};
 use serde_derive::Deserialize;
 
 #[derive(Default, Clone, Deserialize, Debug)]
 pub struct ClusterConfig {
-    /// Local ip address of this node, used as endpoint ip in meta.
-    pub node: String,
-    /// Grpc port of this node, also used as endpoint port in meta.
-    pub port: u16,
-    pub zone: String,
-    pub idc: String,
-    pub binary_version: String,
+    pub node: NodeMetaInfo,
     pub cmd_channel_buffer_size: usize,
-
-    pub meta_client_config: MetaClientConfig,
+    pub meta_client: MetaClientConfig,
 }

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use common_util::define_result;
 pub use meta_client_v2::types::{
     AllocSchemaIdRequest, AllocSchemaIdResponse, AllocTableIdRequest, AllocTableIdResponse,
-    DropTableRequest, DropTableResponse, GetTablesRequest,
+    DropTableRequest, GetTablesRequest,
 };
 use meta_client_v2::types::{ShardId, TableId};
 use snafu::{Backtrace, Snafu};

--- a/interpreters/src/create.rs
+++ b/interpreters/src/create.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 use catalog::{
-    manager::Manager,
+    manager::ManagerRef,
     schema::{CreateOptions, CreateTableRequest},
 };
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
@@ -50,18 +50,18 @@ pub enum Error {
 define_result!(Error);
 
 /// Create interpreter
-pub struct CreateInterpreter<C> {
+pub struct CreateInterpreter {
     ctx: Context,
     plan: CreateTablePlan,
-    catalog_manager: C,
+    catalog_manager: ManagerRef,
     table_engine: TableEngineRef,
 }
 
-impl<C: Manager + 'static> CreateInterpreter<C> {
+impl CreateInterpreter {
     pub fn create(
         ctx: Context,
         plan: CreateTablePlan,
-        catalog_manager: C,
+        catalog_manager: ManagerRef,
         table_engine: TableEngineRef,
     ) -> InterpreterPtr {
         Box::new(Self {
@@ -73,7 +73,7 @@ impl<C: Manager + 'static> CreateInterpreter<C> {
     }
 }
 
-impl<C: Manager> CreateInterpreter<C> {
+impl CreateInterpreter {
     async fn execute_create(self: Box<Self>) -> Result<Output> {
         let default_catalog = self.ctx.default_catalog();
         let catalog = self
@@ -132,7 +132,7 @@ impl<C: Manager> CreateInterpreter<C> {
 // TODO(yingwen): Wrap a method that returns self::Result, simplify some code to
 // converting self::Error to super::Error
 #[async_trait]
-impl<C: Manager> Interpreter for CreateInterpreter<C> {
+impl Interpreter for CreateInterpreter {
     async fn execute(self: Box<Self>) -> InterpreterResult<Output> {
         self.execute_create().await.context(Create)
     }

--- a/interpreters/src/factory.rs
+++ b/interpreters/src/factory.rs
@@ -2,7 +2,7 @@
 
 //! Interpreter factory
 
-use catalog::manager::Manager as CatalogManager;
+use catalog::manager::ManagerRef;
 use query_engine::executor::Executor;
 use sql::plan::Plan;
 use table_engine::engine::TableEngineRef;
@@ -15,14 +15,18 @@ use crate::{
 };
 
 /// A factory to create interpreters
-pub struct Factory<Q, C> {
+pub struct Factory<Q> {
     query_executor: Q,
-    catalog_manager: C,
+    catalog_manager: ManagerRef,
     table_engine: TableEngineRef,
 }
 
-impl<Q: Executor + 'static, C: CatalogManager + 'static> Factory<Q, C> {
-    pub fn new(query_executor: Q, catalog_manager: C, table_engine: TableEngineRef) -> Self {
+impl<Q: Executor + 'static> Factory<Q> {
+    pub fn new(
+        query_executor: Q,
+        catalog_manager: ManagerRef,
+        table_engine: TableEngineRef,
+    ) -> Self {
         Self {
             query_executor,
             catalog_manager,

--- a/interpreters/src/tests.rs
+++ b/interpreters/src/tests.rs
@@ -1,5 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+use std::sync::Arc;
+
 use analytic_engine::{
     setup::{EngineBuilder, RocksEngineBuilder},
     tests::util::TestEnv,
@@ -56,8 +58,8 @@ impl<M> Env<M>
 where
     M: MetaProvider,
 {
-    async fn build_factory(&self) -> Factory<ExecutorImpl, TableBasedManager> {
-        let catalog_manager = build_catalog_manager(self.engine()).await;
+    async fn build_factory(&self) -> Factory<ExecutorImpl> {
+        let catalog_manager = Arc::new(build_catalog_manager(self.engine()).await);
         Factory::new(ExecutorImpl::new(), catalog_manager, self.engine())
     }
 

--- a/interpreters/src/tests.rs
+++ b/interpreters/src/tests.rs
@@ -25,9 +25,7 @@ async fn build_catalog_manager(analytic: TableEngineRef) -> TableBasedManager {
     // Create catalog manager, use analytic table as backend
     TableBasedManager::new(analytic.clone(), analytic)
         .await
-        .unwrap_or_else(|e| {
-            panic!("Failed to create catalog manager, err:{}", e);
-        })
+        .expect("Failed to create catalog manager")
 }
 
 fn sql_to_plan<M: MetaProvider>(meta_provider: &M, sql: &str) -> Plan {

--- a/meta_client/src/lib.rs
+++ b/meta_client/src/lib.rs
@@ -127,7 +127,7 @@ impl From<SchemaShardView> for SchemaConfig {
     }
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct ClusterView {
     pub schema_shards: HashMap<String, ShardViewMap>,
     pub schema_configs: HashMap<String, SchemaConfig>,
@@ -135,7 +135,7 @@ pub struct ClusterView {
 
 pub type ClusterViewRef = Arc<ClusterView>;
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct MetaClientConfig {
     pub cluster: String,

--- a/meta_client_v2/src/lib.rs
+++ b/meta_client_v2/src/lib.rs
@@ -105,7 +105,7 @@ pub trait EventHandler {
 /// MetaClient is the abstraction of client used to communicate with CeresMeta
 /// cluster.
 #[async_trait]
-pub trait MetaClient {
+pub trait MetaClient: Send + Sync {
     /// Start the meta client and the events will occur afterwards.
     async fn start(&self) -> Result<()>;
     /// Stop the meta client and release all the resources.
@@ -126,3 +126,5 @@ pub trait MetaClient {
 
     async fn send_heartbeat(&self, req: Vec<ShardInfo>) -> Result<()>;
 }
+
+pub type MetaClientRef = Arc<dyn MetaClient>;

--- a/meta_client_v2/src/lib.rs
+++ b/meta_client_v2/src/lib.rs
@@ -7,8 +7,7 @@ use common_util::define_result;
 use snafu::{Backtrace, Snafu};
 use types::{
     ActionCmd, AllocSchemaIdRequest, AllocSchemaIdResponse, AllocTableIdRequest,
-    AllocTableIdResponse, DropTableRequest, DropTableResponse, GetTablesRequest, GetTablesResponse,
-    ResponseHeader, ShardInfo,
+    AllocTableIdResponse, DropTableRequest, GetTablesRequest, GetTablesResponse, ShardInfo,
 };
 
 pub mod meta_impl;
@@ -69,9 +68,15 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
-    #[snafu(display("Meta rpc error, resp header:{:?}.\nBacktrace:\n{}", header, backtrace))]
+    #[snafu(display(
+        "Meta rpc error, resp code:{}, msg:{}.\nBacktrace:\n{}",
+        code,
+        msg,
+        backtrace
+    ))]
     MetaRpc {
-        header: ResponseHeader,
+        code: u32,
+        msg: String,
         backtrace: Backtrace,
     },
 
@@ -120,7 +125,7 @@ pub trait MetaClient: Send + Sync {
 
     async fn alloc_table_id(&self, req: AllocTableIdRequest) -> Result<AllocTableIdResponse>;
 
-    async fn drop_table(&self, req: DropTableRequest) -> Result<DropTableResponse>;
+    async fn drop_table(&self, req: DropTableRequest) -> Result<()>;
 
     async fn get_tables(&self, req: GetTablesRequest) -> Result<GetTablesResponse>;
 

--- a/meta_client_v2/src/meta_impl.rs
+++ b/meta_client_v2/src/meta_impl.rs
@@ -96,7 +96,7 @@ impl Inner {
 
     fn request_header(&self) -> RequestHeader {
         RequestHeader {
-            node: self.node_meta_info.node.to_string(),
+            node: self.node_meta_info.endpoint(),
             cluster_name: self.meta_config.cluster_name.clone(),
         }
     }

--- a/meta_client_v2/src/meta_impl.rs
+++ b/meta_client_v2/src/meta_impl.rs
@@ -497,7 +497,7 @@ fn check_response_header(header: &ResponseHeader) -> Result<()> {
     } else {
         MetaRpc {
             code: header.code,
-            msg: header.get_error().clone(),
+            msg: header.get_error(),
         }
         .fail()
     }

--- a/meta_client_v2/src/meta_impl.rs
+++ b/meta_client_v2/src/meta_impl.rs
@@ -6,7 +6,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use ceresdbproto_deps::ceresdbproto::{meta_service, meta_service_grpc::CeresmetaRpcServiceClient};
+use ceresdbproto_deps::ceresdbproto::{
+    common::ResponseHeader, meta_service, meta_service_grpc::CeresmetaRpcServiceClient,
+};
 use common_util::{
     config::ReadableDuration,
     runtime::{JoinHandle, Runtime},
@@ -29,9 +31,8 @@ use tokio::{
 use crate::{
     types::{
         ActionCmd, AllocSchemaIdRequest, AllocSchemaIdResponse, AllocTableIdRequest,
-        AllocTableIdResponse, CreateTableCmd, DropTableCmd, DropTableRequest, DropTableResponse,
-        GetTablesRequest, GetTablesResponse, NodeHeartbeatResponse, NodeInfo, NodeMetaInfo,
-        RequestHeader, ResponseHeader, ShardInfo,
+        AllocTableIdResponse, CreateTableCmd, DropTableCmd, DropTableRequest, GetTablesRequest,
+        GetTablesResponse, NodeHeartbeatResponse, NodeInfo, NodeMetaInfo, RequestHeader, ShardInfo,
     },
     EventHandler, EventHandlerRef, FailAllocSchemaId, FailAllocTableId, FailDropTable,
     FailGetGrpcClient, FailGetTables, FailHandleEvent, FailSendHeartbeat, FetchActionCmd,
@@ -227,11 +228,12 @@ impl Inner {
                 resp,
             );
 
-            let resp = NodeHeartbeatResponse::from(resp);
-            if let Err(e) = check_response_header(&resp.header) {
+            if let Err(e) = check_response_header(resp.get_header()) {
                 error!("Fetch action cmd failed, err:{}", e);
                 continue;
             }
+
+            let resp = NodeHeartbeatResponse::from(resp);
             let event = match resp.action_cmd {
                 Some(action_cmd) => action_cmd,
                 None => {
@@ -355,10 +357,8 @@ impl MetaClient for MetaClientImpl {
             pb_req, pb_resp
         );
 
-        let resp = AllocSchemaIdResponse::from(pb_resp);
-
-        check_response_header(&resp.header)?;
-        Ok(resp)
+        check_response_header(pb_resp.get_header())?;
+        Ok(AllocSchemaIdResponse::from(pb_resp))
     }
 
     async fn alloc_table_id(&self, req: AllocTableIdRequest) -> Result<AllocTableIdResponse> {
@@ -381,8 +381,8 @@ impl MetaClient for MetaClientImpl {
             pb_req, pb_resp
         );
 
+        check_response_header(pb_resp.get_header())?;
         let resp = AllocTableIdResponse::from(pb_resp);
-        check_response_header(&resp.header)?;
 
         let add_table_cmd = ActionCmd::CreateTableCmd(CreateTableCmd {
             schema_name: resp.schema_name.clone(),
@@ -396,7 +396,7 @@ impl MetaClient for MetaClientImpl {
         Ok(resp)
     }
 
-    async fn drop_table(&self, req: DropTableRequest) -> Result<DropTableResponse> {
+    async fn drop_table(&self, req: DropTableRequest) -> Result<()> {
         let grpc_client_guard = self.inner.grpc_client.read().await;
         let grpc_client = grpc_client_guard.as_ref().context(FailGetGrpcClient)?;
 
@@ -416,16 +416,13 @@ impl MetaClient for MetaClientImpl {
             pb_req, pb_resp
         );
 
-        let resp = DropTableResponse::from(pb_resp);
-        check_response_header(&resp.header)?;
-
+        check_response_header(pb_resp.get_header())?;
         let drop_table_cmd = ActionCmd::DropTableCmd(DropTableCmd {
             schema_name: req.schema_name.clone(),
             name: req.name.clone(),
         });
-        self.inner.handle_event(&drop_table_cmd).await?;
 
-        Ok(resp)
+        self.inner.handle_event(&drop_table_cmd).await
     }
 
     async fn get_tables(&self, req: GetTablesRequest) -> Result<GetTablesResponse> {
@@ -449,10 +446,9 @@ impl MetaClient for MetaClientImpl {
             pb_req, pb_resp
         );
 
-        let resp = GetTablesResponse::from(pb_resp);
-        check_response_header(&resp.header)?;
+        check_response_header(pb_resp.get_header())?;
 
-        Ok(resp)
+        Ok(GetTablesResponse::from(pb_resp))
     }
 
     async fn send_heartbeat(&self, shards_info: Vec<ShardInfo>) -> Result<()> {
@@ -496,11 +492,12 @@ impl MetaClient for MetaClientImpl {
 }
 
 fn check_response_header(header: &ResponseHeader) -> Result<()> {
-    if header.is_success() {
+    if header.code == 0 {
         Ok(())
     } else {
         MetaRpc {
-            header: header.clone(),
+            code: header.code,
+            msg: header.get_error().clone(),
         }
         .fail()
     }

--- a/meta_client_v2/src/meta_impl.rs
+++ b/meta_client_v2/src/meta_impl.rs
@@ -52,7 +52,7 @@ impl Default for MetaClientConfig {
     fn default() -> Self {
         Self {
             cluster_name: String::new(),
-            meta_addr: "http://127.0.0.1:8080".to_string(),
+            meta_addr: "127.0.0.1:8080".to_string(),
             lease: ReadableDuration::secs(10),
             timeout: ReadableDuration::secs(5),
             cq_count: 8,

--- a/meta_client_v2/src/types.rs
+++ b/meta_client_v2/src/types.rs
@@ -204,7 +204,7 @@ impl Default for MetaClientConfig {
     fn default() -> Self {
         Self {
             cluster_name: String::new(),
-            meta_addr: "http://127.0.0.1:8080".to_string(),
+            meta_addr: "127.0.0.1:8080".to_string(),
             meta_members_url: "ceresmeta/members".to_string(),
             lease: ReadableDuration::secs(10),
             timeout: ReadableDuration::secs(5),

--- a/meta_client_v2/src/types.rs
+++ b/meta_client_v2/src/types.rs
@@ -102,6 +102,7 @@ pub struct ShardTables {
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
 pub struct NodeMetaInfo {
     pub addr: String,
     pub port: u16,

--- a/meta_client_v2/src/types.rs
+++ b/meta_client_v2/src/types.rs
@@ -113,7 +113,7 @@ pub struct NodeMetaInfo {
 
 impl NodeMetaInfo {
     pub fn endpoint(&self) -> String {
-        return format!("{}:{}", self.addr, self.port);
+        format!("{}:{}", self.addr, self.port)
     }
 }
 

--- a/meta_client_v2/src/types.rs
+++ b/meta_client_v2/src/types.rs
@@ -101,24 +101,19 @@ pub struct ShardTables {
     pub tables: Vec<TableInfo>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct Node {
-    pub addr: String,
-    pub port: u16,
-}
-
-impl ToString for Node {
-    fn to_string(&self) -> String {
-        format!("{}:{}", self.addr, self.port)
-    }
-}
-
 #[derive(Debug, Default, Clone, Deserialize)]
 pub struct NodeMetaInfo {
-    pub node: Node,
+    pub addr: String,
+    pub port: u16,
     pub zone: String,
     pub idc: String,
     pub binary_version: String,
+}
+
+impl NodeMetaInfo {
+    pub fn endpoint(&self) -> String {
+        return format!("{}:{}", self.addr, self.addr);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -221,7 +216,7 @@ impl Default for MetaClientConfig {
 impl From<NodeInfo> for meta_service::NodeInfo {
     fn from(node_info: NodeInfo) -> Self {
         let mut pb_node_info = meta_service::NodeInfo::new();
-        pb_node_info.set_node(node_info.node_meta_info.node.to_string());
+        pb_node_info.set_node(node_info.node_meta_info.endpoint());
         pb_node_info.set_zone(node_info.node_meta_info.zone);
         pb_node_info.set_binary_version(node_info.node_meta_info.binary_version);
         pb_node_info.set_shardsInfo(protobuf::RepeatedField::from_vec(

--- a/meta_client_v2/src/types.rs
+++ b/meta_client_v2/src/types.rs
@@ -113,7 +113,7 @@ pub struct NodeMetaInfo {
 
 impl NodeMetaInfo {
     pub fn endpoint(&self) -> String {
-        return format!("{}:{}", self.addr, self.addr);
+        return format!("{}:{}", self.addr, self.port);
     }
 }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = "0.1.53"
 avro-rs = "0.13"
 catalog = { path = "../catalog" }
 ceresdbproto = { git = "https://github.com/CeresDB/ceresdbproto.git", rev= "2c10152d021cd5a26b9c870cdede6a0317adca3d" }
+cluster = { path = "../cluster" }
 common_types = { path = "../common_types" }
 common_util = { path = "../common_util" }
 df_operator = { path = "../df_operator" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,7 +14,7 @@ arrow_deps = { path = "../arrow_deps" }
 async-trait = "0.1.53"
 avro-rs = "0.13"
 catalog = { path = "../catalog" }
-ceresdbproto = { git = "https://github.com/CeresDB/ceresdbproto.git", rev= "2c10152d021cd5a26b9c870cdede6a0317adca3d" }
+ceresdbproto_deps = { path = "../ceresdbproto_deps" }
 cluster = { path = "../cluster" }
 common_types = { path = "../common_types" }
 common_util = { path = "../common_util" }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -3,10 +3,17 @@
 //! Server configs
 
 use analytic_engine;
+use cluster::config::ClusterConfig;
 use meta_client::MetaClientConfig;
 use serde_derive::Deserialize;
 
 use crate::router::RuleList;
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+pub enum DeployMode {
+    Standalone,
+    Cluster,
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(default)]
@@ -52,6 +59,8 @@ pub struct Config {
 
     // Analytic engine configs:
     pub analytic: analytic_engine::Config,
+    pub cluster: ClusterConfig,
+    pub deploy_mode: DeployMode,
 }
 
 impl Default for RuntimeConfig {
@@ -88,6 +97,8 @@ impl Default for Config {
             },
             route_rules: RuleList::default(),
             analytic: analytic_engine::Config::default(),
+            cluster: ClusterConfig::default(),
+            deploy_mode: DeployMode::Standalone,
         }
     }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -15,7 +15,7 @@ pub enum DeployMode {
     Cluster,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct RuntimeConfig {
     // Runtime for reading data
@@ -29,7 +29,7 @@ pub struct RuntimeConfig {
 }
 
 // TODO(yingwen): Split config into several sub configs.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
     /// The address to listen.

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -10,7 +10,7 @@ use std::{
 
 use async_trait::async_trait;
 use catalog::{consts as catalogConst, manager::ManagerRef};
-use ceresdbproto::{
+use ceresdbproto_deps::ceresdbproto::{
     common::ResponseHeader,
     prometheus::{PrometheusQueryRequest, PrometheusQueryResponse},
     storage::{
@@ -507,8 +507,8 @@ impl<Q: QueryExecutor + 'static> StorageService for StorageServiceImpl<Q> {
     fn stream_write(
         &mut self,
         ctx: RpcContext<'_>,
-        mut stream_req: RequestStream<ceresdbproto::storage::WriteRequest>,
-        sink: ClientStreamingSink<ceresdbproto::storage::WriteResponse>,
+        mut stream_req: RequestStream<WriteRequest>,
+        sink: ClientStreamingSink<WriteResponse>,
     ) {
         let begin_instant = Instant::now();
         let router = self.router.clone();

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -884,7 +884,9 @@ fn try_get_data_type_from_value(value: &Value_oneof_value) -> Result<DatumKind> 
 
 #[cfg(test)]
 mod tests {
-    use ceresdbproto::storage::{Field, FieldGroup, Tag, Value, WriteEntry, WriteMetric};
+    use ceresdbproto_deps::ceresdbproto::storage::{
+        Field, FieldGroup, Tag, Value, WriteEntry, WriteMetric,
+    };
     use common_types::datum::DatumKind;
     use meta_client::SchemaConfig;
 

--- a/server/src/grpc/prom_query.rs
+++ b/server/src/grpc/prom_query.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use ceresdbproto::{
+use ceresdbproto_deps::ceresdbproto::{
     common::ResponseHeader,
     prometheus::{Label, PrometheusQueryRequest, PrometheusQueryResponse, Sample, TimeSeries},
 };

--- a/server/src/grpc/prom_query.rs
+++ b/server/src/grpc/prom_query.rs
@@ -5,7 +5,6 @@ use std::{
     sync::Arc,
 };
 
-use catalog::manager::Manager as CatalogManager;
 use ceresdbproto::{
     common::ResponseHeader,
     prometheus::{Label, PrometheusQueryRequest, PrometheusQueryResponse, Sample, TimeSeries},
@@ -37,12 +36,11 @@ fn is_table_not_found_error(e: &FrontendError) -> bool {
                          if matches!(source, sql::promql::Error::TableNotFound { .. })))
 }
 
-pub async fn handle_query<C, Q>(
-    ctx: &HandlerContext<'_, C, Q>,
+pub async fn handle_query<Q>(
+    ctx: &HandlerContext<'_, Q>,
     req: PrometheusQueryRequest,
 ) -> Result<PrometheusQueryResponse>
 where
-    C: CatalogManager + 'static,
     Q: QueryExecutor + 'static,
 {
     let request_id = RequestId::next_id();
@@ -60,7 +58,7 @@ where
     // TODO(yingwen): Privilege check, cannot access data of other tenant
     // TODO(yingwen): Maybe move MetaProvider to instance
     let provider = CatalogMetaProvider {
-        manager: &instance.catalog_manager,
+        manager: instance.catalog_manager.clone(),
         default_catalog: ctx.catalog(),
         default_schema: ctx.tenant(),
         function_registry: &*instance.function_registry,

--- a/server/src/grpc/query.rs
+++ b/server/src/grpc/query.rs
@@ -4,7 +4,6 @@
 
 use std::time::Instant;
 
-use catalog::manager::Manager as CatalogManager;
 use ceresdbproto::{
     common::ResponseHeader,
     storage::{QueryRequest, QueryResponse, QueryResponse_SchemaType},
@@ -39,8 +38,8 @@ fn empty_ok_resp() -> QueryResponse {
     resp
 }
 
-pub async fn handle_query<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, C, Q>,
+pub async fn handle_query<Q: QueryExecutor + 'static>(
+    ctx: &HandlerContext<'_, Q>,
     req: QueryRequest,
 ) -> Result<QueryResponse> {
     let output_result = fetch_query_output(ctx, &req).await?;
@@ -56,8 +55,8 @@ pub async fn handle_query<C: CatalogManager + 'static, Q: QueryExecutor + 'stati
     }
 }
 
-pub async fn fetch_query_output<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, C, Q>,
+pub async fn fetch_query_output<Q: QueryExecutor + 'static>(
+    ctx: &HandlerContext<'_, Q>,
     req: &QueryRequest,
 ) -> Result<Option<Output>> {
     let request_id = RequestId::next_id();
@@ -76,7 +75,7 @@ pub async fn fetch_query_output<C: CatalogManager + 'static, Q: QueryExecutor + 
     // TODO(yingwen): Privilege check, cannot access data of other tenant
     // TODO(yingwen): Maybe move MetaProvider to instance
     let provider = CatalogMetaProvider {
-        manager: &instance.catalog_manager,
+        manager: instance.catalog_manager.clone(),
         default_catalog: ctx.catalog(),
         default_schema: ctx.tenant(),
         function_registry: &*instance.function_registry,

--- a/server/src/grpc/query.rs
+++ b/server/src/grpc/query.rs
@@ -4,7 +4,7 @@
 
 use std::time::Instant;
 
-use ceresdbproto::{
+use ceresdbproto_deps::ceresdbproto::{
     common::ResponseHeader,
     storage::{QueryRequest, QueryResponse, QueryResponse_SchemaType},
 };

--- a/server/src/grpc/route.rs
+++ b/server/src/grpc/route.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use catalog::manager::Manager;
 use ceresdbproto::storage::{RouteRequest, RouteResponse};
 
 use crate::{
@@ -13,8 +12,8 @@ use crate::{
     router::Router,
 };
 
-pub async fn handle_route<C: Manager, Q>(
-    ctx: &HandlerContext<'_, C, Q>,
+pub async fn handle_route<Q>(
+    ctx: &HandlerContext<'_, Q>,
     req: RouteRequest,
 ) -> Result<RouteResponse> {
     handle_route_sync(ctx.router.clone(), req, ctx.tenant())

--- a/server/src/grpc/route.rs
+++ b/server/src/grpc/route.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use ceresdbproto::storage::{RouteRequest, RouteResponse};
+use ceresdbproto_deps::ceresdbproto::storage::{RouteRequest, RouteResponse};
 
 use crate::{
     error::Result,

--- a/server/src/grpc/write.rs
+++ b/server/src/grpc/write.rs
@@ -431,6 +431,7 @@ fn convert_proto_value_to_datum(
 
 #[cfg(test)]
 mod test {
+    use ceresdbproto_deps::ceresdbproto::storage::{Field, FieldGroup, Tag, Value};
     use common_types::{
         column_schema::{self, ColumnSchema},
         schema::Builder,

--- a/server/src/grpc/write.rs
+++ b/server/src/grpc/write.rs
@@ -4,7 +4,6 @@
 
 use std::collections::HashMap;
 
-use catalog::manager::Manager as CatalogManager;
 use ceresdbproto::storage::{
     Value_oneof_value, WriteEntry, WriteMetric, WriteRequest, WriteResponse,
 };
@@ -28,8 +27,8 @@ use crate::{
     grpc::{self, HandlerContext},
 };
 
-pub(crate) async fn handle_write<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, C, Q>,
+pub(crate) async fn handle_write<Q: QueryExecutor + 'static>(
+    ctx: &HandlerContext<'_, Q>,
     req: WriteRequest,
 ) -> Result<WriteResponse> {
     let request_id = RequestId::next_id();
@@ -105,8 +104,8 @@ pub(crate) async fn handle_write<C: CatalogManager + 'static, Q: QueryExecutor +
     Ok(resp)
 }
 
-async fn write_request_to_insert_plan<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, C, Q>,
+async fn write_request_to_insert_plan<Q: QueryExecutor + 'static>(
+    ctx: &HandlerContext<'_, Q>,
     mut write_request: WriteRequest,
     request_id: RequestId,
 ) -> Result<Vec<InsertPlan>> {
@@ -144,8 +143,8 @@ async fn write_request_to_insert_plan<C: CatalogManager + 'static, Q: QueryExecu
     Ok(plan_vec)
 }
 
-fn try_get_table<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, C, Q>,
+fn try_get_table<Q: QueryExecutor + 'static>(
+    ctx: &HandlerContext<'_, Q>,
     table_name: &str,
 ) -> Result<Option<TableRef>> {
     ctx.instance
@@ -178,8 +177,8 @@ fn try_get_table<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
         })
 }
 
-async fn create_table<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, C, Q>,
+async fn create_table<Q: QueryExecutor + 'static>(
+    ctx: &HandlerContext<'_, Q>,
     write_metric: &WriteMetric,
     request_id: RequestId,
 ) -> Result<()> {

--- a/server/src/grpc/write.rs
+++ b/server/src/grpc/write.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use ceresdbproto::storage::{
+use ceresdbproto_deps::ceresdbproto::storage::{
     Value_oneof_value, WriteEntry, WriteMetric, WriteRequest, WriteResponse,
 };
 use common_types::{

--- a/server/src/grpc/write.rs
+++ b/server/src/grpc/write.rs
@@ -431,7 +431,6 @@ fn convert_proto_value_to_datum(
 
 #[cfg(test)]
 mod test {
-    use ceresdbproto::storage::{Field, FieldGroup, Tag, Value};
     use common_types::{
         column_schema::{self, ColumnSchema},
         schema::Builder,

--- a/server/src/handlers/admin.rs
+++ b/server/src/handlers/admin.rs
@@ -24,9 +24,9 @@ pub struct RejectResponse {
     read_reject_list: BTreeSet<String>,
 }
 
-pub async fn handle_reject<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
+pub async fn handle_reject<Q: QueryExecutor + 'static>(
     _ctx: RequestContext,
-    instance: InstanceRef<C, Q>,
+    instance: InstanceRef<Q>,
     request: RejectRequest,
 ) -> Result<RejectResponse> {
     match request.operation {

--- a/server/src/handlers/sql.rs
+++ b/server/src/handlers/sql.rs
@@ -95,9 +95,9 @@ impl From<String> for Request {
     }
 }
 
-pub async fn handle_sql<C: CatalogManager + 'static, Q: QueryExecutor + 'static>(
+pub async fn handle_sql<Q: QueryExecutor + 'static>(
     ctx: RequestContext,
-    instance: InstanceRef<C, Q>,
+    instance: InstanceRef<Q>,
     request: Request,
 ) -> Result<Response> {
     let request_id = RequestId::next_id();
@@ -110,7 +110,7 @@ pub async fn handle_sql<C: CatalogManager + 'static, Q: QueryExecutor + 'static>
     // TODO(yingwen): Privilege check, cannot access data of other tenant
     // TODO(yingwen): Maybe move MetaProvider to instance
     let provider = CatalogMetaProvider {
-        manager: &instance.catalog_manager,
+        manager: instance.catalog_manager.clone(),
         default_catalog: &ctx.catalog,
         default_schema: &ctx.tenant,
         function_registry: &*instance.function_registry,

--- a/server/src/instance.rs
+++ b/server/src/instance.rs
@@ -12,7 +12,6 @@ use crate::limiter::Limiter;
 
 /// A cluster instance. Usually there is only one instance per cluster
 ///
-/// C: catalog::manager::Manager
 /// Q: query_engine::executor::Executor
 pub struct Instance<Q> {
     pub catalog_manager: ManagerRef,

--- a/server/src/instance.rs
+++ b/server/src/instance.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use catalog::manager::ManagerRef;
 use df_operator::registry::FunctionRegistryRef;
 use table_engine::engine::TableEngineRef;
 
@@ -13,8 +14,8 @@ use crate::limiter::Limiter;
 ///
 /// C: catalog::manager::Manager
 /// Q: query_engine::executor::Executor
-pub struct Instance<C, Q> {
-    pub catalog_manager: C,
+pub struct Instance<Q> {
+    pub catalog_manager: ManagerRef,
     pub query_executor: Q,
     pub table_engine: TableEngineRef,
     // User defined functions registry.
@@ -23,4 +24,4 @@ pub struct Instance<C, Q> {
 }
 
 /// A reference counted instance pointer
-pub type InstanceRef<C, Q> = Arc<Instance<C, Q>>;
+pub type InstanceRef<Q> = Arc<Instance<Q>>;

--- a/server/src/mysql/builder.rs
+++ b/server/src/mysql/builder.rs
@@ -2,7 +2,6 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
-use catalog::manager::Manager as CatalogManager;
 use query_engine::executor::Executor as QueryExecutor;
 use snafu::{OptionExt, ResultExt};
 use table_engine::engine::EngineRuntimes;
@@ -15,10 +14,10 @@ use crate::{
     },
 };
 
-pub struct Builder<C, Q> {
+pub struct Builder<Q> {
     config: Config,
     runtimes: Option<Arc<EngineRuntimes>>,
-    instance: Option<InstanceRef<C, Q>>,
+    instance: Option<InstanceRef<Q>>,
 }
 
 #[derive(Debug)]
@@ -27,7 +26,7 @@ pub struct Config {
     pub port: u16,
 }
 
-impl<C, Q> Builder<C, Q> {
+impl<Q> Builder<Q> {
     pub fn new(config: Config) -> Self {
         Self {
             config,
@@ -41,14 +40,14 @@ impl<C, Q> Builder<C, Q> {
         self
     }
 
-    pub fn instance(mut self, instance: InstanceRef<C, Q>) -> Self {
+    pub fn instance(mut self, instance: InstanceRef<Q>) -> Self {
         self.instance = Some(instance);
         self
     }
 }
 
-impl<C: CatalogManager + 'static, Q: QueryExecutor + 'static> Builder<C, Q> {
-    pub fn build(self) -> Result<MysqlService<C, Q>> {
+impl<Q: QueryExecutor + 'static> Builder<Q> {
+    pub fn build(self) -> Result<MysqlService<Q>> {
         let runtimes = self.runtimes.context(MissingRuntimes)?;
         let instance = self.instance.context(MissingInstance)?;
 

--- a/server/src/mysql/service.rs
+++ b/server/src/mysql/service.rs
@@ -2,7 +2,6 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
-use catalog::manager::Manager as CatalogManager;
 use common_util::runtime::JoinHandle;
 use log::{error, info};
 use opensrv_mysql::AsyncMysqlIntermediary;
@@ -19,20 +18,20 @@ use crate::{
     },
 };
 
-pub struct MysqlService<C, Q> {
-    instance: InstanceRef<C, Q>,
+pub struct MysqlService<Q> {
+    instance: InstanceRef<Q>,
     runtimes: Arc<EngineRuntimes>,
     socket_addr: SocketAddr,
     join_handler: Option<JoinHandle<()>>,
     tx: Option<Sender<()>>,
 }
 
-impl<C, Q> MysqlService<C, Q> {
+impl<Q> MysqlService<Q> {
     pub fn new(
-        instance: Arc<Instance<C, Q>>,
+        instance: Arc<Instance<Q>>,
         runtimes: Arc<EngineRuntimes>,
         socket_addr: SocketAddr,
-    ) -> MysqlService<C, Q> {
+    ) -> MysqlService<Q> {
         Self {
             instance,
             runtimes,
@@ -43,7 +42,7 @@ impl<C, Q> MysqlService<C, Q> {
     }
 }
 
-impl<C: CatalogManager + 'static, Q: QueryExecutor + 'static> MysqlService<C, Q> {
+impl<Q: QueryExecutor + 'static> MysqlService<Q> {
     pub async fn start(&mut self) -> Result<()> {
         let (tx, rx) = oneshot::channel();
 
@@ -66,7 +65,7 @@ impl<C: CatalogManager + 'static, Q: QueryExecutor + 'static> MysqlService<C, Q>
     }
 
     async fn loop_accept(
-        instance: InstanceRef<C, Q>,
+        instance: InstanceRef<Q>,
         runtimes: Arc<EngineRuntimes>,
         socket_addr: SocketAddr,
         mut rx: Receiver<()>,

--- a/server/src/mysql/worker.rs
+++ b/server/src/mysql/worker.rs
@@ -2,7 +2,6 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use catalog::manager::Manager as CatalogManager;
 use log::{error, info};
 use opensrv_mysql::{AsyncMysqlShim, ErrorKind, QueryResultWriter, StatementMetaWriter};
 use query_engine::executor::Executor as QueryExecutor;
@@ -22,19 +21,18 @@ use crate::{
     },
 };
 
-pub struct MysqlWorker<W: std::io::Write + Send + Sync, C, Q> {
+pub struct MysqlWorker<W: std::io::Write + Send + Sync, Q> {
     generic_hold: PhantomData<W>,
-    instance: Arc<Instance<C, Q>>,
+    instance: Arc<Instance<Q>>,
     runtimes: Arc<EngineRuntimes>,
 }
 
-impl<W, C, Q> MysqlWorker<W, C, Q>
+impl<W, Q> MysqlWorker<W, Q>
 where
     W: std::io::Write + Send + Sync,
-    C: CatalogManager + 'static,
     Q: QueryExecutor + 'static,
 {
-    pub fn new(instance: Arc<Instance<C, Q>>, runtimes: Arc<EngineRuntimes>) -> Self {
+    pub fn new(instance: Arc<Instance<Q>>, runtimes: Arc<EngineRuntimes>) -> Self {
         Self {
             generic_hold: PhantomData::default(),
             instance,
@@ -44,10 +42,9 @@ where
 }
 
 #[async_trait::async_trait]
-impl<W, C, Q> AsyncMysqlShim<W> for MysqlWorker<W, C, Q>
+impl<W, Q> AsyncMysqlShim<W> for MysqlWorker<W, Q>
 where
     W: std::io::Write + Send + Sync,
-    C: CatalogManager + 'static,
     Q: QueryExecutor + 'static,
 {
     type Error = crate::mysql::error::Error;
@@ -101,10 +98,9 @@ where
     }
 }
 
-impl<W, C, Q> MysqlWorker<W, C, Q>
+impl<W, Q> MysqlWorker<W, Q>
 where
     W: std::io::Write + Send + Sync,
-    C: CatalogManager + 'static,
     Q: QueryExecutor + 'static,
 {
     async fn do_query<'a>(&'a mut self, sql: &'a str) -> Result<Response> {

--- a/server/src/router.rs
+++ b/server/src/router.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-use ceresdbproto::storage::{Endpoint, Route, RouteRequest};
+use ceresdbproto_deps::ceresdbproto::storage::{Endpoint, Route, RouteRequest};
 use log::info;
 use meta_client::{MetaClient, ShardId};
 use serde_derive::Deserialize;

--- a/server/src/router.rs
+++ b/server/src/router.rs
@@ -24,7 +24,7 @@ pub trait Router {
     fn route(&self, schema: &str, req: RouteRequest) -> Result<Vec<Route>>;
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct PrefixRule {
     /// Schema name of the prefix.
     pub schema: String,
@@ -34,7 +34,7 @@ pub struct PrefixRule {
     pub shard: ShardId,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct HashRule {
     /// Schema name of the prefix.
     pub schema: String,
@@ -42,7 +42,7 @@ pub struct HashRule {
     pub shards: Vec<ShardId>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct RuleList {
     pub prefix_rules: Vec<PrefixRule>,
     pub hash_rules: Vec<HashRule>,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -89,16 +89,17 @@ impl<Q: QueryExecutor + 'static> Server<Q> {
     }
 
     pub async fn start(&mut self) -> Result<()> {
-        self.mysql_service
-            .start()
-            .await
-            .context(StartMysqlService)?;
-        self.rpc_services.start().await.context(StartGrpcService)?;
         if let Some(cluster) = &self.cluster {
             cluster.start().await.context(StartCluster)?;
         }
 
         self.create_default_schema_if_not_exists().await;
+
+        self.mysql_service
+            .start()
+            .await
+            .context(StartMysqlService)?;
+        self.rpc_services.start().await.context(StartGrpcService)?;
 
         Ok(())
     }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -156,8 +156,8 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
         self
     }
 
-    pub fn cluster(mut self, cluster: Option<ClusterRef>) -> Self {
-        self.cluster = cluster;
+    pub fn cluster(mut self, cluster: ClusterRef) -> Self {
+        self.cluster = Some(cluster);
 
         self
     }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -84,7 +84,7 @@ impl<Q: QueryExecutor + 'static> Server<Q> {
         self.mysql_service.shutdown();
 
         if let Some(cluster) = &self.cluster {
-            cluster.stop().await.unwrap();
+            cluster.stop().await.expect("fail to stop cluster");
         }
     }
 
@@ -183,7 +183,6 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
 
     pub fn cluster(mut self, cluster: ClusterRef) -> Self {
         self.cluster = Some(cluster);
-
         self
     }
 

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -15,6 +15,7 @@ test = []
 # In alphabetical order
 arrow_deps = { path = "../arrow_deps" }
 catalog = { path = "../catalog" }
+ceresdbproto_deps = { path = "../ceresdbproto_deps" }
 common_types = { path = "../common_types"}
 common_util = { path = "../common_util" }
 df_operator = { path = "../df_operator" }
@@ -23,7 +24,6 @@ paste = "1.0"
 snafu = { version ="0.6.10", features = ["backtraces"]}
 sqlparser = "0.19.0"
 table_engine = { path = "../table_engine" }
-ceresdbproto = { git = "https://github.com/CeresDB/ceresdbproto.git", rev = "2c10152d021cd5a26b9c870cdede6a0317adca3d" }
 regex = "1"
 
 [dev-dependencies]

--- a/sql/src/frontend.rs
+++ b/sql/src/frontend.rs
@@ -4,7 +4,7 @@
 
 use std::{convert::TryInto, sync::Arc};
 
-use ceresdbproto::prometheus::PrometheusQueryRequest;
+use ceresdbproto_deps::ceresdbproto::prometheus::PrometheusQueryRequest;
 use common_types::request_id::RequestId;
 use snafu::{ResultExt, Snafu};
 use table_engine::table;

--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -868,7 +868,7 @@ mod tests {
     InsertPlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100, 0, 100),
+            id: TableId(100),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1044,7 +1044,7 @@ mod tests {
     DescribeTablePlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100, 0, 100),
+            id: TableId(100),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1111,7 +1111,7 @@ mod tests {
     AlterTablePlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100, 0, 100),
+            id: TableId(100),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1191,7 +1191,7 @@ mod tests {
     AlterTablePlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100, 0, 100),
+            id: TableId(100),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1264,7 +1264,7 @@ mod tests {
         ShowCreatePlan {
             table: MemoryTable {
                 name: "test_table",
-                id: TableId(100, 0, 100),
+                id: TableId(100),
                 schema: Schema {
                     num_key_columns: 2,
                     timestamp_index: 1,

--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -868,7 +868,9 @@ mod tests {
     InsertPlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100),
+            id: TableId(
+                100,
+            ),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1044,7 +1046,9 @@ mod tests {
     DescribeTablePlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100),
+            id: TableId(
+                100,
+            ),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1111,7 +1115,9 @@ mod tests {
     AlterTablePlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100),
+            id: TableId(
+                100,
+            ),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1191,7 +1197,9 @@ mod tests {
     AlterTablePlan {
         table: MemoryTable {
             name: "test_table",
-            id: TableId(100),
+            id: TableId(
+                100,
+            ),
             schema: Schema {
                 num_key_columns: 2,
                 timestamp_index: 1,
@@ -1264,7 +1272,9 @@ mod tests {
         ShowCreatePlan {
             table: MemoryTable {
                 name: "test_table",
-                id: TableId(100),
+                id: TableId(
+                    100,
+                ),
                 schema: Schema {
                     num_key_columns: 2,
                     timestamp_index: 1,

--- a/sql/src/promql/convert.rs
+++ b/sql/src/promql/convert.rs
@@ -13,7 +13,7 @@ use arrow_deps::datafusion::{
     },
     sql::planner::ContextProvider,
 };
-use ceresdbproto::prometheus::{
+use ceresdbproto_deps::ceresdbproto::prometheus::{
     Expr as ExprPb, Filter as FilterPb, FilterType as FilterPbType, Operand as OperandPb,
     Selector as PbSelector, SubExpr as PbSubExpr, SubExpr_OperatorType,
 };

--- a/sql/src/provider.rs
+++ b/sql/src/provider.rs
@@ -14,7 +14,7 @@ use arrow_deps::{
     },
     datafusion_expr::TableSource,
 };
-use catalog::manager::Manager;
+use catalog::manager::ManagerRef;
 use common_types::request_id::RequestId;
 use df_operator::{registry::FunctionRegistry, scalar::ScalarUdf, udaf::AggregateUdf};
 use snafu::{ResultExt, Snafu};
@@ -78,14 +78,14 @@ pub trait MetaProvider {
 /// - Other meta data like default catalog and schema are needed
 // TODO(yingwen): Maybe support schema searching instead of using a fixed
 // default schema
-pub struct CatalogMetaProvider<'a, M> {
-    pub manager: &'a M,
+pub struct CatalogMetaProvider<'a> {
+    pub manager: ManagerRef,
     pub default_catalog: &'a str,
     pub default_schema: &'a str,
     pub function_registry: &'a (dyn FunctionRegistry + Send + Sync),
 }
 
-impl<'a, M: Manager> MetaProvider for CatalogMetaProvider<'a, M> {
+impl<'a> MetaProvider for CatalogMetaProvider<'a> {
     fn default_catalog_name(&self) -> &str {
         self.default_catalog
     }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -13,10 +13,10 @@ use table_engine::{
     ANALYTIC_ENGINE_TYPE,
 };
 
-pub struct SchemaIdAllocAdpater(pub MetaClientRef);
+pub struct SchemaIdAllocAdapter(pub MetaClientRef);
 
 #[async_trait]
-impl SchemaIdAlloc for SchemaIdAllocAdpater {
+impl SchemaIdAlloc for SchemaIdAllocAdapter {
     type Error = meta_client_v2::Error;
 
     async fn alloc_schema_id<'a>(&self, schema_name: NameRef<'a>) -> Result<SchemaId, Self::Error> {

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,0 +1,154 @@
+use async_trait::async_trait;
+use catalog::{
+    manager::ManagerRef as CatalogManagerRef,
+    schema::{CloseOptions, CloseTableRequest, NameRef, OpenOptions, OpenTableRequest, SchemaRef},
+};
+use catalog_impls::{SchemaIdAlloc, TableIdAlloc};
+use cluster::TableManipulator;
+use log::debug;
+use meta_client_v2::{types::DropTableRequest, MetaClientRef};
+use table_engine::{
+    engine::TableEngineRef,
+    table::{SchemaId, TableId},
+    ANALYTIC_ENGINE_TYPE,
+};
+
+pub struct SchemaIdAllocAdpater(pub MetaClientRef);
+
+#[async_trait]
+impl SchemaIdAlloc for SchemaIdAllocAdpater {
+    type Error = meta_client_v2::Error;
+
+    async fn alloc_schema_id<'a>(
+        &'a self,
+        schema_name: NameRef<'a>,
+    ) -> Result<SchemaId, Self::Error> {
+        self.0
+            .alloc_schema_id(cluster::AllocSchemaIdRequest {
+                name: schema_name.to_string(),
+            })
+            .await
+            .map(|resp| SchemaId::from(resp.id))
+    }
+}
+pub struct TableIdAllocAdapter(pub MetaClientRef);
+
+#[async_trait]
+impl TableIdAlloc for TableIdAllocAdapter {
+    type Error = meta_client_v2::Error;
+
+    async fn alloc_table_id<'a>(
+        &'a self,
+        schema_name: NameRef<'a>,
+        table_name: NameRef<'a>,
+    ) -> Result<TableId, Self::Error> {
+        self.0
+            .alloc_table_id(cluster::AllocTableIdRequest {
+                schema_name: schema_name.to_string(),
+                name: table_name.to_string(),
+            })
+            .await
+            .map(|v| TableId::from(v.id))
+    }
+
+    async fn invalidate_table_id<'a>(
+        &'a self,
+        schema_name: NameRef<'a>,
+        table_name: NameRef<'a>,
+        table_id: TableId,
+    ) -> Result<(), Self::Error> {
+        self.0
+            .drop_table(DropTableRequest {
+                schema_name: schema_name.to_string(),
+                name: table_name.to_string(),
+                id: table_id.as_u64(),
+            })
+            .await
+            .map(|_| ())
+    }
+}
+
+pub struct TableManipulatorImpl {
+    pub catalog_manager: CatalogManagerRef,
+    pub table_engine: TableEngineRef,
+}
+
+impl TableManipulatorImpl {
+    fn catalog_schema_by_name(
+        &self,
+        schema_name: &str,
+    ) -> Result<(NameRef, Option<SchemaRef>), Box<dyn std::error::Error + Send + Sync>> {
+        let default_catalog_name = self.catalog_manager.default_catalog_name();
+        let default_catalog = self
+            .catalog_manager
+            .catalog_by_name(default_catalog_name)
+            .map_err(Box::new)?
+            .unwrap();
+        let schema = default_catalog
+            .schema_by_name(schema_name)
+            .map_err(Box::new)?;
+        Ok((default_catalog_name, schema))
+    }
+}
+#[async_trait]
+impl TableManipulator for TableManipulatorImpl {
+    async fn open_table(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        table_id: u64,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let (default_catalog_name, schema) = self.catalog_schema_by_name(schema_name)?;
+        let schema = schema.unwrap();
+        let table_id = TableId::from(table_id);
+        let req = OpenTableRequest {
+            catalog_name: default_catalog_name.to_string(),
+            schema_name: schema_name.to_string(),
+            schema_id: schema.id(),
+            table_name: table_name.to_string(),
+            table_id,
+            engine: ANALYTIC_ENGINE_TYPE.to_string(),
+        };
+        let opts = OpenOptions {
+            table_engine: self.table_engine.clone(),
+        };
+        let table = schema.open_table(req, opts).await.map_err(Box::new)?;
+        debug!(
+            "Finish opening table:{}-{}, catalog:{}, schema:{}, really_opened:{}",
+            table_name,
+            table_id,
+            default_catalog_name,
+            schema_name,
+            table.is_some()
+        );
+        Ok(())
+    }
+
+    async fn close_table(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+        table_id: u64,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let (default_catalog_name, schema) = self.catalog_schema_by_name(schema_name)?;
+        let schema = schema.unwrap();
+        let table_id = TableId::from(table_id);
+        let req = CloseTableRequest {
+            catalog_name: default_catalog_name.to_string(),
+            schema_name: schema_name.to_string(),
+            schema_id: schema.id(),
+            table_name: table_name.to_string(),
+            table_id,
+            engine: ANALYTIC_ENGINE_TYPE.to_string(),
+        };
+        let opts = CloseOptions {
+            table_engine: self.table_engine.clone(),
+        };
+        schema.close_table(req, opts).await.map_err(Box::new)?;
+        debug!(
+            "Finish closing table:{}-{}, catalog:{}, schema:{}",
+            table_name, table_id, default_catalog_name, schema_name
+        );
+        Ok(())
+    }
+}

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -61,7 +61,6 @@ impl TableIdAlloc for TableIdAllocAdapter {
                 id: table_id.as_u64(),
             })
             .await
-            .map(|_| ())
     }
 }
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -86,6 +86,7 @@ impl TableManipulatorImpl {
         Ok((default_catalog_name, schema))
     }
 }
+
 #[async_trait]
 impl TableManipulator for TableManipulatorImpl {
     async fn open_table(

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -19,10 +19,7 @@ pub struct SchemaIdAllocAdpater(pub MetaClientRef);
 impl SchemaIdAlloc for SchemaIdAllocAdpater {
     type Error = meta_client_v2::Error;
 
-    async fn alloc_schema_id<'a>(
-        &'a self,
-        schema_name: NameRef<'a>,
-    ) -> Result<SchemaId, Self::Error> {
+    async fn alloc_schema_id<'a>(&self, schema_name: NameRef<'a>) -> Result<SchemaId, Self::Error> {
         self.0
             .alloc_schema_id(cluster::AllocSchemaIdRequest {
                 name: schema_name.to_string(),
@@ -38,7 +35,7 @@ impl TableIdAlloc for TableIdAllocAdapter {
     type Error = meta_client_v2::Error;
 
     async fn alloc_table_id<'a>(
-        &'a self,
+        &self,
         schema_name: NameRef<'a>,
         table_name: NameRef<'a>,
     ) -> Result<TableId, Self::Error> {
@@ -52,7 +49,7 @@ impl TableIdAlloc for TableIdAllocAdapter {
     }
 
     async fn invalidate_table_id<'a>(
-        &'a self,
+        &self,
         schema_name: NameRef<'a>,
         table_name: NameRef<'a>,
         table_id: TableId,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-//! ceresdb
-
 mod adapter;
 pub mod setup;
-pub(crate) mod signal_handler;
+mod signal_handler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@
 
 //! ceresdb
 
+mod adapter;
 pub mod setup;
-mod signal_handler;
+pub(crate) mod signal_handler;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -28,7 +28,7 @@ use tracing_util::{
 };
 
 use crate::{
-    adapter::{SchemaIdAllocAdpater, TableIdAllocAdapter, TableManipulatorImpl},
+    adapter::{SchemaIdAllocAdapter, TableIdAllocAdapter, TableManipulatorImpl},
     signal_handler,
 };
 
@@ -155,7 +155,7 @@ async fn build_in_cluster_mode<Q: Executor + 'static>(
     .unwrap();
 
     let catalog_manager = {
-        let schema_id_alloc = SchemaIdAllocAdpater(meta_client.clone());
+        let schema_id_alloc = SchemaIdAllocAdapter(meta_client.clone());
         let table_id_alloc = TableIdAllocAdapter(meta_client.clone());
         Arc::new(volatile::ManagerImpl::new(schema_id_alloc, table_id_alloc).await)
     };

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -110,14 +110,13 @@ where
         analytic: analytic.clone(),
     });
 
+    let table_based_manager = TableBasedManager::new(analytic, engine_proxy.clone())
+        .await
+        .unwrap_or_else(|e| {
+            panic!("Failed to create catalog manager, err:{}", e);
+        });
     // Create catalog manager, use analytic table as backend
-    let catalog_manager = CatalogManagerImpl::new(
-        TableBasedManager::new(analytic, engine_proxy.clone())
-            .await
-            .unwrap_or_else(|e| {
-                panic!("Failed to create catalog manager, err:{}", e);
-            }),
-    );
+    let catalog_manager = Arc::new(CatalogManagerImpl::new(Arc::new(table_based_manager)));
 
     // Init function registry.
     let mut function_registry = FunctionRegistryImpl::new();

--- a/src/signal_handler.rs
+++ b/src/signal_handler.rs
@@ -12,10 +12,8 @@ mod details {
     use signal_hook::{consts::TERM_SIGNALS, iterator::Signals};
 
     pub fn wait_for_signal() {
-        let mut sigs = Signals::new(TERM_SIGNALS).unwrap_or_else(|e| {
-            // TODO(yingwen): Log here
-            panic!("Failed to register signal handlers, err:{}", e);
-        });
+        let mut sigs = Signals::new(TERM_SIGNALS).expect("Failed to register signal handlers");
+
         for signal in &mut sigs {
             if TERM_SIGNALS.contains(&signal) {
                 info!("Received signal {}, stopping server...", signal);

--- a/system_catalog/src/lib.rs
+++ b/system_catalog/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! System catalog implementations
 
+#![feature(const_option)]
+
 use std::{
     collections::HashMap,
     fmt::Debug,
@@ -30,21 +32,22 @@ pub mod sys_catalog_table;
 pub mod tables;
 
 /// Schema id of the sys catalog schema (`system/public`).
-pub const SYSTEM_SCHEMA_ID: SchemaId = SchemaId::from_u16(1);
+pub const SYSTEM_SCHEMA_ID: SchemaId = SchemaId::from_u32(1);
 
 /// Table name of the `sys_catalog`.
 pub const SYS_CATALOG_TABLE_NAME: &str = "sys_catalog";
 /// Table sequence of the `sys_catalog` table, always set to 1
 pub const SYS_CATALOG_TABLE_SEQ: TableSeq = TableSeq::from_u32(1);
 /// Table id of the `sys_catalog` table.
-pub const SYS_CATALOG_TABLE_ID: TableId = TableId::new(SYSTEM_SCHEMA_ID, SYS_CATALOG_TABLE_SEQ);
+pub const SYS_CATALOG_TABLE_ID: TableId =
+    TableId::new(SYSTEM_SCHEMA_ID, SYS_CATALOG_TABLE_SEQ).unwrap();
 
 /// Table name of the `tables` table.
 pub const TABLES_TABLE_NAME: &str = "tables";
 /// Table sequence of the `tables` table.
 pub const TABLES_TABLE_SEQ: TableSeq = TableSeq::from_u32(2);
 /// Table id of the `tables` table.
-pub const TABLES_TABLE_ID: TableId = TableId::new(SYSTEM_SCHEMA_ID, TABLES_TABLE_SEQ);
+pub const TABLES_TABLE_ID: TableId = TableId::new(SYSTEM_SCHEMA_ID, TABLES_TABLE_SEQ).unwrap();
 
 // NOTE: The MAX_SYSTEM_TABLE_ID should be updated if any new system table is
 // added.

--- a/system_catalog/src/lib.rs
+++ b/system_catalog/src/lib.rs
@@ -40,14 +40,14 @@ pub const SYS_CATALOG_TABLE_NAME: &str = "sys_catalog";
 pub const SYS_CATALOG_TABLE_SEQ: TableSeq = TableSeq::from_u32(1);
 /// Table id of the `sys_catalog` table.
 pub const SYS_CATALOG_TABLE_ID: TableId =
-    TableId::new(SYSTEM_SCHEMA_ID, SYS_CATALOG_TABLE_SEQ).unwrap();
+    TableId::with_seq(SYSTEM_SCHEMA_ID, SYS_CATALOG_TABLE_SEQ).unwrap();
 
 /// Table name of the `tables` table.
 pub const TABLES_TABLE_NAME: &str = "tables";
 /// Table sequence of the `tables` table.
 pub const TABLES_TABLE_SEQ: TableSeq = TableSeq::from_u32(2);
 /// Table id of the `tables` table.
-pub const TABLES_TABLE_ID: TableId = TableId::new(SYSTEM_SCHEMA_ID, TABLES_TABLE_SEQ).unwrap();
+pub const TABLES_TABLE_ID: TableId = TableId::with_seq(SYSTEM_SCHEMA_ID, TABLES_TABLE_SEQ).unwrap();
 
 // NOTE: The MAX_SYSTEM_TABLE_ID should be updated if any new system table is
 // added.

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -873,19 +873,15 @@ impl CreateSchemaRequest {
     }
 }
 
-impl TryFrom<SchemaEntry> for CreateSchemaRequest {
-    type Error = Error;
+impl From<SchemaEntry> for CreateSchemaRequest {
+    fn from(entry: SchemaEntry) -> Self {
+        let schema_id = SchemaId::from(entry.schema_id);
 
-    fn try_from(entry: SchemaEntry) -> Result<Self> {
-        let schema_id = SchemaId::new(entry.schema_id).context(InvalidSchemaId {
-            id: entry.schema_id,
-        })?;
-
-        Ok(Self {
+        Self {
             catalog_name: entry.catalog_name,
             schema_name: entry.schema_name,
             schema_id,
-        })
+        }
     }
 }
 
@@ -1002,7 +998,7 @@ fn decode_one_request(key: &[u8], value: &[u8]) -> Result<DecodedRequest> {
         }
         KeyType::CreateSchema => {
             let entry = SchemaEntry::parse_from_bytes(value).context(DecodeEntryPb)?;
-            DecodedRequest::CreateSchema(CreateSchemaRequest::try_from(entry)?)
+            DecodedRequest::CreateSchema(CreateSchemaRequest::from(entry))
         }
         KeyType::TableEntry => {
             let entry = TableEntry::parse_from_bytes(value).context(DecodeEntryPb)?;

--- a/system_catalog/src/tables.rs
+++ b/system_catalog/src/tables.rs
@@ -5,7 +5,7 @@
 use std::fmt::{Debug, Formatter};
 
 use async_trait::async_trait;
-use catalog::{manager::Manager, schema::SchemaRef, CatalogRef};
+use catalog::{manager::ManagerRef, schema::SchemaRef, CatalogRef};
 use common_types::{
     column_schema,
     datum::{Datum, DatumKind},
@@ -82,12 +82,12 @@ fn tables_schema() -> Schema {
         .unwrap()
 }
 
-pub struct Tables<M> {
+pub struct Tables {
     schema: Schema,
-    catalog_manager: M,
+    catalog_manager: ManagerRef,
 }
 
-impl<M> Debug for Tables<M> {
+impl Debug for Tables {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SysTables")
             .field("schema", &self.schema)
@@ -95,8 +95,8 @@ impl<M> Debug for Tables<M> {
     }
 }
 
-impl<M: Manager> Tables<M> {
-    pub fn new(catalog_manager: M) -> Self {
+impl Tables {
+    pub fn new(catalog_manager: ManagerRef) -> Self {
         Self {
             schema: tables_schema(),
             catalog_manager,
@@ -117,7 +117,7 @@ impl<M: Manager> Tables<M> {
 }
 
 #[async_trait]
-impl<M: Manager> SystemTable for Tables<M> {
+impl SystemTable for Tables {
     fn name(&self) -> &str {
         TABLES_TABLE_NAME
     }

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -137,28 +137,12 @@ pub const DEFAULT_READ_PARALLELISM: usize = 8;
 pub struct SchemaId(u32);
 
 impl SchemaId {
-    /// Bits of schema id.
-    const BITS: u32 = 24;
-    /// 24 bits mask (0xffffff)
-    const MASK: u32 = (1 << Self::BITS) - 1;
-    /// Max schema id.
-    pub const MAX: SchemaId = SchemaId(Self::MASK);
+    pub const MAX: SchemaId = SchemaId(u32::MAX);
     /// Min schema id.
     pub const MIN: SchemaId = SchemaId(0);
 
-    /// Create a new schema id from u32, return None if `id` is invalid.
-    pub fn new(id: u32) -> Option<Self> {
-        // Only need to check max as min is 0.
-        if id <= SchemaId::MAX.0 {
-            Some(Self(id))
-        } else {
-            None
-        }
-    }
-
-    // It is safe to convert u16 into schema id.
-    pub const fn from_u16(id: u16) -> Self {
-        Self(id as u32)
+    pub const fn from_u32(id: u32) -> Self {
+        Self(id)
     }
 
     /// Convert the schema id into u32.
@@ -176,7 +160,13 @@ impl PartialEq<u32> for SchemaId {
 
 impl From<u16> for SchemaId {
     fn from(id: u16) -> SchemaId {
-        SchemaId::from_u16(id)
+        Self(id as u32)
+    }
+}
+
+impl From<u32> for SchemaId {
+    fn from(id: u32) -> SchemaId {
+        Self(id)
     }
 }
 
@@ -205,8 +195,8 @@ impl TableSeq {
     }
 
     // It is safe to convert u32 into table seq.
-    pub const fn from_u32(id: u32) -> Self {
-        Self(id as u64)
+    pub const fn from_u32(seq: u32) -> Self {
+        Self(seq as u64)
     }
 
     /// Convert the table sequence into u64.
@@ -218,7 +208,16 @@ impl TableSeq {
 
 impl From<u32> for TableSeq {
     fn from(id: u32) -> TableSeq {
-        TableSeq::from_u32(id)
+        TableSeq(id as u64)
+    }
+}
+
+impl From<TableId> for TableSeq {
+    /// Get the sequence part of the table id.
+    fn from(table_id: TableId) -> TableSeq {
+        let seq_part = table_id.0 & TableSeq::MASK;
+
+        TableSeq(seq_part)
     }
 }
 
@@ -226,7 +225,7 @@ impl From<u32> for TableSeq {
 ///
 /// Table id is constructed via schema id (24 bits) and a table sequence (40
 /// bits).
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Deserialize)]
 pub struct TableId(u64);
 
 impl TableId {
@@ -239,28 +238,16 @@ impl TableId {
     }
 
     /// Create a new table id from `schema_id` and `table_seq`.
-    pub const fn new(schema_id: SchemaId, table_seq: TableSeq) -> Self {
+    ///
+    /// Return `None` If `schema_id` is not invalid.
+    pub const fn new(schema_id: SchemaId, table_seq: TableSeq) -> Option<Self> {
         let schema_id_data = schema_id.0 as u64;
         let schema_id_part = schema_id_data << TableSeq::BITS;
-        let table_id_data = schema_id_part | table_seq.0;
-
-        Self(table_id_data)
-    }
-
-    /// Get the schema id part of the table id.
-    #[inline]
-    pub fn schema_id(&self) -> SchemaId {
-        let schema_id_part = self.0 >> TableSeq::BITS;
-
-        SchemaId(schema_id_part as u32)
-    }
-
-    /// Get the sequence part of the table id.
-    #[inline]
-    pub fn table_seq(&self) -> TableSeq {
-        let seq_part = self.0 & TableSeq::MASK;
-
-        TableSeq(seq_part)
+        if (schema_id_part >> TableSeq::BITS) != schema_id_data {
+            None
+        } else {
+            Some(Self(schema_id_part | table_seq.0))
+        }
     }
 
     /// Convert table id into u64.
@@ -273,18 +260,6 @@ impl TableId {
 impl From<u64> for TableId {
     fn from(id: u64) -> TableId {
         TableId(id)
-    }
-}
-
-impl fmt::Debug for TableId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "TableId({}, {}, {})",
-            self.0,
-            self.schema_id().as_u32(),
-            self.table_seq().as_u64()
-        )
     }
 }
 
@@ -490,9 +465,10 @@ impl SchemaIdGenerator {
     }
 
     pub fn alloc_schema_id(&self) -> Option<SchemaId> {
+        // TODO: consider the case where schema id overflows.
         let last = self.last_schema_id.fetch_add(1, Ordering::Relaxed);
 
-        SchemaId::new(last + 1)
+        Some(SchemaId::from(last + 1))
     }
 }
 
@@ -520,6 +496,7 @@ impl TableSeqGenerator {
     }
 
     pub fn alloc_table_seq(&self) -> Option<TableSeq> {
+        // TODO: consider the case where table sequence overflows.
         let last = self.last_table_seq.fetch_add(1, Ordering::Relaxed);
 
         TableSeq::new(last + 1)

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -258,7 +258,7 @@ impl TableId {
 
 impl From<u64> for TableId {
     fn from(id: u64) -> TableId {
-        TableId(id)
+        TableId::new(id)
     }
 }
 

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -232,14 +232,14 @@ impl TableId {
     pub const MIN: TableId = TableId(0);
 
     /// Create table id from raw u64 number.
-    pub const fn from_raw(id: u64) -> Self {
+    pub const fn new(id: u64) -> Self {
         Self(id)
     }
 
     /// Create a new table id from `schema_id` and `table_seq`.
     ///
     /// Return `None` If `schema_id` is not invalid.
-    pub const fn new(schema_id: SchemaId, table_seq: TableSeq) -> Option<Self> {
+    pub const fn with_seq(schema_id: SchemaId, table_seq: TableSeq) -> Option<Self> {
         let schema_id_data = schema_id.0 as u64;
         let schema_id_part = schema_id_data << TableSeq::BITS;
         if (schema_id_part >> TableSeq::BITS) != schema_id_data {

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -137,7 +137,6 @@ pub const DEFAULT_READ_PARALLELISM: usize = 8;
 pub struct SchemaId(u32);
 
 impl SchemaId {
-    pub const MAX: SchemaId = SchemaId(u32::MAX);
     /// Min schema id.
     pub const MIN: SchemaId = SchemaId(0);
 
@@ -583,7 +582,6 @@ mod tests {
     #[test]
     fn test_schema_id() {
         assert_eq!(0, SchemaId::MIN.as_u32());
-        assert_eq!(0xffffff, SchemaId::MAX.as_u32());
     }
 
     #[test]

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.53"
+async-trait = "0.1.41"
 common_util = {path = "../common_util"}
 common_types = {path = "../common_types"}
 chrono = "0.4"

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.41"
+async-trait = "0.1.53"
 common_util = {path = "../common_util"}
 common_types = {path = "../common_types"}
 chrono = "0.4"


### PR DESCRIPTION
# Which issue does this PR close?

Part of #92 

# Rationale for this change
 After all the work concerning cluster mode done, we need to support to start server in cluster mode (now the server can only start standalone).
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Replace the `Manager` type parameter in `Server`/`Instance`/... with trait object.
- Add config to control in which mode the server starts.
- Refactor the setup procedure for different deloyment mode.
<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?
New configurations are introduced.
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
This PR should be tested with `CeresMeta` manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
