### PR TITLE
fix: ci cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -22,168 +23,83 @@ on:
       - '**.md'
       - '**.yml'
 
+# Common environment variables
 env:
+  RUSTFLAGS: "-C debuginfo=1"
   CARGO_TERM_COLOR: always
 
 jobs:
-  # build the library, a compilation step used by multiple steps below
-  linux-build-lib:
-    name: Build Libraries with Rust ${{ matrix.rust }}
+  fmt:
+    name: fmt-clippy
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
-        rust: [1.59.0]
-    container:
-      image: rust:${{ matrix.rust }}-slim-bullseye
-      env:
-        # Disable full debug symbol generation to speed up CI build and keep memory down
-        # "1" means line tables only, which is useful for panic tracebacks.
-        RUSTFLAGS: "-C debuginfo=1"
+        rust: [nightly-2022-08-08]
     steps:
       - uses: actions/checkout@v3
         # with:
         #   submodules: true
-      - name: Cache Cargo
+      - run: |
+          rustup set auto-self-update disable
+          rustup toolchain install ${{ matrix.rust }} --profile minimal
+      - name: Cache Rust Dependencies
         uses: actions/cache@v3
         with:
-          path: /github/home/.cargo
-          key: cargo-cache-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home/target
-          key: ${{ runner.os }}-target-cache-${{ matrix.rust }}-
-      - name: Cache Build Dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home
-          key: ${{ runner.os }}-toolchain-cache-
+          path: |
+            ~/.cargo
+            ./target
+          key: rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
+            rust-debug-${{ runner.os }}
+            rust-
       - name: Setup Build Environment
         run: |
-          apt update
-          apt install --yes gcc g++ libssl-dev pkg-config cmake
-          rm -rf /var/lib/apt/lists/*
-      - name: Build workspace in debug mode
+          sudo apt update
+          sudo apt install --yes gcc g++ libssl-dev pkg-config cmake
+          sudo rm -rf /var/lib/apt/lists/*
+      - name: Install clippy rustfmt
         run: |
-          make build-ut
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target/debug"
-
-  style-check:
-    name: Libraries Style Check
-    needs: [linux-build-lib]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    strategy:
-      matrix:
-        rust: [1.59.0]
-    container:
-      image: rust:${{ matrix.rust }}-slim-bullseye
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Build Environment
-        run: |
-          apt update
-          apt install --yes cmake
-          rm -rf /var/lib/apt/lists/*
-      - name: Setup Toolchain
-        run: |
+          rustup component add clippy
           rustup component add rustfmt
       - name: Run
         run: |
-          make fmt
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target/debug"
-
-  clippy:
-    name: Clippy
-    needs: [linux-build-lib]
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        rust: [1.59.0]
-    container:
-      image: rust:${{ matrix.rust }}-slim-bullseye
-      env:
-        RUSTFLAGS: "-C debuginfo=1"
-    steps:
-      - uses: actions/checkout@v3
-        # with:
-        #   submodules: true
-      - name: Cache Cargo
-        uses: actions/cache@v3
-        with:
-          path: /github/home/.cargo
-          key: cargo-cache-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home/target
-          key: ${{ runner.os }}-target-cache-${{ matrix.rust }}-
-      - name: Cache Build Dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home
-          key: ${{ runner.os }}-toolchain-cache-
-      - name: Setup Build Environment
-        run: |
-          apt update
-          apt install --yes gcc g++ libssl-dev pkg-config cmake
-          rm -rf /var/lib/apt/lists/*
-      - name: Install Clippy
-        run: |
-          rustup component add clippy
-      - name: Run Clippy
-        run: |
           make clippy
-        env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target/debug"
+          make fmt
 
   linux-test:
-    name: Test Workspace with Rust ${{ matrix.rust }}
-    needs: [linux-build-lib]
+    name: unit-test
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
-        rust: [1.59.0]
-    container:
-      image: rust:${{ matrix.rust }}-slim-bullseye
-      env:
-        RUSTFLAGS: "-C debuginfo=1"
+        rust: [nightly-2022-08-08]
     steps:
       - uses: actions/checkout@v3
         # with:
         #   submodule: true
-      - name: Cache Cargo
+      - run: |
+          rustup set auto-self-update disable
+          rustup toolchain install ${{ matrix.rust }} --profile minimal
+      - name: Cache Rust Dependencies
         uses: actions/cache@v3
         with:
-          path: /github/home/.cargo
-          key: cargo-cache-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home/target
-          key: ${{ runner.os }}-target-cache-${{ matrix.rust }}-
-      - name: Cache Build Dependencies
-        uses: actions/cache@v3
-        with:
-          path: /github/home
-          key: ${{ runner.os }}-toolchain-cache-
+          path: |
+            ~/.cargo
+            ./target
+          key: rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
+          restore-keys: |
+            rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
+            rust-debug-${{ runner.os }}
+            rust-
       - name: Setup Build Environment
         run: |
-          apt update
-          apt install --yes gcc g++ libssl-dev pkg-config cmake git
+          sudo apt update
+          sudo apt install --yes gcc g++ libssl-dev pkg-config cmake git
       - name: Run Tests
         run: |
           git clone https://github.com/apache/parquet-testing.git components/parquet-testing
           make test-ut
         env:
-          CARGO_HOME: "/github/home/.cargo"
-          CARGO_TARGET_DIR: "/github/home/target/debug"
           RUST_BACKTRACE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
+          key: rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
-            rust-debug-${{ runner.os }}
+            rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
+            rust-debug-${{ runner.os }}-
             rust-
       - name: Setup Build Environment
         run: |
@@ -88,10 +88,10 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
+          key: rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.toml') }}
-            rust-debug-${{ runner.os }}
+            rust-debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
+            rust-debug-${{ runner.os }}-
             rust-
       - name: Setup Build Environment
         run: |


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5 

# Rationale for this change
 
Currently  CI will take 50+ mintues to execute, which is too long, developers can do nothing but wait before review/merge...

# What changes are included in this PR?

Simplify CI jobs, to be exactly:
1. Remove `linux-build-lib` job, which is a pre-task for others. However this is not required, and other task can just run in parallel.
2. Remove container, run CI directly on ubuntu
3. Run clippy & rustfmt within one job
# Are there any user-facing changes?

No
# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
- https://github.com/jiacai2050/ceresdb/runs/7826879006

The CI execution time only take 7min now