### PR TITLE
feat: support double quoted string.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,8 +226,8 @@ name = "arrow_deps"
 version = "0.1.0"
 dependencies = [
  "arrow",
- "datafusion 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
+ "datafusion 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
  "parquet 15.0.0",
  "uncover",
 ]
@@ -1309,6 +1309,44 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "9.0.0"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
+dependencies = [
+ "ahash 0.7.6",
+ "arrow",
+ "async-trait",
+ "chrono",
+ "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-data-access 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-optimizer 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-physical-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-row 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-sql 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "futures 0.3.21",
+ "glob",
+ "hashbrown",
+ "itertools",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "ordered-float 3.0.0",
+ "parking_lot 0.12.1",
+ "parquet 15.0.0",
+ "paste 1.0.8",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "smallvec 1.9.0",
+ "sqlparser 0.19.0",
+ "tempfile",
+ "tokio 1.20.1",
+ "tokio-stream",
+ "url 2.2.2",
+ "uuid 1.1.2",
+]
+
+[[package]]
+name = "datafusion"
+version = "9.0.0"
 source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=bb3e002a4d89f9a5104bba34511b4c593a9c0d05#bb3e002a4d89f9a5104bba34511b4c593a9c0d05"
 dependencies = [
  "ahash 0.7.6",
@@ -1345,41 +1383,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion"
+name = "datafusion-common"
 version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
 dependencies = [
- "ahash 0.7.6",
  "arrow",
- "async-trait",
- "chrono",
- "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-data-access 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-optimizer 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-physical-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-row 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-sql 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "futures 0.3.21",
- "glob",
- "hashbrown",
- "itertools",
- "lazy_static",
- "log",
- "num_cpus",
  "ordered-float 3.0.0",
- "parking_lot 0.12.1",
  "parquet 15.0.0",
- "paste 1.0.8",
- "pin-project-lite",
- "rand 0.8.5",
- "smallvec 1.9.0",
  "sqlparser 0.19.0",
- "tempfile",
- "tokio 1.20.1",
- "tokio-stream",
- "url 2.2.2",
- "uuid 1.1.2",
 ]
 
 [[package]]
@@ -1394,14 +1405,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-common"
+name = "datafusion-data-access"
 version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
 dependencies = [
- "arrow",
- "ordered-float 3.0.0",
- "parquet 15.0.0",
- "sqlparser 0.19.0",
+ "async-trait",
+ "chrono",
+ "futures 0.3.21",
+ "parking_lot 0.12.1",
+ "tempfile",
+ "tokio 1.20.1",
 ]
 
 [[package]]
@@ -1418,16 +1431,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-data-access"
+name = "datafusion-expr"
 version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
 dependencies = [
- "async-trait",
- "chrono",
- "futures 0.3.21",
- "parking_lot 0.12.1",
- "tempfile",
- "tokio 1.20.1",
+ "ahash 0.7.6",
+ "arrow",
+ "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "sqlparser 0.19.0",
 ]
 
 [[package]]
@@ -1442,14 +1453,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-expr"
+name = "datafusion-optimizer"
 version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
 dependencies = [
- "ahash 0.7.6",
  "arrow",
- "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "sqlparser 0.19.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-physical-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "hashbrown",
+ "log",
 ]
 
 [[package]]
@@ -1468,18 +1483,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-optimizer"
+name = "datafusion-physical-expr"
 version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
 dependencies = [
+ "ahash 0.7.6",
  "arrow",
- "async-trait",
+ "blake2",
+ "blake3",
  "chrono",
- "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-physical-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
+ "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-row 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
  "hashbrown",
- "log",
+ "lazy_static",
+ "md-5",
+ "ordered-float 3.0.0",
+ "paste 1.0.8",
+ "rand 0.8.5",
+ "regex",
+ "sha2 0.10.2",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1507,27 +1531,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-physical-expr"
+name = "datafusion-row"
 version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
 dependencies = [
- "ahash 0.7.6",
  "arrow",
- "blake2",
- "blake3",
- "chrono",
- "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-row 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "hashbrown",
- "lazy_static",
- "md-5",
- "ordered-float 3.0.0",
+ "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
  "paste 1.0.8",
  "rand 0.8.5",
- "regex",
- "sha2 0.10.2",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1542,14 +1553,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-row"
+name = "datafusion-sql"
 version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4#8330a40519b0cb32c04a24a540511cd4638ac9b4"
 dependencies = [
+ "ahash 0.7.6",
  "arrow",
- "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "paste 1.0.8",
- "rand 0.8.5",
+ "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=8330a40519b0cb32c04a24a540511cd4638ac9b4)",
+ "hashbrown",
+ "sqlparser 0.19.0",
+ "tokio 1.20.1",
 ]
 
 [[package]]
@@ -1563,20 +1577,6 @@ dependencies = [
  "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=bb3e002a4d89f9a5104bba34511b4c593a9c0d05)",
  "hashbrown",
  "sqlparser 0.18.0",
- "tokio 1.20.1",
-]
-
-[[package]]
-name = "datafusion-sql"
-version = "9.0.0"
-source = "git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a#d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
-dependencies = [
- "ahash 0.7.6",
- "arrow",
- "datafusion-common 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "datafusion-expr 9.0.0 (git+https://github.com/waynexia/arrow-datafusion.git?rev=d8184e71589e95b27db0e2c0ce0a8c51a6564c7a)",
- "hashbrown",
- "sqlparser 0.19.0",
  "tokio 1.20.1",
 ]
 

--- a/arrow_deps/Cargo.toml
+++ b/arrow_deps/Cargo.toml
@@ -18,8 +18,8 @@ rev = "1d0770d997e29731b287e9e11e4ffbbea5f456da"
 
 [dependencies.datafusion]
 git = "https://github.com/waynexia/arrow-datafusion.git"
-rev = "d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+rev = "8330a40519b0cb32c04a24a540511cd4638ac9b4"
 
 [dependencies.datafusion-expr]
 git = "https://github.com/waynexia/arrow-datafusion.git"
-rev = "d8184e71589e95b27db0e2c0ce0a8c51a6564c7a"
+rev = "8330a40519b0cb32c04a24a540511cd4638ac9b4"

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -505,6 +505,12 @@ impl Datum {
             (DatumKind::String, Value::SingleQuotedString(s)) => {
                 Ok(Datum::String(StringBytes::from(s)))
             }
+            (DatumKind::Varbinary, Value::DoubleQuotedString(s)) => {
+                Ok(Datum::Varbinary(Bytes::from(s)))
+            }
+            (DatumKind::String, Value::DoubleQuotedString(s)) => {
+                Ok(Datum::String(StringBytes::from(s)))
+            }
             (DatumKind::UInt64, Value::Number(n, _long)) => {
                 let n = n.parse::<u64>().context(InvalidInt)?;
                 Ok(Datum::UInt64(n))

--- a/tests/cases/00_dummy/select_1.result
+++ b/tests/cases/00_dummy/select_1.result
@@ -56,7 +56,9 @@ Int64(24),
 
 SELECT "That is not good.";
 
-Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: SELECT \"That is not good.\";. Caused by: Failed to create plan, err:DataFusion Failed to plan, err:This feature is not implemented: Unsupported ast node Value(DoubleQuotedString(\"That is not good.\")) in sqltorel" })
+Utf8("That is not good."),
+String(StringBytes(b"That is not good.")),
+
 
 SELECT *;
 

--- a/tests/cases/local/basic.result
+++ b/tests/cases/local/basic.result
@@ -6,6 +6,10 @@ INSERT INTO demo(t, name, value) VALUES(1651737067000, 'ceresdb', 100);
 
 affected_rows: 1
 
+INSERT INTO demo(t, name, value) VALUES(1651737067000, "ceresdb", 100);
+
+affected_rows: 1
+
 SELECT * FROM demo;
 
 t,tsid,name,value,

--- a/tests/cases/local/basic.result
+++ b/tests/cases/local/basic.result
@@ -6,7 +6,13 @@ INSERT INTO demo(t, name, value) VALUES(1651737067000, 'ceresdb', 100);
 
 affected_rows: 1
 
-INSERT INTO demo(t, name, value) VALUES(1651737067000, "ceresdb", 100);
+SELECT * FROM demo;
+
+t,tsid,name,value,
+Timestamp(Timestamp(1651737067000)),Int64(-6317898613073581291),String(StringBytes(b"ceresdb")),Double(100.0),
+
+
+INSERT INTO demo(t, name, value) VALUES(1651737067001, "ceresdb", 100);
 
 affected_rows: 1
 
@@ -14,6 +20,18 @@ SELECT * FROM demo;
 
 t,tsid,name,value,
 Timestamp(Timestamp(1651737067000)),Int64(-6317898613073581291),String(StringBytes(b"ceresdb")),Double(100.0),
+Timestamp(Timestamp(1651737067001)),Int64(-6317898613073581291),String(StringBytes(b"ceresdb")),Double(100.0),
+
+
+CREATE TABLE "DeMo"("nAmE" string TAG, value double NOT NULL, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE=Analytic with (enable_ttl='false');
+
+Failed to execute query, err: Server(ServerError { code: 400, msg: "Failed to parse sql. Caused by: Invalid sql, sql: CREATE TABLE \"DeMo\"(\"nAmE\" string TAG, value double NOT NULL, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE=Analytic with (enable_ttl='false');, err:sql parser error: Expected identifier, found: \"DeMo\"" })
+
+SELECT "name" FROM demo;
+
+Utf8("name"),
+String(StringBytes(b"name")),
+String(StringBytes(b"name")),
 
 
 DROP TABLE demo;

--- a/tests/cases/local/basic.sql
+++ b/tests/cases/local/basic.sql
@@ -1,8 +1,17 @@
 CREATE TABLE demo (name string TAG, value double NOT NULL, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE=Analytic with (enable_ttl='false');
 
 INSERT INTO demo(t, name, value) VALUES(1651737067000, 'ceresdb', 100);
-INSERT INTO demo(t, name, value) VALUES(1651737067000, "ceresdb", 100);
 
 SELECT * FROM demo;
+
+-- Support double quoted string like MySql.
+-- Don't support case sensitive by double quote like PostgreSql.
+INSERT INTO demo(t, name, value) VALUES(1651737067001, "ceresdb", 100);
+
+SELECT * FROM demo;
+
+CREATE TABLE "DeMo"("nAmE" string TAG, value double NOT NULL, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE=Analytic with (enable_ttl='false');
+
+SELECT "name" FROM demo;
 
 DROP TABLE demo;

--- a/tests/cases/local/basic.sql
+++ b/tests/cases/local/basic.sql
@@ -1,6 +1,7 @@
 CREATE TABLE demo (name string TAG, value double NOT NULL, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE=Analytic with (enable_ttl='false');
 
 INSERT INTO demo(t, name, value) VALUES(1651737067000, 'ceresdb', 100);
+INSERT INTO demo(t, name, value) VALUES(1651737067000, "ceresdb", 100);
 
 SELECT * FROM demo;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #123 

# Rationale for this change
Double quoted string is supported in Mysql and ceresdb plans to support such dialect.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
+ Bump datafusion's version.
+ Add datum's conversion from double quoted string in ceresdb.
<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?
Users can use double quoted string like what they do in Mysql now.
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by integrated tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
