### PR TITLE
docs: fix build dir

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Use Guide
+name: Deploy Documentation
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     paths:
-      - 'docs/user-guide/**'
+      - 'docs/guides/**'
 
 env:
   MDBOOK_VERSION: v0.4.20
@@ -25,7 +25,7 @@ jobs:
         echo `pwd`/mdbook >> $GITHUB_PATH
     - name: Deploy GitHub Pages
       run: |
-        cd docs/user-guide
+        cd docs/guides
         mdbook build
         git worktree add gh-pages gh-pages
         git config user.name "Deploy from CI"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
After #186, user-guide is renamed to guides, but build script still use old directory.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

- https://github.com/jiacai2050/ceresdb/runs/7853729539?check_suite_focus=true
