### PR TITLE
chore: update the async_trait used by wal to 0.1.53

### DIFF
--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.41"
+async-trait = "0.1.53"
 common_util = {path = "../common_util"}
 common_types = {path = "../common_types"}
 chrono = "0.4"


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 `async-trait` crate has been used by multiple crates and all of them has the version 0.1.53 except the `wal` crate.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Update the version of `async-trait` to 0.1.53 used by `wal` crate.
<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR to help reviewer understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that needs to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing unit test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
