### PR TITLE
refactor: store `SpaceId` and `TableId` in `TableImpl`

### DIFF
--- a/analytic_engine/src/context.rs
+++ b/analytic_engine/src/context.rs
@@ -9,12 +9,6 @@ use table_engine::engine::EngineRuntimes;
 
 use crate::Config;
 
-/// Common context for instance
-pub struct CommonContext {
-    pub db_write_buffer_size: usize,
-    pub space_write_buffer_size: usize,
-}
-
 /// Context for instance open
 pub struct OpenContext {
     /// Engine config

--- a/analytic_engine/src/engine.rs
+++ b/analytic_engine/src/engine.rs
@@ -80,9 +80,10 @@ impl TableEngine for TableEngineImpl {
         let space_table = self.instance.create_table(&ctx, space_id, request).await?;
 
         let table_impl = Arc::new(TableImpl::new(
-            space_table,
             self.instance.clone(),
             ANALYTIC_ENGINE_TYPE.to_string(),
+            space_id,
+            space_table.table_data().id,
         ));
 
         Ok(table_impl)
@@ -121,9 +122,10 @@ impl TableEngine for TableEngineImpl {
         };
 
         let table_impl = Arc::new(TableImpl::new(
-            space_table,
             self.instance.clone(),
             ANALYTIC_ENGINE_TYPE.to_string(),
+            space_id,
+            space_table.table_data().id,
         ));
 
         Ok(Some(table_impl))

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -262,7 +262,7 @@ impl Instance {
     }
 
     /// Find space by id
-    pub fn find_space(&self, _ctx: &CommonContext, space_id: SpaceId) -> Option<SpaceRef> {
+    pub fn find_space(&self, space_id: SpaceId) -> Option<SpaceRef> {
         let spaces = self.space_store.spaces.read().unwrap();
         spaces.get_by_id(space_id).cloned()
     }
@@ -290,7 +290,7 @@ impl Instance {
         space_id: SpaceId,
         table: &str,
     ) -> Result<Option<SpaceAndTable>> {
-        let space = match self.find_space(ctx, space_id) {
+        let space = match self.find_space(space_id) {
             Some(s) => s,
             None => return Ok(None),
         };
@@ -325,7 +325,7 @@ impl Instance {
         space_id: SpaceId,
         request: DropTableRequest,
     ) -> Result<bool> {
-        let space = self.find_space(ctx, space_id).context(SpaceNotExist {
+        let space = self.find_space(space_id).context(SpaceNotExist {
             space_id,
             table: &request.table_name,
         })?;
@@ -340,7 +340,7 @@ impl Instance {
         space_id: SpaceId,
         request: CloseTableRequest,
     ) -> Result<()> {
-        let space = self.find_space(ctx, space_id).context(SpaceNotExist {
+        let space = self.find_space(space_id).context(SpaceNotExist {
             space_id,
             table: &request.table_name,
         })?;

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -13,7 +13,6 @@ use table_engine::{
 };
 
 use crate::{
-    context::CommonContext,
     instance::{write_worker::WriteGroup, Instance},
     space::{Space, SpaceAndTable, SpaceId, SpaceRef},
 };
@@ -226,11 +225,7 @@ impl From<Error> for table_engine::engine::Error {
 
 impl Instance {
     /// Find space by name, create if the space is not exists
-    pub async fn find_or_create_space(
-        self: &Arc<Self>,
-        _ctx: &CommonContext,
-        space_id: SpaceId,
-    ) -> Result<SpaceRef> {
+    pub async fn find_or_create_space(self: &Arc<Self>, space_id: SpaceId) -> Result<SpaceRef> {
         // Find space first
         if let Some(space) = self.get_space_by_read_lock(space_id) {
             return Ok(space);
@@ -270,11 +265,10 @@ impl Instance {
     /// Create a table under given space
     pub async fn create_table(
         self: &Arc<Self>,
-        ctx: &CommonContext,
         space_id: SpaceId,
         request: CreateTableRequest,
     ) -> Result<SpaceAndTable> {
-        let space = self.find_or_create_space(ctx, space_id).await?;
+        let space = self.find_or_create_space(space_id).await?;
         let table_data = self.do_create_table(space.clone(), request).await?;
 
         Ok(SpaceAndTable::new(space, table_data))
@@ -286,7 +280,6 @@ impl Instance {
     /// Return None if space or table is not found
     pub async fn find_table(
         &self,
-        ctx: &CommonContext,
         space_id: SpaceId,
         table: &str,
     ) -> Result<Option<SpaceAndTable>> {
@@ -307,11 +300,10 @@ impl Instance {
     /// Return None if space or table is not found
     pub async fn open_table(
         self: &Arc<Self>,
-        ctx: &CommonContext,
         space_id: SpaceId,
         request: &OpenTableRequest,
     ) -> Result<Option<SpaceAndTable>> {
-        let space = self.find_or_create_space(ctx, space_id).await?;
+        let space = self.find_or_create_space(space_id).await?;
 
         let table_data = self.do_open_table(space.clone(), request.table_id).await?;
 
@@ -321,7 +313,6 @@ impl Instance {
     /// Drop a table under given space
     pub async fn drop_table(
         self: &Arc<Self>,
-        ctx: &CommonContext,
         space_id: SpaceId,
         request: DropTableRequest,
     ) -> Result<bool> {
@@ -336,7 +327,6 @@ impl Instance {
     /// Close the table under given space by its table name
     pub async fn close_table(
         self: &Arc<Self>,
-        ctx: &CommonContext,
         space_id: SpaceId,
         request: CloseTableRequest,
     ) -> Result<()> {

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -43,8 +43,8 @@ pub struct TableImpl {
     space_id: SpaceId,
     table_id: TableId,
 
-    /// Holds a strong reference to prevent the underlying table being dropped
-    /// when this handle exist.
+    /// Holds a strong reference to prevent the underlying table from being
+    /// dropped when this handle exist.
     table_data: TableDataRef,
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In our design #175 a table handle `RoleTable` is decoupled with `TableData`, and needs to be able to change dynamically. One way is making `TableImpl` fetch the table handle from `Instance` every time rather than keep one. This PR finished (partially) the part in `TableImpl` -- keep some infos (space id and table id) for fetching the table handle.

# What changes are included in this PR?

- refactor: remove unused struct `CommonContext`
- refactor: add fields to `TableImpl`

The second change is for making `RoleTable` can be change dynamically. So we need to fetch the table handle from `Instance` each time rather than keep an unchangeable handle. But we do not have `RoleTable` for now so I also keep `SpaceAndTable` to pass compilation. It should be removed maybe after #188.



# Are there any user-facing changes?
no
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

this patch doesn't need
