### PR TITLE
refactor: build Payload in encode_batch for LogBatchEncoder

### DIFF
--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -117,12 +117,10 @@ impl Instance {
                     region_id: table_data.wal_region_id(),
                 })?;
 
-        let log_batch = log_batch_encoder
-            .encode(&[payload])
-            .context(EncodePayloads {
-                table: &table_data.name,
-                region_id: table_data.wal_region_id(),
-            })?;
+        let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
+            table: &table_data.name,
+            region_id: table_data.wal_region_id(),
+        })?;
 
         // Write log batch
         let write_ctx = WriteContext::default();
@@ -290,12 +288,10 @@ impl Instance {
                     region_id: table_data.wal_region_id(),
                 })?;
 
-        let log_batch = log_batch_encoder
-            .encode(&[payload])
-            .context(EncodePayloads {
-                table: &table_data.name,
-                region_id: table_data.wal_region_id(),
-            })?;
+        let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
+            table: &table_data.name,
+            region_id: table_data.wal_region_id(),
+        })?;
 
         // Write log batch
         let write_ctx = WriteContext::default();

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -374,12 +374,10 @@ impl Instance {
                     table: &table_data.name,
                     region_id: table_data.wal_region_id(),
                 })?;
-        let log_batch = log_batch_encoder
-            .encode(&[payload])
-            .context(EncodePayloads {
-                table: &table_data.name,
-                region_id: table_data.wal_region_id(),
-            })?;
+        let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
+            table: &table_data.name,
+            region_id: table_data.wal_region_id(),
+        })?;
 
         // Write to wal manager
         let write_ctx = WriteContext::default();

--- a/analytic_engine/src/payload.rs
+++ b/analytic_engine/src/payload.rs
@@ -131,6 +131,12 @@ impl<'a> Payload for WritePayload<'a> {
     }
 }
 
+impl<'a> From<&'a table_requests::WriteRequest> for WritePayload<'a> {
+    fn from(write_request: &'a table_requests::WriteRequest) -> Self {
+        Self::Write(write_request)
+    }
+}
+
 /// Payload decoded from wal
 #[derive(Debug)]
 pub enum ReadPayload {

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -192,3 +192,9 @@ impl<'a> Payload for WritePayload<'a> {
         Ok(())
     }
 }
+
+impl<'a> From<&'a Vec<u8>> for WritePayload<'a> {
+    fn from(data: &'a Vec<u8>) -> Self {
+        Self(data)
+    }
+}

--- a/benchmarks/src/wal_write_bench.rs
+++ b/benchmarks/src/wal_write_bench.rs
@@ -74,16 +74,11 @@ impl WalWriteBench {
             .expect("should succeed to open WalNamespaceImpl(Memory)");
 
             let values = self.build_value_vec();
-            let payloads = values
-                .iter()
-                .map(|value| WritePayload(value))
-                .collect::<Vec<_>>();
-
             let wal_encoder = wal
                 .encoder(1)
                 .expect("should succeed to create wal encoder");
             let log_batch = wal_encoder
-                .encode(&payloads)
+                .encode_batch::<WritePayload, Vec<u8>>(values.as_slice())
                 .expect("should succeed to encode payload batch");
 
             // Write to wal manager

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1699,9 +1699,10 @@ mod tests {
             payload_batch.push(payload);
         }
 
+        let log_entries = (start_sequence..end_sequence).collect::<Vec<_>>();
         let wal_encoder = LogBatchEncoder::create(region_id);
         let log_batch = wal_encoder
-            .encode(&payload_batch)
+            .encode_batch::<TestPayload, u32>(&log_entries)
             .expect("should succeed to encode payload batch");
         let write_ctx = manager::WriteContext::default();
         namespace


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Building Payload in `encode_batch` can improve performance.

# What changes are included in this PR?
1. Add `encode_batch` to encode batch payload in LogBatchEncoder.
2. Receive `&impl Payload` in encode to encode single payload.

# Are there any user-facing changes?
No

# How does this change test
Unit Tests.
