### PR TITLE
fix: insert negative number value

### DIFF
--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -999,10 +999,10 @@ mod tests {
     #[test]
     fn test_to_overflow_negative_value() {
         let cases = [
-            Datum::Int64(i64::MAX),
-            Datum::Int32(i32::MAX),
-            Datum::Int16(i16::MAX),
-            Datum::Int8(i8::MAX),
+            Datum::Int64(i64::MIN),
+            Datum::Int32(i32::MIN),
+            Datum::Int16(i16::MIN),
+            Datum::Int8(i8::MIN),
         ];
 
         for source in cases {

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -488,8 +488,8 @@ impl Datum {
     /// Generate a negative datum if possible.
     ///
     /// It will return `None` if:
-    /// - The data type has no negative value;
-    /// - The negative value overflows;
+    /// - The data type has no negative value.
+    /// - The negative value overflows.
     pub fn to_negative(self) -> Option<Self> {
         match self {
             Datum::Null => None,

--- a/server/src/mysql/error.rs
+++ b/server/src/mysql/error.rs
@@ -3,6 +3,7 @@
 use snafu::{Backtrace, Snafu};
 
 #[derive(Debug, Snafu)]
+#[allow(clippy::large_enum_variant)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
     #[snafu(display("Missing runtimes to build service.\nBacktrace:\n{}", backtrace))]

--- a/tests/cases/03_dml/insert_mode.result
+++ b/tests/cases/03_dml/insert_mode.result
@@ -6,7 +6,7 @@ CREATE TABLE `03_dml_insert_mode_table1` (    `timestamp` timestamp NOT NULL,   
 
 affected_rows: 0
 
-INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)    VALUES (1, 10), (2, 0), (3, -30);
+INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)    VALUES (1, +10), (2, 0), (3, -30);
 
 affected_rows: 3
 

--- a/tests/cases/03_dml/insert_mode.result
+++ b/tests/cases/03_dml/insert_mode.result
@@ -6,16 +6,16 @@ CREATE TABLE `03_dml_insert_mode_table1` (    `timestamp` timestamp NOT NULL,   
 
 affected_rows: 0
 
-INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)    VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)    VALUES (1, 10), (2, 0), (3, -30);
 
 affected_rows: 3
 
 SELECT    *FROM    `03_dml_insert_mode_table1`ORDER BY    `value` ASC;
 
 timestamp,tsid,value,
+Timestamp(Timestamp(3)),Int64(0),Double(-30.0),
+Timestamp(Timestamp(2)),Int64(0),Double(0.0),
 Timestamp(Timestamp(1)),Int64(0),Double(10.0),
-Timestamp(Timestamp(2)),Int64(0),Double(20.0),
-Timestamp(Timestamp(3)),Int64(0),Double(30.0),
 
 
 INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)    VALUES (1, 100), (2, 200), (3, 300);

--- a/tests/cases/03_dml/insert_mode.sql
+++ b/tests/cases/03_dml/insert_mode.sql
@@ -12,7 +12,7 @@ WITH(
 
 
 INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)
-    VALUES (1, 10), (2, 20), (3, 30);
+    VALUES (1, 10), (2, 0), (3, -30);
 
 
 SELECT

--- a/tests/cases/03_dml/insert_mode.sql
+++ b/tests/cases/03_dml/insert_mode.sql
@@ -12,7 +12,7 @@ WITH(
 
 
 INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)
-    VALUES (1, 10), (2, 0), (3, -30);
+    VALUES (1, +10), (2, 0), (3, -30);
 
 
 SELECT


### PR DESCRIPTION
# Which issue does this PR close?

Closes #211

# Rationale for this change
 Now CeresDB reports failure when inserting negative number value and that is a bug needing fix. And the bug actually will lead to the failure of inserting any **explicitly signed** number.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Fix the parsing procedure from `Expr` to `Datum` to ensure numbers with sign are allowed to insert.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Add new UT tests and integration tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
