### PR TITLE
feat: Make use of `LeaderTable`

### DIFF
--- a/analytic_engine/src/engine.rs
+++ b/analytic_engine/src/engine.rs
@@ -16,7 +16,7 @@ use table_engine::{
     ANALYTIC_ENGINE_TYPE,
 };
 
-use crate::{instance::InstanceRef, space::SpaceId, table::TableImpl};
+use crate::{instance::InstanceRef, role_table::TableRole, space::SpaceId, table::TableImpl};
 
 /// TableEngine implementation
 pub struct TableEngineImpl {
@@ -73,7 +73,9 @@ impl TableEngine for TableEngineImpl {
             space_id, request
         );
 
-        let space_table = self.instance.create_table(space_id, request).await?;
+        // TODO: remove this hardcode, add it to [CreateTableRequest].
+        let role = TableRole::Leader;
+        let space_table = self.instance.create_table(space_id, request, role).await?;
 
         let table_impl = Arc::new(TableImpl::new(
             self.instance.clone(),

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -15,6 +15,7 @@ use wal::manager::RegionId;
 
 use crate::{
     instance::{write_worker::WriteGroup, Instance},
+    role_table::TableRole,
     space::{Space, SpaceAndTable, SpaceId, SpaceRef},
 };
 
@@ -294,9 +295,11 @@ impl Instance {
         self: &Arc<Self>,
         space_id: SpaceId,
         request: CreateTableRequest,
+        // TODO: move this param into [CreateTableRequest].
+        role: TableRole,
     ) -> Result<SpaceAndTable> {
         let space = self.find_or_create_space(space_id).await?;
-        let table_data = self.do_create_table(space.clone(), request).await?;
+        let table_data = self.do_create_table(space.clone(), request, role).await?;
 
         Ok(SpaceAndTable::new(space, table_data))
     }

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -190,7 +190,7 @@ pub enum TableFlushPolicy {
 
 impl Instance {
     /// Flush this table.
-    pub async fn flush_table(
+    pub(crate) async fn flush_table(
         &self,
         space_table: &SpaceAndTable,
         flush_opts: TableFlushOptions,

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -133,7 +133,7 @@ impl Instance {
             Some(v) => v,
             None => return Ok(None),
         };
-        let role_table = LeaderTable::new(table_data);
+        let role_table = LeaderTable::open(table_data);
 
         let (tx, rx) = oneshot::channel();
         let cmd = RecoverTableCommand {

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -33,10 +33,9 @@ use crate::{
         merge::{MergeBuilder, MergeConfig, MergeIterator},
         IterOptions, RecordBatchWithKeyIterator,
     },
-    space::SpaceAndTable,
     sst::factory::SstReaderOptions,
     table::{
-        data::TableData,
+        data::{TableData, TableDataRef},
         version::{ReadView, TableVersion},
     },
     table_options::TableOptions,
@@ -78,18 +77,13 @@ impl Instance {
     /// `read_parallelism` output streams.
     pub async fn partitioned_read_from_table(
         &self,
-        space_table: &SpaceAndTable,
+        table_data: &TableDataRef,
         request: ReadRequest,
     ) -> Result<PartitionedStreams> {
         debug!(
             "Instance read from table, space_id:{}, table:{}, table_id:{:?}, request:{:?}",
-            space_table.space().id,
-            space_table.table_data().name,
-            space_table.table_data().id,
-            request
+            table_data.space_id, table_data.name, table_data.id, request
         );
-
-        let table_data = space_table.table_data();
 
         // Collect metrics.
         table_data.metrics.on_read_request_begin();

--- a/analytic_engine/src/instance/write_worker.rs
+++ b/analytic_engine/src/instance/write_worker.rs
@@ -28,7 +28,7 @@ use table_engine::{
 };
 use tokio::sync::{mpsc, oneshot, watch, watch::Ref, Mutex, Notify};
 
-use super::{alter::TableAlterSchemaPolicy, write::TableWritePolicy};
+use super::{alter::TableAlterPolicy, write::TableWritePolicy};
 use crate::{
     compaction::{TableCompactionRequest, WaitResult},
     instance::{
@@ -865,7 +865,7 @@ impl WriteWorker {
                 &mut self.local,
                 &table_data,
                 request,
-                TableAlterSchemaPolicy::Unknown,
+                TableAlterPolicy::Unknown,
             )
             .await
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+#![feature(try_blocks)]
+
 //! Analytic table engine implementations
 
 mod compaction;

--- a/analytic_engine/src/role_table/leader.rs
+++ b/analytic_engine/src/role_table/leader.rs
@@ -20,9 +20,7 @@ use crate::{
         write::TableWritePolicy,
         Instance, InstanceRef,
     },
-    role_table::{
-        AlterTable, FlushTable, ReadTable, Result, RoleTable, RoleTableRef, TableRole, WriteTable,
-    },
+    role_table::{Alter, Flush, Read, Result, RoleTable, RoleTableRef, TableRole, Write},
     table::data::TableDataRef,
 };
 
@@ -80,7 +78,7 @@ impl LeaderTableInner {
             .write_to_table(self.table_data.clone(), request, policy)
             .await
             .map_err(|e| Box::new(e) as _)
-            .context(WriteTable)
+            .context(Write)
     }
 
     async fn read(
@@ -94,7 +92,7 @@ impl LeaderTableInner {
             .partitioned_read_from_table(&self.table_data, request)
             .await
             .map_err(|e| Box::new(e) as _)
-            .context(ReadTable)
+            .context(Read)
     }
 
     async fn flush(
@@ -109,7 +107,7 @@ impl LeaderTableInner {
             .flush_table(&self.table_data, flush_opts)
             .await
             .map_err(|e| Box::new(e) as _)
-            .context(FlushTable)
+            .context(Flush)
     }
 
     async fn alter_schema(
@@ -124,7 +122,7 @@ impl LeaderTableInner {
             .alter_schema_of_table(&self.table_data, request, policy)
             .await
             .map_err(|e| Box::new(e) as _)
-            .context(AlterTable)
+            .context(Alter)
     }
 
     async fn alter_options(
@@ -139,7 +137,7 @@ impl LeaderTableInner {
             .alter_options_of_table(&self.table_data, options, policy)
             .await
             .map_err(|e| Box::new(e) as _)
-            .context(AlterTable)
+            .context(Alter)
     }
 }
 

--- a/analytic_engine/src/role_table/leader.rs
+++ b/analytic_engine/src/role_table/leader.rs
@@ -29,7 +29,7 @@ pub struct LeaderTable {
 }
 
 impl LeaderTable {
-    pub fn new(table_data: TableDataRef) -> RoleTableRef {
+    pub fn open(table_data: TableDataRef) -> RoleTableRef {
         let inner = Arc::new(LeaderTableInner {
             state: AtomicU8::new(LeaderTableInner::ROLE),
             table_data,

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -21,6 +21,11 @@ pub enum Error {
     WriteTable {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
+
+    #[snafu(display("Failed to alter table, err:{}", source))]
+    AlterTable {
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
 }
 
 define_result!(Error);
@@ -45,7 +50,7 @@ pub trait RoleTable: std::fmt::Debug + 'static {
 
     // async fn close(&self) -> Result<()>;
 
-    async fn write(&self, request: WriteRequest, instance: &InstanceRef) -> Result<usize>;
+    async fn write(&self, instance: &InstanceRef, request: WriteRequest) -> Result<usize>;
 
     // async fn read(&self, request: ReadRequest) -> Result<PartitionedStreams>;
 
@@ -59,14 +64,12 @@ pub trait RoleTable: std::fmt::Debug + 'static {
     async fn alter_schema(
         &self,
         instance: &Arc<Instance>,
-        worker_local: &mut WorkerLocal,
         request: AlterSchemaRequest,
     ) -> Result<()>;
 
     async fn alter_options(
         &self,
         instance: &Arc<Instance>,
-        worker_local: &mut WorkerLocal,
         options: HashMap<String, String>,
     ) -> Result<()>;
 

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use common_util::define_result;
 use snafu::Snafu;
-use table_engine::{table::{AlterSchemaRequest, ReadRequest, WriteRequest}, stream::PartitionedStreams};
+use table_engine::{
+    stream::PartitionedStreams,
+    table::{AlterSchemaRequest, ReadRequest, WriteRequest},
+};
 
 pub use self::leader::LeaderTable;
 use crate::{
@@ -33,7 +36,7 @@ pub type RoleTableRef = Arc<dyn RoleTable + Send + Sync + 'static>;
 pub fn create_role_table(table_data: TableDataRef, role: TableRole) -> RoleTableRef {
     match role {
         TableRole::Invalid => todo!(),
-        TableRole::Leader => LeaderTable::new(table_data),
+        TableRole::Leader => LeaderTable::open(table_data),
         TableRole::InSync => todo!(),
         TableRole::NoSync => todo!(),
     }
@@ -45,8 +48,6 @@ pub trait RoleTable: std::fmt::Debug + 'static {
     fn check_state(&self) -> bool;
 
     async fn change_role(&self) -> Result<()>;
-
-    // async fn close(&self) -> Result<()>;
 
     async fn write(&self, instance: &InstanceRef, request: WriteRequest) -> Result<usize>;
 

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -7,8 +7,9 @@ use table_engine::table::{AlterSchemaRequest, WriteRequest};
 
 pub use self::leader::LeaderTable;
 use crate::{
-    instance::{flush_compaction::TableFlushOptions, write_worker::WorkerLocal, Instance},
-    space::SpaceRef,
+    instance::{
+        flush_compaction::TableFlushOptions, write_worker::WorkerLocal, Instance, InstanceRef,
+    },
     table::data::TableDataRef,
 };
 
@@ -44,13 +45,7 @@ pub trait RoleTable: std::fmt::Debug + 'static {
 
     // async fn close(&self) -> Result<()>;
 
-    async fn write(
-        &self,
-        request: WriteRequest,
-        instance: &Arc<Instance>,
-        space: &SpaceRef,
-        worker_local: &mut WorkerLocal,
-    ) -> Result<usize>;
+    async fn write(&self, request: WriteRequest, instance: &InstanceRef) -> Result<usize>;
 
     // async fn read(&self, request: ReadRequest) -> Result<PartitionedStreams>;
 

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -23,8 +23,18 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
+    #[snafu(display("Failed to read table, err:{}", source))]
+    ReadTable {
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
     #[snafu(display("Failed to alter table, err:{}", source))]
     AlterTable {
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    #[snafu(display("Failed to flush table, err:{}", source))]
+    FlushTable {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 }

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -19,22 +19,22 @@ mod leader;
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to write table, err:{}", source))]
-    WriteTable {
+    Write {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
     #[snafu(display("Failed to read table, err:{}", source))]
-    ReadTable {
+    Read {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
     #[snafu(display("Failed to alter table, err:{}", source))]
-    AlterTable {
+    Alter {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 
     #[snafu(display("Failed to flush table, err:{}", source))]
-    FlushTable {
+    Flush {
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
 }

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use common_util::define_result;
 use snafu::Snafu;
-use table_engine::table::{AlterSchemaRequest, WriteRequest};
+use table_engine::{table::{AlterSchemaRequest, ReadRequest, WriteRequest}, stream::PartitionedStreams};
 
 pub use self::leader::LeaderTable;
 use crate::{
@@ -50,7 +50,11 @@ pub trait RoleTable: std::fmt::Debug + 'static {
 
     async fn write(&self, instance: &InstanceRef, request: WriteRequest) -> Result<usize>;
 
-    // async fn read(&self, request: ReadRequest) -> Result<PartitionedStreams>;
+    async fn read(
+        &self,
+        instance: &InstanceRef,
+        request: ReadRequest,
+    ) -> Result<PartitionedStreams>;
 
     async fn flush(&self, instance: &Arc<Instance>, flush_opts: TableFlushOptions) -> Result<()>;
 

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -7,9 +7,7 @@ use table_engine::table::{AlterSchemaRequest, WriteRequest};
 
 pub use self::leader::LeaderTable;
 use crate::{
-    instance::{
-        flush_compaction::TableFlushOptions, write_worker::WorkerLocal, Instance, InstanceRef,
-    },
+    instance::{flush_compaction::TableFlushOptions, Instance, InstanceRef},
     table::data::TableDataRef,
 };
 
@@ -54,12 +52,7 @@ pub trait RoleTable: std::fmt::Debug + 'static {
 
     // async fn read(&self, request: ReadRequest) -> Result<PartitionedStreams>;
 
-    async fn flush(
-        &self,
-        flush_opts: TableFlushOptions,
-        instance: &Arc<Instance>,
-        worker_local: &mut WorkerLocal,
-    ) -> Result<()>;
+    async fn flush(&self, instance: &Arc<Instance>, flush_opts: TableFlushOptions) -> Result<()>;
 
     async fn alter_schema(
         &self,

--- a/analytic_engine/src/space.rs
+++ b/analytic_engine/src/space.rs
@@ -156,6 +156,13 @@ impl Space {
         self.table_datas.read().unwrap().find_table_by_id(table_id)
     }
 
+    pub fn find_role_table_by_id(&self, table_id: TableId) -> Option<RoleTableRef> {
+        self.table_datas
+            .read()
+            .unwrap()
+            .find_role_table_by_id(table_id)
+    }
+
     /// Remove table under this space by table name
     pub fn remove_table(&self, table_name: &str) -> Option<TableDataRef> {
         self.table_datas.write().unwrap().remove_table(table_name)

--- a/analytic_engine/src/space.rs
+++ b/analytic_engine/src/space.rs
@@ -15,6 +15,7 @@ use table_engine::table::TableId;
 
 use crate::{
     instance::{mem_collector::MemUsageCollector, write_worker::WriteGroup},
+    role_table::RoleTableRef,
     table::data::{TableDataRef, TableDataSet},
 };
 
@@ -136,12 +137,12 @@ impl Space {
     /// absent. For internal use only
     ///
     /// Panic if the table is already exists
-    pub(crate) fn insert_table(&self, table_data: TableDataRef) {
+    pub(crate) fn insert_table(&self, role_table: RoleTableRef) {
         let success = self
             .table_datas
             .write()
             .unwrap()
-            .insert_if_absent(table_data);
+            .insert_if_absent(role_table);
         assert!(success);
     }
 

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -519,6 +519,10 @@ impl TableDataSet {
         self.id_to_tables.get(&table_id).cloned()
     }
 
+    pub fn find_role_table_by_id(&self, table_id: TableId) -> Option<RoleTableRef> {
+        self.id_to_roles.get(&table_id).cloned()
+    }
+
     /// Remove table by table name
     pub fn remove_table(&mut self, table_name: &str) -> Option<TableDataRef> {
         let table = self.table_datas.remove(table_name)?;

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -35,6 +35,7 @@ use crate::{
         skiplist::factory::SkiplistMemTableFactory,
     },
     meta::meta_update::AddTableMeta,
+    role_table::RoleTableRef,
     space::SpaceId,
     sst::{factory::SstType, file::FilePurger, manager::FileId},
     table::{
@@ -478,6 +479,8 @@ pub struct TableDataSet {
     table_datas: HashMap<String, TableDataRef>,
     /// Id to table data
     id_to_tables: HashMap<TableId, TableDataRef>,
+    /// Id to [RoleTable]
+    id_to_roles: HashMap<TableId, RoleTableRef>,
 }
 
 impl TableDataSet {
@@ -486,19 +489,23 @@ impl TableDataSet {
         Self {
             table_datas: HashMap::new(),
             id_to_tables: HashMap::new(),
+            id_to_roles: HashMap::new(),
         }
     }
 
     /// Insert if absent, if successfully inserted, return true and return
     /// false if the data already exists
-    pub fn insert_if_absent(&mut self, table_data_ref: TableDataRef) -> bool {
-        let table_name = &table_data_ref.name;
+    pub fn insert_if_absent(&mut self, role_table: RoleTableRef) -> bool {
+        let table_name = &role_table.table_data().name;
         if self.table_datas.contains_key(table_name) {
             return false;
         }
         self.table_datas
-            .insert(table_name.to_string(), table_data_ref.clone());
-        self.id_to_tables.insert(table_data_ref.id, table_data_ref);
+            .insert(table_name.to_string(), role_table.table_data());
+        self.id_to_tables
+            .insert(role_table.table_data().id, role_table.table_data());
+        self.id_to_roles
+            .insert(role_table.table_data().id, role_table);
         true
     }
 

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -133,8 +133,9 @@ impl Table for TableImpl {
     async fn read(&self, mut request: ReadRequest) -> Result<SendableRecordBatchStream> {
         request.opts.read_parallelism = 1;
         let mut streams = self
-            .instance
-            .partitioned_read_from_table(&self.space_table, request)
+            .get_table()
+            .expect("todo: remove this expect")
+            .read(&self.instance, request)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(Scan { table: self.name() })?;
@@ -219,8 +220,9 @@ impl Table for TableImpl {
 
     async fn partitioned_read(&self, request: ReadRequest) -> Result<PartitionedStreams> {
         let streams = self
-            .instance
-            .partitioned_read_from_table(&self.space_table, request)
+            .get_table()
+            .expect("todo: remove this expect")
+            .read(&self.instance, request)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(Scan { table: self.name() })?;

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -123,7 +123,7 @@ impl Table for TableImpl {
         let num_rows = self
             .get_table()
             .expect("todo: remove this expect")
-            .write(request, &self.instance)
+            .write(&self.instance, request)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(Write { table: self.name() })?;
@@ -229,8 +229,9 @@ impl Table for TableImpl {
     }
 
     async fn alter_schema(&self, request: AlterSchemaRequest) -> Result<usize> {
-        self.instance
-            .alter_schema_of_table(&self.space_table, request)
+        self.get_table()
+            .expect("todo: remove this expect")
+            .alter_schema(&self.instance, request)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(AlterSchema { table: self.name() })?;
@@ -238,8 +239,9 @@ impl Table for TableImpl {
     }
 
     async fn alter_options(&self, options: HashMap<String, String>) -> Result<usize> {
-        self.instance
-            .alter_options_of_table(&self.space_table, options)
+        self.get_table()
+            .expect("todo: remove this expect")
+            .alter_options(&self.instance, options)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(AlterOptions { table: self.name() })?;

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -261,14 +261,16 @@ impl Table for TableImpl {
             } else {
                 None
             },
-            policy: TableFlushPolicy::Dump,
+            policy: TableFlushPolicy::Unknown,
         };
 
-        self.instance
-            .flush_table(&self.space_table, flush_opts)
+        self.get_table()
+            .expect("todo: remove this expect")
+            .flush(&self.instance, flush_opts)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(Flush { table: self.name() })?;
+
         if let Some(rx) = rx_opt {
             rx.await
                 .map_err(|e| Box::new(e) as _)

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -84,6 +84,9 @@ pub enum Error {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    #[snafu(display("Table {:?} not found.\nBacktrace:\n{}", table, backtrace))]
+    TableNotFound { table: String, backtrace: Backtrace },
+
     #[snafu(display("Failed to write table, table:{}, err:{}", table, source))]
     Write {
         table: String,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #175, follows #188

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

#188 defines `RoleTable` trait and a implementation `LeaderTable`. But `LeaderTable` is not used by other components. This patch refines `RoleTable`'s interface (removed the `WorkerLocal` requirement) and makes `TableImpl` use `RoleTable`'s interfaces.

# What changes are included in this PR?

Change `write`, `read`, `alter_schema`, `alter_options` and `flush` in `TableImpl` to go though `RoleTable`.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

Existing UT