### PR TITLE
feat: support route in cluster mode

### DIFF
--- a/catalog/src/schema.rs
+++ b/catalog/src/schema.rs
@@ -134,7 +134,6 @@ define_result!(Error);
 
 /// A name reference.
 pub type NameRef<'a> = &'a str;
-pub type SchemaName = String;
 // TODO: This name is conflict with [table_engine::schema::SchemaRef].
 pub type SchemaRef = Arc<dyn Schema + Send + Sync>;
 

--- a/catalog_impls/src/volatile.rs
+++ b/catalog_impls/src/volatile.rs
@@ -16,10 +16,11 @@ use catalog::{
     schema::{
         self, CatalogMismatch, CloseOptions, CloseTable, CloseTableRequest, CreateOptions,
         CreateTable, CreateTableRequest, DropOptions, DropTable, DropTableRequest, NameRef,
-        OpenOptions, OpenTable, OpenTableRequest, Schema, SchemaMismatch, SchemaName, SchemaRef,
+        OpenOptions, OpenTable, OpenTableRequest, Schema, SchemaMismatch, SchemaRef,
     },
     Catalog, CatalogRef,
 };
+use common_types::schema::SchemaName;
 use log::{debug, info};
 use snafu::{ensure, ResultExt};
 use table_engine::table::{SchemaId, TableRef};

--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -217,6 +217,7 @@ impl Inner {
 
         // TODO: Besides such patching update, one background `CheckAndUpdate` job
         // should be supported to keep the topology cache latest.
+        // TODO: Now the version is ignored because current topology is almost static.
         {
             // Apply the update patch to the topology cache.
             let update_patch = make_route_update_patch(&req.table_names, &route_resp.entries);

--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -93,7 +93,7 @@ impl ClusterImpl {
 
     // Register node every 2/3 lease
     fn heartbeat_interval(&self) -> Duration {
-        Duration::from_secs(self.config.meta_client.lease.as_millis() * 2 / 3)
+        Duration::from_millis(self.config.meta_client.lease.as_millis() * 2 / 3)
     }
 
     fn error_wait_lease(&self) -> Duration {

--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -1,15 +1,19 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use std::{
-    sync::{Arc, Mutex},
+    collections::HashMap,
+    sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
 
 use async_trait::async_trait;
+use common_types::table::TableName;
 use common_util::runtime::{JoinHandle, Runtime};
 use log::{error, info, warn};
 use meta_client::{
-    types::{ActionCmd, GetShardTablesRequest},
+    types::{
+        ActionCmd, GetShardTablesRequest, RouteEntry, RouteTablesRequest, RouteTablesResponse,
+    },
     EventHandler, MetaClient,
 };
 use snafu::ResultExt;
@@ -21,7 +25,8 @@ use tokio::{
 use crate::{
     config::ClusterConfig,
     table_manager::{ShardTableInfo, TableManager},
-    Cluster, ClusterTopologyRef, MetaClientFailure, Result, StartMetaClient, TableManipulator,
+    topology::{ClusterTopology, RouteSlot},
+    Cluster, MetaClientFailure, Result, StartMetaClient, TableManipulator,
 };
 
 /// ClusterImpl is an implementation of [`Cluster`] based [`MetaClient`].
@@ -100,6 +105,7 @@ struct Inner {
     table_manager: TableManager,
     meta_client: Arc<dyn MetaClient + Send + Sync>,
     table_manipulator: Arc<dyn TableManipulator + Send + Sync>,
+    topology: RwLock<ClusterTopology>,
 }
 
 #[async_trait]
@@ -158,8 +164,25 @@ impl EventHandler for Inner {
     }
 }
 
+fn make_route_update_patch(
+    queried_tables: &[TableName],
+    route_entries: &HashMap<TableName, RouteEntry>,
+) -> HashMap<TableName, RouteSlot> {
+    let mut slots = HashMap::with_capacity(queried_tables.len());
+
+    for table_name in queried_tables {
+        let slot = match route_entries.get(table_name) {
+            Some(entry) => RouteSlot::Exist(entry.clone()),
+            None => RouteSlot::NotExist,
+        };
+        slots.insert(table_name.clone(), slot);
+    }
+
+    slots
+}
+
 impl Inner {
-    pub fn new(
+    fn new(
         meta_client: Arc<dyn MetaClient + Send + Sync>,
         table_manipulator: Arc<dyn TableManipulator + Send + Sync>,
     ) -> Result<Self> {
@@ -167,7 +190,45 @@ impl Inner {
             table_manager: TableManager::default(),
             meta_client,
             table_manipulator,
+            topology: Default::default(),
         })
+    }
+
+    async fn route_tables(&self, req: &RouteTablesRequest) -> Result<RouteTablesResponse> {
+        let route_res = {
+            let topology = self.topology.read().unwrap();
+            topology.route_tables(&req.schema_name, &req.table_names)
+        };
+
+        if route_res.missing_tables.is_empty() {
+            return Ok(RouteTablesResponse::from(route_res));
+        }
+
+        // TODO: Actually, only the missing tables' routing information needs fetching
+        // from CeresMeta.
+
+        // Some tables are not found in the cluster topology cache, and we need to fetch
+        // them from CeresMeta.
+        let route_resp = self
+            .meta_client
+            .route_tables(req.clone())
+            .await
+            .context(MetaClientFailure)?;
+
+        // TODO: Besides such patching update, one background `CheckAndUpdate` job
+        // should be supported to keep the topology cache latest.
+        {
+            // Apply the update patch to the topology cache.
+            let update_patch = make_route_update_patch(&req.table_names, &route_resp.entries);
+            let mut topology = self.topology.write().unwrap();
+            topology.update_tables(
+                &req.schema_name,
+                update_patch,
+                route_resp.cluster_topology_version,
+            );
+        }
+
+        Ok(route_resp)
     }
 }
 
@@ -222,7 +283,7 @@ impl Cluster for ClusterImpl {
         Ok(())
     }
 
-    async fn fetch_topology(&self) -> Result<ClusterTopologyRef> {
-        todo!("fetch topology from the meta")
+    async fn route_tables(&self, req: &RouteTablesRequest) -> Result<RouteTablesResponse> {
+        self.inner.route_tables(req).await
     }
 }

--- a/cluster/src/config.rs
+++ b/cluster/src/config.rs
@@ -1,7 +1,27 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+use common_types::schema::TIMESTAMP_COLUMN;
 use meta_client::{meta_impl::MetaClientConfig, types::NodeMetaInfo};
 use serde_derive::Deserialize;
+use table_engine::ANALYTIC_ENGINE_TYPE;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SchemaConfig {
+    pub auto_create_tables: bool,
+    pub default_engine_type: String,
+    pub default_timestamp_column_name: String,
+}
+
+impl Default for SchemaConfig {
+    fn default() -> Self {
+        Self {
+            auto_create_tables: false,
+            default_engine_type: ANALYTIC_ENGINE_TYPE.to_string(),
+            default_timestamp_column_name: TIMESTAMP_COLUMN.to_string(),
+        }
+    }
+}
 
 #[derive(Default, Clone, Deserialize, Debug)]
 #[serde(default)]

--- a/cluster/src/table_manager.rs
+++ b/cluster/src/table_manager.rs
@@ -5,11 +5,14 @@ use std::{
     sync::RwLock,
 };
 
-use common_types::{schema::SchemaId, table::TableId};
+use common_types::{
+    schema::{SchemaId, SchemaName},
+    table::{TableId, TableName},
+};
 use meta_client::types::{CreateTableCmd, ShardId, ShardInfo, ShardTables, TableInfo};
 use snafu::OptionExt;
 
-use crate::{Result, SchemaName, ShardNotFound, TableName};
+use crate::{Result, ShardNotFound};
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -71,7 +71,7 @@ impl ClusterTopology {
     /// Any update on the topology should ensure the version is valid: the
     /// target version must be not older than the current version.
     pub fn is_outdated_version(&self, version: u64) -> bool {
-        return version >= self.version;
+        version >= self.version
     }
 
     pub fn route_tables(&self, schema_name: &str, tables: &[TableName]) -> RouteTablesResult {

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -3,30 +3,12 @@
 use std::collections::HashMap;
 
 use common_types::{
-    schema::{SchemaId, SchemaName, TIMESTAMP_COLUMN},
+    schema::{SchemaId, SchemaName},
     table::TableName,
 };
 use meta_client::types::{RouteEntry, RouteTablesResponse};
-use serde::Deserialize;
-use table_engine::ANALYTIC_ENGINE_TYPE;
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(default)]
-pub struct SchemaConfig {
-    pub auto_create_tables: bool,
-    pub default_engine_type: String,
-    pub default_timestamp_column_name: String,
-}
-
-impl Default for SchemaConfig {
-    fn default() -> Self {
-        Self {
-            auto_create_tables: false,
-            default_engine_type: ANALYTIC_ENGINE_TYPE.to_string(),
-            default_timestamp_column_name: TIMESTAMP_COLUMN.to_string(),
-        }
-    }
-}
+use crate::config::SchemaConfig;
 
 /// RouteSlot is used to prevent cache penetration, that is to say, the
 /// `NotExist` routing result of a table is also kept in the memory.

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -1,0 +1,134 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::collections::HashMap;
+
+use common_types::{
+    schema::{SchemaId, SchemaName, TIMESTAMP_COLUMN},
+    table::TableName,
+};
+use meta_client::types::{RouteEntry, RouteTablesResponse};
+use serde::Deserialize;
+use table_engine::ANALYTIC_ENGINE_TYPE;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SchemaConfig {
+    pub auto_create_tables: bool,
+    pub default_engine_type: String,
+    pub default_timestamp_column_name: String,
+}
+
+impl Default for SchemaConfig {
+    fn default() -> Self {
+        Self {
+            auto_create_tables: false,
+            default_engine_type: ANALYTIC_ENGINE_TYPE.to_string(),
+            default_timestamp_column_name: TIMESTAMP_COLUMN.to_string(),
+        }
+    }
+}
+
+/// RouteSlot is used to prevent cache penetration, that is to say, the
+/// `NotExist` routing result of a table is also kept in the memory.
+#[derive(Debug, Clone)]
+pub enum RouteSlot {
+    Exist(RouteEntry),
+    NotExist,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+struct SchemaTopology {
+    id: SchemaId,
+    config: SchemaConfig,
+    /// The [RouteSlot] in the `route_slots` only can be `Exist` or `NotExist`.
+    route_slots: HashMap<TableName, RouteSlot>,
+}
+
+#[derive(Debug, Default)]
+pub struct ClusterTopology {
+    version: u64,
+    schema_topologies: HashMap<SchemaName, SchemaTopology>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RouteTablesResult {
+    pub version: u64,
+    pub route_entries: HashMap<TableName, RouteEntry>,
+    pub missing_tables: Vec<TableName>,
+}
+
+impl From<RouteTablesResult> for RouteTablesResponse {
+    fn from(result: RouteTablesResult) -> Self {
+        RouteTablesResponse {
+            cluster_topology_version: result.version,
+            entries: result.route_entries,
+        }
+    }
+}
+
+impl ClusterTopology {
+    /// Any update on the topology should ensure the version is valid: the
+    /// target version must be not older than the current version.
+    pub fn is_outdated_version(&self, version: u64) -> bool {
+        return version >= self.version;
+    }
+
+    pub fn route_tables(&self, schema_name: &str, tables: &[TableName]) -> RouteTablesResult {
+        if let Some(schema_topology) = self.schema_topologies.get(schema_name) {
+            let mut route_entries = HashMap::with_capacity(tables.len());
+            let mut missing_tables = vec![];
+
+            for table in tables {
+                match schema_topology.route_slots.get(table) {
+                    None => missing_tables.push(table.clone()),
+                    Some(RouteSlot::Exist(route_entry)) => {
+                        route_entries.insert(table.clone(), route_entry.clone());
+                    }
+                    Some(RouteSlot::NotExist) => (),
+                };
+            }
+
+            return RouteTablesResult {
+                version: self.version,
+                route_entries,
+                missing_tables,
+            };
+        }
+
+        RouteTablesResult {
+            version: self.version,
+            route_entries: Default::default(),
+            missing_tables: tables.to_vec(),
+        }
+    }
+
+    /// Update the routing information into the topology if its version is
+    /// valid.
+    ///
+    /// Return false if the version is outdated.
+    pub fn update_tables(
+        &mut self,
+        schema_name: &str,
+        tables: HashMap<TableName, RouteSlot>,
+        version: u64,
+    ) -> bool {
+        if self.is_outdated_version(version) {
+            return false;
+        }
+
+        self.schema_topologies
+            .entry(schema_name.to_string())
+            .or_insert_with(Default::default)
+            .update_tables(tables);
+        true
+    }
+}
+
+impl SchemaTopology {
+    fn update_tables(&mut self, tables: HashMap<TableName, RouteSlot>) {
+        for (table_name, slot) in tables {
+            self.route_slots.insert(table_name, slot);
+        }
+    }
+}

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -36,10 +36,11 @@ pub enum RouteSlot {
     NotExist,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Default)]
 struct SchemaTopology {
+    #[allow(dead_code)]
     id: SchemaId,
+    #[allow(dead_code)]
     config: SchemaConfig,
     /// The [RouteSlot] in the `route_slots` only can be `Exist` or `NotExist`.
     route_slots: HashMap<TableName, RouteSlot>,

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -153,6 +153,7 @@ pub enum Error {
 }
 
 pub type SchemaId = u32;
+pub type SchemaName = String;
 // TODO: make these constants configurable
 pub const TSID_COLUMN: &str = "tsid";
 pub const TIMESTAMP_COLUMN: &str = "timestamp";

--- a/common_types/src/table.rs
+++ b/common_types/src/table.rs
@@ -1,3 +1,4 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 pub type TableId = u64;
+pub type TableName = String;

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -2,12 +2,14 @@
 
 use std::collections::HashMap;
 
-use catalog::schema::SchemaName;
 use ceresdbproto_deps::ceresdbproto::{
     cluster,
     meta_service::{self, NodeHeartbeatResponse_oneof_cmd},
 };
-use common_types::{schema::SchemaId, table::TableId};
+use common_types::{
+    schema::{SchemaId, SchemaName},
+    table::TableId,
+};
 use common_util::config::ReadableDuration;
 use protobuf::RepeatedField;
 use serde_derive::Deserialize;
@@ -122,7 +124,14 @@ pub struct ShardInfo {
     pub role: ShardRole,
 }
 
-#[derive(Debug, Copy, Clone)]
+impl ShardInfo {
+    #[inline]
+    pub fn is_leader(&self) -> bool {
+        self.role == ShardRole::LEADER
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ShardRole {
     LEADER,
     FOLLOWER,

--- a/query_engine/src/logical_optimizer/type_conversion.rs
+++ b/query_engine/src/logical_optimizer/type_conversion.rs
@@ -274,9 +274,9 @@ fn string_to_timestamp_ms(string: &str) -> Result<ScalarValue> {
     ))
 }
 
-#[allow(dead_code)]
 enum TimestampType {
     Second,
+    #[allow(dead_code)]
     Millisecond,
     Microsecond,
     Nanosecond,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 
 use analytic_engine;
-use cluster::{config::ClusterConfig, Node, SchemaConfig};
+use cluster::{config::ClusterConfig, topology::SchemaConfig};
 use common_types::schema::TIMESTAMP_COLUMN;
 use meta_client::types::ShardId;
 use serde_derive::Deserialize;
@@ -44,6 +44,12 @@ pub struct RuntimeConfig {
 pub struct StaticRouteConfig {
     pub rule_list: RuleList,
     pub topology: StaticTopologyConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Node {
+    pub addr: String,
+    pub port: u16,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use analytic_engine;
 use ceresdbproto_deps::ceresdbproto::storage;
-use cluster::{config::ClusterConfig, topology::SchemaConfig};
+use cluster::config::{ClusterConfig, SchemaConfig};
 use common_types::schema::TIMESTAMP_COLUMN;
 use meta_client::types::ShardId;
 use serde_derive::Deserialize;

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -65,7 +65,7 @@ impl FromStr for Endpoint {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let (addr, raw_port) = match s.rsplit_once(':') {
             Some(v) => v,
-            None => return Err(format!("Can't find ':' in the source string")),
+            None => return Err("Can't find ':' in the source string".to_string()),
         };
         let port = raw_port
             .parse()
@@ -235,7 +235,7 @@ mod tests {
         let cases = [
             (
                 "abc.1234.com:1000",
-                Endpoint::new("abc.1235.com".to_string(), 1000),
+                Endpoint::new("abc.1234.com".to_string(), 1000),
             ),
             (
                 "127.0.0.1:1000",

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -17,7 +17,7 @@ use ceresdbproto_deps::ceresdbproto::{
     },
     storage_grpc::{self, StorageService},
 };
-use cluster::topology::SchemaConfig;
+use cluster::config::SchemaConfig;
 use common_types::{
     column_schema::{self, ColumnSchema},
     datum::DatumKind,
@@ -849,7 +849,7 @@ mod tests {
     use ceresdbproto_deps::ceresdbproto::storage::{
         Field, FieldGroup, Tag, Value, WriteEntry, WriteMetric,
     };
-    use cluster::topology::SchemaConfig;
+    use cluster::config::SchemaConfig;
     use common_types::datum::DatumKind;
 
     use super::*;

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -849,7 +849,7 @@ mod tests {
     use ceresdbproto_deps::ceresdbproto::storage::{
         Field, FieldGroup, Tag, Value, WriteEntry, WriteMetric,
     };
-    use cluster::SchemaConfig;
+    use cluster::topology::SchemaConfig;
     use common_types::datum::DatumKind;
 
     use super::*;

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -17,7 +17,7 @@ use ceresdbproto_deps::ceresdbproto::{
     },
     storage_grpc::{self, StorageService},
 };
-use cluster::SchemaConfig;
+use cluster::topology::SchemaConfig;
 use common_types::{
     column_schema::{self, ColumnSchema},
     datum::DatumKind,

--- a/server/src/grpc/route.rs
+++ b/server/src/grpc/route.rs
@@ -2,33 +2,22 @@
 
 //! Route handler
 
-use std::sync::Arc;
-
 use ceresdbproto_deps::ceresdbproto::storage::{RouteRequest, RouteResponse};
 
 use crate::{
     error::Result,
     grpc::{self, HandlerContext},
-    route::Router,
 };
 
 pub async fn handle_route<Q>(
     ctx: &HandlerContext<'_, Q>,
     req: RouteRequest,
 ) -> Result<RouteResponse> {
-    handle_route_sync(ctx.router.clone(), req, ctx.tenant())
-}
-
-fn handle_route_sync(
-    router: Arc<dyn Router + Sync + Send>,
-    req: RouteRequest,
-    schema: &str,
-) -> Result<RouteResponse> {
-    let route_vec = router.route(schema, req)?;
+    let routes = ctx.router.route(ctx.tenant(), req).await?;
 
     let mut resp = RouteResponse::new();
     resp.set_header(grpc::build_ok_header());
-    resp.set_routes(route_vec.into());
+    resp.set_routes(routes.into());
 
     Ok(resp)
 }

--- a/server/src/route/cluster_based.rs
+++ b/server/src/route/cluster_based.rs
@@ -30,8 +30,8 @@ impl ClusterBasedRouter {
 //
 // Returns `None` if fail to parse.
 fn try_parse_endpoint(raw: &str) -> Option<Endpoint> {
-    let (domain, raw_port) = raw.split_once(":")?;
-    let port: u16 = raw_port.parse().map(|p| Some(p)).unwrap_or(None)?;
+    let (domain, raw_port) = raw.split_once(':')?;
+    let port: u16 = raw_port.parse().map(Some).unwrap_or(None)?;
 
     let mut endpoint = Endpoint::default();
     endpoint.set_ip(domain.to_string());

--- a/server/src/route/cluster_based.rs
+++ b/server/src/route/cluster_based.rs
@@ -4,10 +4,17 @@
 
 #![allow(dead_code)]
 
-use ceresdbproto_deps::ceresdbproto::storage::{Route, RouteRequest};
+use async_trait::async_trait;
+use ceresdbproto_deps::ceresdbproto::storage::{Endpoint, Route, RouteRequest};
 use cluster::ClusterRef;
+use log::warn;
+use meta_client::types::RouteTablesRequest;
+use snafu::ResultExt;
 
-use crate::{error::Result, route::Router};
+use crate::{
+    error::{ErrWithCause, Result, StatusCode},
+    route::Router,
+};
 
 pub struct ClusterBasedRouter {
     cluster: ClusterRef,
@@ -19,8 +26,58 @@ impl ClusterBasedRouter {
     }
 }
 
+// Parse the raw endpoint which should be the form: <domain_name>:<port>
+//
+// Returns `None` if fail to parse.
+fn try_parse_endpoint(raw: &str) -> Option<Endpoint> {
+    let (domain, raw_port) = raw.split_once(":")?;
+    let port: u16 = raw_port.parse().map(|p| Some(p)).unwrap_or(None)?;
+
+    let mut endpoint = Endpoint::default();
+    endpoint.set_ip(domain.to_string());
+    endpoint.set_port(port as u32);
+    Some(endpoint)
+}
+
+#[async_trait]
 impl Router for ClusterBasedRouter {
-    fn route(&self, _schema: &str, _req: RouteRequest) -> Result<Vec<Route>> {
-        todo!();
+    async fn route(&self, schema: &str, mut req: RouteRequest) -> Result<Vec<Route>> {
+        let route_tables_req = RouteTablesRequest {
+            schema_name: schema.to_string(),
+            table_names: req.take_metrics().into(),
+        };
+        let route_resp = self
+            .cluster
+            .route_tables(&route_tables_req)
+            .await
+            .map_err(|e| Box::new(e) as _)
+            .context(ErrWithCause {
+                code: StatusCode::InternalError,
+                msg: "Fail to route tables by cluster",
+            })?;
+
+        let mut routes = Vec::with_capacity(route_resp.entries.len());
+
+        // Now we pick up the nodes who own the leader shard for the route response.
+        for (table_name, route_entry) in route_resp.entries {
+            for node_shard in route_entry.node_shards {
+                if node_shard.shard_info.is_leader() {
+                    let mut route = Route::default();
+                    let endpoint = match try_parse_endpoint(&node_shard.endpoint) {
+                        Some(v) => v,
+                        None => {
+                            warn!("Fail to parse endpoint:{}", node_shard.endpoint);
+                            continue;
+                        }
+                    };
+                    route.set_metric(table_name.clone());
+                    route.set_endpoint(endpoint);
+
+                    routes.push(route);
+                }
+            }
+        }
+
+        Ok(routes)
     }
 }

--- a/server/src/route/cluster_based.rs
+++ b/server/src/route/cluster_based.rs
@@ -2,8 +2,6 @@
 
 //! A router based on the [`cluster::Cluster`].
 
-#![allow(dead_code)]
-
 use async_trait::async_trait;
 use ceresdbproto_deps::ceresdbproto::storage::{Endpoint, Route, RouteRequest};
 use cluster::ClusterRef;
@@ -31,7 +29,7 @@ impl ClusterBasedRouter {
 // Returns `None` if fail to parse.
 fn try_parse_endpoint(raw: &str) -> Option<Endpoint> {
     let (domain, raw_port) = raw.split_once(':')?;
-    let port: u16 = raw_port.parse().map(Some).unwrap_or(None)?;
+    let port: u16 = raw_port.parse().ok()?;
 
     let mut endpoint = Endpoint::default();
     endpoint.set_ip(domain.to_string());

--- a/server/src/route/mod.rs
+++ b/server/src/route/mod.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use ceresdbproto_deps::ceresdbproto::storage::{Route, RouteRequest};
 
 use crate::error::Result;
@@ -14,6 +15,7 @@ pub use rule_based::{RuleBasedRouter, RuleList};
 
 pub type RouterRef = Arc<dyn Router + Sync + Send>;
 
+#[async_trait]
 pub trait Router {
-    fn route(&self, schema: &str, req: RouteRequest) -> Result<Vec<Route>>;
+    async fn route(&self, schema: &str, req: RouteRequest) -> Result<Vec<Route>>;
 }

--- a/server/src/route/rule_based.rs
+++ b/server/src/route/rule_based.rs
@@ -7,14 +7,16 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+use async_trait::async_trait;
 use ceresdbproto_deps::ceresdbproto::storage::{Endpoint, Route, RouteRequest};
-use cluster::{Node, SchemaConfig};
+use cluster::topology::SchemaConfig;
 use log::info;
 use meta_client::types::ShardId;
 use serde_derive::Deserialize;
 use twox_hash::XxHash64;
 
 use crate::{
+    config::Node,
     error::{ErrNoCause, Result, StatusCode},
     route::Router,
 };
@@ -149,8 +151,9 @@ impl RuleBasedRouter {
     }
 }
 
+#[async_trait]
 impl Router for RuleBasedRouter {
-    fn route(&self, schema: &str, req: RouteRequest) -> Result<Vec<Route>> {
+    async fn route(&self, schema: &str, req: RouteRequest) -> Result<Vec<Route>> {
         if let Some(shard_nodes) = self.cluster_view.schema_shards.get(schema) {
             if shard_nodes.is_empty() {
                 return ErrNoCause {

--- a/server/src/route/rule_based.rs
+++ b/server/src/route/rule_based.rs
@@ -9,7 +9,7 @@ use std::{
 
 use async_trait::async_trait;
 use ceresdbproto_deps::ceresdbproto::storage::{self, Route, RouteRequest};
-use cluster::topology::SchemaConfig;
+use cluster::config::SchemaConfig;
 use log::info;
 use meta_client::types::ShardId;
 use serde_derive::Deserialize;

--- a/server/src/schema_config_provider/cluster_based.rs
+++ b/server/src/schema_config_provider/cluster_based.rs
@@ -2,13 +2,12 @@
 
 //! Schema provider based on cluster.
 
-#![allow(dead_code)]
-
 use cluster::{topology::SchemaConfig, ClusterRef};
 
 use crate::schema_config_provider::{Result, SchemaConfigProvider};
 
 pub struct ClusterBasedProvider {
+    #[allow(dead_code)]
     cluster: ClusterRef,
     default_schema_config: SchemaConfig,
 }

--- a/server/src/schema_config_provider/cluster_based.rs
+++ b/server/src/schema_config_provider/cluster_based.rs
@@ -4,22 +4,28 @@
 
 #![allow(dead_code)]
 
-use cluster::ClusterRef;
+use cluster::{topology::SchemaConfig, ClusterRef};
 
 use crate::schema_config_provider::{Result, SchemaConfigProvider};
 
 pub struct ClusterBasedProvider {
     cluster: ClusterRef,
+    default_schema_config: SchemaConfig,
 }
 
 impl ClusterBasedProvider {
     pub fn new(cluster: ClusterRef) -> Self {
-        Self { cluster }
+        Self {
+            cluster,
+            default_schema_config: Default::default(),
+        }
     }
 }
 
 impl SchemaConfigProvider for ClusterBasedProvider {
-    fn schema_config(&self, _schema_name: &str) -> Result<Option<&cluster::SchemaConfig>> {
-        todo!()
+    fn schema_config(&self, _schema_name: &str) -> Result<Option<&SchemaConfig>> {
+        // FIXME: Fetch the schema config from the cluster rather than the hard-coded
+        // default_schema_config.
+        Ok(Some(&self.default_schema_config))
     }
 }

--- a/server/src/schema_config_provider/cluster_based.rs
+++ b/server/src/schema_config_provider/cluster_based.rs
@@ -2,7 +2,7 @@
 
 //! Schema provider based on cluster.
 
-use cluster::{topology::SchemaConfig, ClusterRef};
+use cluster::{config::SchemaConfig, ClusterRef};
 
 use crate::schema_config_provider::{Result, SchemaConfigProvider};
 

--- a/server/src/schema_config_provider/config_based.rs
+++ b/server/src/schema_config_provider/config_based.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use cluster::topology::SchemaConfig;
+use cluster::config::SchemaConfig;
 
 use crate::schema_config_provider::{Result, SchemaConfigProvider};
 

--- a/server/src/schema_config_provider/config_based.rs
+++ b/server/src/schema_config_provider/config_based.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use cluster::SchemaConfig;
+use cluster::topology::SchemaConfig;
 
 use crate::schema_config_provider::{Result, SchemaConfigProvider};
 

--- a/server/src/schema_config_provider/mod.rs
+++ b/server/src/schema_config_provider/mod.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use cluster::topology::SchemaConfig;
+use cluster::config::SchemaConfig;
 use snafu::Snafu;
 
 pub mod cluster_based;

--- a/server/src/schema_config_provider/mod.rs
+++ b/server/src/schema_config_provider/mod.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use cluster::SchemaConfig;
+use cluster::topology::SchemaConfig;
 use snafu::Snafu;
 
 pub mod cluster_based;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #92 

# Rationale for this change
 The routing information when starting CeresDB with CeresMeta is stored in CeresMeta, and we need to provide such information to the clients by `route` grpc service.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Implement the router based on `Cluster`, and then provide the `route` gRPC service based on the router.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None because the `route` service is compatible.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Some new unit tests to ensure this PR.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
