### PR TITLE
fix: deadlock when reconnect heartbeat channel

### DIFF
--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -509,7 +509,6 @@ impl MetaClient for MetaClientImpl {
         // FIXME: reconnect the heartbeat channel iff specific errors occur.
         if send_res.is_err() {
             let client = self.inner.reconnect_heartbeat_channel().await;
-            drop(grpc_client);
             drop(grpc_client_guard);
             *self.inner.grpc_client.write().await = Some(client);
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Deadlock occurs when fail to send heartbeat stream and reconnect the gRPC server. Actually, `reconnect_hearbeat_channel` will take the write lock on the `grpc_client` but it is very implicit.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Avoid taking the write lock on the `grpc_client` in the `reconnect_heartbeat_channel`, and let the caller to update the `grpc_client` manually.
- Remove topology cache update procedure because it can't handle the updates.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
