### PR TITLE
feat: support to route for missing tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=ad6c1031bb8288445397b37670b3d4bdee0caa88#ad6c1031bb8288445397b37670b3d4bdee0caa88"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=8e54107e0255429313024822ec85b78561939d00#8e54107e0255429313024822ec85b78561939d00"
 dependencies = [
  "futures 0.3.21",
  "grpcio 0.9.1",
@@ -825,7 +825,7 @@ dependencies = [
 name = "ceresdbproto_deps"
 version = "0.1.0"
 dependencies = [
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=ad6c1031bb8288445397b37670b3d4bdee0caa88)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=8e54107e0255429313024822ec85b78561939d00)",
 ]
 
 [[package]]

--- a/analytic_engine/src/table_options.rs
+++ b/analytic_engine/src/table_options.rs
@@ -229,7 +229,7 @@ pub enum StorageFormat {
     /// Collapsible Columns within same primary key are collapsed
     /// into list, other columns are the same format with columar's.
     ///
-    /// Wether a column is collapsible is decided by
+    /// Whether a column is collapsible is decided by
     /// `Schema::is_collapsible_column`
     ///
     /// Note: minTime/maxTime is optional and not implemented yet, mainly used

--- a/catalog_impls/src/volatile.rs
+++ b/catalog_impls/src/volatile.rs
@@ -285,6 +285,7 @@ impl<T: TableIdAlloc> Schema for SchemaImpl<T> {
         request: CreateTableRequest,
         opts: CreateOptions,
     ) -> schema::Result<TableRef> {
+        // FIXME: Error should be returned if create_if_not_exist is false.
         if let Some(table) = self.get_table(
             &request.catalog_name,
             &request.schema_name,

--- a/ceresdbproto_deps/Cargo.toml
+++ b/ceresdbproto_deps/Cargo.toml
@@ -10,4 +10,4 @@ workspace = true
 
 [dependencies.ceresdbproto]
 git = "https://github.com/CeresDB/ceresdbproto.git"
-rev = "ad6c1031bb8288445397b37670b3d4bdee0caa88"
+rev = "8e54107e0255429313024822ec85b78561939d00"

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -38,6 +38,13 @@ pub enum Error {
         shard_id: ShardId,
         backtrace: Backtrace,
     },
+
+    #[snafu(display(
+        "Cluster nodes is not found in the topology, version:{}.\nBacktrace:\n{}",
+        version,
+        backtrace
+    ))]
+    ClusterNodesNotFound { version: u64, backtrace: Backtrace },
 }
 
 define_result!(Error);

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -15,6 +15,9 @@ use snafu::{Backtrace, Snafu};
 pub mod cluster_impl;
 pub mod config;
 mod table_manager;
+// FIXME: Remove this lint ignore derive when topology about schema tables is
+// finished.
+#[allow(dead_code)]
 pub mod topology;
 
 #[derive(Debug, Snafu)]

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -62,11 +62,17 @@ pub trait TableManipulator {
     ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
 }
 
+#[derive(Clone, Debug)]
+pub struct ClusterNodesResp {
+    pub cluster_topology_version: u64,
+    pub cluster_nodes: ClusterNodesRef,
+}
+
 /// Cluster manages tables and shard infos in cluster mode.
 #[async_trait]
 pub trait Cluster {
     async fn start(&self) -> Result<()>;
     async fn stop(&self) -> Result<()>;
     async fn route_tables(&self, req: &RouteTablesRequest) -> Result<RouteTablesResponse>;
-    async fn fetch_nodes(&self) -> Result<ClusterNodesRef>;
+    async fn fetch_nodes(&self) -> Result<ClusterNodesResp>;
 }

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -9,7 +9,7 @@ pub use meta_client::types::{
     AllocSchemaIdRequest, AllocSchemaIdResponse, AllocTableIdRequest, AllocTableIdResponse,
     DropTableRequest, GetShardTablesRequest,
 };
-use meta_client::types::{RouteTablesRequest, RouteTablesResponse, ShardId};
+use meta_client::types::{ClusterNodesRef, RouteTablesRequest, RouteTablesResponse, ShardId};
 use snafu::{Backtrace, Snafu};
 
 pub mod cluster_impl;
@@ -68,4 +68,5 @@ pub trait Cluster {
     async fn start(&self) -> Result<()>;
     async fn stop(&self) -> Result<()>;
     async fn route_tables(&self, req: &RouteTablesRequest) -> Result<RouteTablesResponse>;
+    async fn fetch_nodes(&self) -> Result<ClusterNodesRef>;
 }

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -43,7 +43,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Cluster nodes is not found in the topology, version:{}.\nBacktrace:\n{}",
+        "Cluster nodes are not found in the topology, version:{}.\nBacktrace:\n{}",
         version,
         backtrace
     ))]

--- a/cluster/src/table_manager.rs
+++ b/cluster/src/table_manager.rs
@@ -104,6 +104,7 @@ impl Inner {
             let shard_info = ShardInfo {
                 shard_id: *shard_id,
                 role: shard_tables.role,
+                version: shard_tables.version,
             };
             self.shard_infos.insert(*shard_id, shard_info.clone());
             for table in &shard_tables.tables {

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -20,19 +20,28 @@ pub enum RouteSlot {
 
 #[derive(Debug, Default)]
 struct SchemaTopology {
-    #[allow(dead_code)]
     id: SchemaId,
-    #[allow(dead_code)]
     config: SchemaConfig,
     /// The [RouteSlot] in the `route_slots` only can be `Exist` or `NotExist`.
     route_slots: HashMap<TableName, RouteSlot>,
 }
 
 #[derive(Debug, Default)]
-pub struct ClusterTopology {
+pub struct SchemaTopologies {
     version: u64,
-    schema_topologies: HashMap<SchemaName, SchemaTopology>,
-    nodes: Option<ClusterNodesRef>,
+    topologies: HashMap<SchemaName, SchemaTopology>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct NodeTopology {
+    pub version: u64,
+    pub nodes: ClusterNodesRef,
+}
+
+#[derive(Debug, Default)]
+pub struct ClusterTopology {
+    schemas: Option<SchemaTopologies>,
+    nodes: Option<NodeTopology>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -51,15 +60,9 @@ impl From<RouteTablesResult> for RouteTablesResponse {
     }
 }
 
-impl ClusterTopology {
-    /// Any update on the topology should ensure the version is valid: the
-    /// target version must be not older than the current version.
-    pub fn is_outdated_version(&self, version: u64) -> bool {
-        version >= self.version
-    }
-
-    pub fn route_tables(&self, schema_name: &str, tables: &[TableName]) -> RouteTablesResult {
-        if let Some(schema_topology) = self.schema_topologies.get(schema_name) {
+impl SchemaTopologies {
+    fn route_tables(&self, schema_name: &str, tables: &[TableName]) -> RouteTablesResult {
+        if let Some(schema_topology) = self.topologies.get(schema_name) {
             let mut route_entries = HashMap::with_capacity(tables.len());
             let mut missing_tables = vec![];
 
@@ -91,40 +94,63 @@ impl ClusterTopology {
     /// valid.
     ///
     /// Return false if the version is outdated.
-    pub fn update_tables(
+    fn maybe_update_tables(
         &mut self,
         schema_name: &str,
         tables: HashMap<TableName, RouteSlot>,
         version: u64,
     ) -> bool {
-        if self.is_outdated_version(version) {
+        if ClusterTopology::is_outdated_version(self.version, version) {
             return false;
         }
 
-        self.schema_topologies
+        self.topologies
             .entry(schema_name.to_string())
             .or_insert_with(Default::default)
             .update_tables(tables);
 
         true
     }
+}
 
-    pub fn nodes(&self) -> Option<ClusterNodesRef> {
-        self.nodes.clone()
-    }
-
-    pub fn update_nodes(&mut self, nodes: ClusterNodesRef, version: u64) -> bool {
-        if self.is_outdated_version(version) {
+impl NodeTopology {
+    fn maybe_update_nodes(&mut self, nodes: ClusterNodesRef, version: u64) -> bool {
+        if ClusterTopology::is_outdated_version(self.version, version) {
             return false;
         }
 
-        self.nodes = Some(nodes);
+        self.nodes = nodes;
 
         true
     }
+}
 
-    pub fn version(&self) -> u64 {
-        self.version
+impl ClusterTopology {
+    /// Any update on the topology should ensure the version is valid: the
+    /// target version must not be older than the current version.
+    fn is_outdated_version(current_version: u64, version: u64) -> bool {
+        version < current_version
+    }
+
+    pub fn nodes(&self) -> Option<NodeTopology> {
+        self.nodes.clone()
+    }
+
+    /// Try to update the nodes topology of the cluster.
+    ///
+    /// If the provided version is not newer, then the update will be
+    /// ignored.
+    pub fn maybe_update_nodes(&mut self, nodes: ClusterNodesRef, version: u64) -> bool {
+        if self.nodes.is_none() {
+            let nodes = NodeTopology { version, nodes };
+            self.nodes = Some(nodes);
+            return true;
+        }
+
+        self.nodes
+            .as_mut()
+            .unwrap()
+            .maybe_update_nodes(nodes, version)
     }
 }
 

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -6,7 +6,7 @@ use common_types::{
     schema::{SchemaId, SchemaName},
     table::TableName,
 };
-use meta_client::types::{RouteEntry, RouteTablesResponse};
+use meta_client::types::{ClusterNodesRef, RouteEntry, RouteTablesResponse};
 
 use crate::config::SchemaConfig;
 
@@ -32,6 +32,7 @@ struct SchemaTopology {
 pub struct ClusterTopology {
     version: u64,
     schema_topologies: HashMap<SchemaName, SchemaTopology>,
+    nodes: Option<ClusterNodesRef>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -104,6 +105,21 @@ impl ClusterTopology {
             .entry(schema_name.to_string())
             .or_insert_with(Default::default)
             .update_tables(tables);
+
+        true
+    }
+
+    pub fn nodes(&self) -> Option<ClusterNodesRef> {
+        self.nodes.clone()
+    }
+
+    pub fn update_nodes(&mut self, nodes: ClusterNodesRef, version: u64) -> bool {
+        if self.is_outdated_version(version) {
+            return false;
+        }
+
+        self.nodes = Some(nodes);
+
         true
     }
 }

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -122,6 +122,10 @@ impl ClusterTopology {
 
         true
     }
+
+    pub fn version(&self) -> u64 {
+        self.version
+    }
 }
 
 impl SchemaTopology {

--- a/meta_client/src/lib.rs
+++ b/meta_client/src/lib.rs
@@ -7,8 +7,9 @@ use common_util::define_result;
 use snafu::{Backtrace, Snafu};
 use types::{
     ActionCmd, AllocSchemaIdRequest, AllocSchemaIdResponse, AllocTableIdRequest,
-    AllocTableIdResponse, DropTableRequest, GetShardTablesRequest, GetShardTablesResponse,
-    RouteTablesRequest, RouteTablesResponse, ShardInfo,
+    AllocTableIdResponse, DropTableRequest, GetNodesRequest, GetNodesResponse,
+    GetShardTablesRequest, GetShardTablesResponse, RouteTablesRequest, RouteTablesResponse,
+    ShardInfo,
 };
 
 pub mod meta_impl;
@@ -136,6 +137,8 @@ pub trait MetaClient: Send + Sync {
     async fn get_tables(&self, req: GetShardTablesRequest) -> Result<GetShardTablesResponse>;
 
     async fn route_tables(&self, req: RouteTablesRequest) -> Result<RouteTablesResponse>;
+
+    async fn get_nodes(&self, req: GetNodesRequest) -> Result<GetNodesResponse>;
 
     async fn send_heartbeat(&self, req: Vec<ShardInfo>) -> Result<()>;
 }

--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -470,6 +470,8 @@ impl MetaClient for MetaClientImpl {
             .map_err(|e| Box::new(e) as _)
             .context(FailRouteTables)?;
 
+        debug!("get_nodes response:{:?}, request:{:?}", pb_resp, pb_req);
+
         check_response_header(pb_resp.get_header())?;
         Ok(RouteTablesResponse::from(pb_resp))
     }
@@ -491,6 +493,8 @@ impl MetaClient for MetaClientImpl {
             .map_err(|e| Box::new(e) as _)
             .context(FailRouteTables)?;
 
+        debug!("get_nodes response:{:?}, request:{:?}", pb_resp, pb_req);
+
         check_response_header(pb_resp.get_header())?;
         Ok(GetNodesResponse::from(pb_resp))
     }
@@ -505,22 +509,22 @@ impl MetaClient for MetaClientImpl {
         let grpc_client_guard = self.inner.grpc_client.read().await;
         let grpc_client = grpc_client_guard.as_ref().context(FailGetGrpcClient)?;
 
-        let mut pb_request = meta_service::NodeHeartbeatRequest::new();
-        pb_request.set_header(self.inner.request_header().into());
+        let mut pb_req = meta_service::NodeHeartbeatRequest::new();
+        pb_req.set_header(self.inner.request_header().into());
         let node_info = NodeInfo {
             node_meta_info: self.inner.node_meta_info(),
             shards_info,
         };
-        pb_request.set_info(node_info.into());
+        pb_req.set_info(node_info.into());
 
-        info!("Meta client send heartbeat req:{:?}", pb_request);
+        info!("Meta client send heartbeat req:{:?}", pb_req);
 
         let send_res = grpc_client
             .heartbeat_channel
             .write()
             .await
             .heartbeat_sender
-            .send((pb_request, WriteFlags::default()))
+            .send((pb_req, WriteFlags::default()))
             .await
             .map_err(|e| Box::new(e) as _)
             .context(FailSendHeartbeat {

--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -470,7 +470,10 @@ impl MetaClient for MetaClientImpl {
             .map_err(|e| Box::new(e) as _)
             .context(FailRouteTables)?;
 
-        debug!("get_nodes response:{:?}, request:{:?}", pb_resp, pb_req);
+        debug!(
+            "Meta client route tables, req:{:?}, resp:{:?}",
+            pb_req, pb_resp
+        );
 
         check_response_header(pb_resp.get_header())?;
         Ok(RouteTablesResponse::from(pb_resp))
@@ -493,7 +496,10 @@ impl MetaClient for MetaClientImpl {
             .map_err(|e| Box::new(e) as _)
             .context(FailRouteTables)?;
 
-        debug!("get_nodes response:{:?}, request:{:?}", pb_resp, pb_req);
+        debug!(
+            "Meta client get nodes, req:{:?}, resp:{:?}",
+            pb_req, pb_resp
+        );
 
         check_response_header(pb_resp.get_header())?;
         Ok(GetNodesResponse::from(pb_resp))

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -120,7 +120,7 @@ pub struct NodeHeartbeatResponse {
     pub action_cmd: Option<ActionCmd>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShardInfo {
     pub shard_id: ShardId,
     pub role: ShardRole,
@@ -417,7 +417,7 @@ pub struct RouteTablesRequest {
     pub table_names: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeShard {
     pub endpoint: String,
     pub shard_info: ShardInfo,

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -436,7 +436,7 @@ pub struct RouteTablesResponse {
 }
 
 impl RouteTablesResponse {
-    pub fn contains_missing_table(&self, queried_tables: &[TableName]) -> bool {
+    pub fn contains_all_tables(&self, queried_tables: &[TableName]) -> bool {
         queried_tables
             .iter()
             .all(|table_name| self.entries.contains_key(table_name))

--- a/server/src/route/cluster_based.rs
+++ b/server/src/route/cluster_based.rs
@@ -34,7 +34,7 @@ impl ClusterBasedRouter {
         route_resp: &RouteTablesResponse,
         route_result: &mut Vec<Route>,
     ) -> Result<()> {
-        if !route_resp.contains_missing_table(queried_tables) {
+        if route_resp.contains_all_tables(queried_tables) {
             return Ok(());
         }
 

--- a/server/src/route/cluster_based.rs
+++ b/server/src/route/cluster_based.rs
@@ -45,7 +45,7 @@ impl ClusterBasedRouter {
             .map_err(|e| Box::new(e) as _)
             .context(ErrWithCause {
                 code: StatusCode::InternalError,
-                msg: "fail to fetch cluster nodes",
+                msg: "Failed to fetch cluster nodes",
             })?;
 
         if cluster_nodes_resp.cluster_nodes.is_empty() {
@@ -77,7 +77,7 @@ impl ClusterBasedRouter {
     }
 }
 
-/// Make a route according the table name and the raw endpoint.
+/// Make a route according to the table name and the raw endpoint.
 fn make_route(table_name: &str, endpoint: &str) -> Result<Route> {
     let mut route = Route::default();
     let endpoint: Endpoint = endpoint.parse().with_context(|| ErrWithCause {
@@ -104,7 +104,7 @@ impl Router for ClusterBasedRouter {
             .map_err(|e| Box::new(e) as _)
             .context(ErrWithCause {
                 code: StatusCode::InternalError,
-                msg: "Fail to route tables by cluster",
+                msg: "Failed to route tables by cluster",
             })?;
 
         let mut routes = Vec::with_capacity(route_resp.entries.len());
@@ -206,7 +206,7 @@ mod tests {
                     assert!(node_shard.shard_info.is_leader());
                 }
 
-                // pick again and check whether they are the same.
+                // Pick again and check whether they are the same.
                 let picked_again_node_shard = pick_node_for_table(table_name, &node_shards);
                 assert_eq!(picked_node_shard, picked_again_node_shard);
             }

--- a/server/src/route/cluster_based.rs
+++ b/server/src/route/cluster_based.rs
@@ -5,14 +5,15 @@
 use async_trait::async_trait;
 use ceresdbproto_deps::ceresdbproto::storage::{Route, RouteRequest};
 use cluster::ClusterRef;
+use common_types::table::TableName;
 use log::warn;
-use meta_client::types::RouteTablesRequest;
+use meta_client::types::{RouteTablesRequest, RouteTablesResponse};
 use snafu::ResultExt;
 
 use crate::{
     config::Endpoint,
     error::{ErrWithCause, Result, StatusCode},
-    route::Router,
+    route::{hash, Router},
 };
 
 pub struct ClusterBasedRouter {
@@ -23,6 +24,64 @@ impl ClusterBasedRouter {
     pub fn new(cluster: ClusterRef) -> Self {
         Self { cluster }
     }
+
+    /// For missing tables in the topology, the Router will choose random nodes
+    /// for them so that some requests such as create table, can also find a
+    /// node to be served.
+    async fn route_for_missing_tables(
+        &self,
+        queried_tables: &[TableName],
+        route_resp: &RouteTablesResponse,
+        route_result: &mut Vec<Route>,
+    ) -> Result<()> {
+        if !route_resp.contains_missing_table(queried_tables) {
+            return Ok(());
+        }
+
+        let cluster_nodes = self
+            .cluster
+            .fetch_nodes()
+            .await
+            .map_err(|e| Box::new(e) as _)
+            .context(ErrWithCause {
+                code: StatusCode::InternalError,
+                msg: "fail to fetch cluster nodes",
+            })?;
+
+        if cluster_nodes.is_empty() {
+            warn!("Cluster has no nodes for route response");
+            return Ok(());
+        }
+
+        // Check wether some tables are missing, and pick some nodes for them if any.
+        for table_name in queried_tables {
+            if route_resp.entries.contains_key(table_name) {
+                continue;
+            }
+
+            // The cluster_nodes has been ensured not empty.
+            let random_idx = hash::hash_metric(table_name) as usize % cluster_nodes.len();
+            let random_node = &cluster_nodes[random_idx];
+
+            let route = make_route(table_name, &random_node.endpoint)?;
+            route_result.push(route);
+        }
+
+        Ok(())
+    }
+}
+
+/// Make a route according the table name and the raw endpoint.
+fn make_route(table_name: &str, endpoint: &str) -> Result<Route> {
+    let mut route = Route::default();
+    let endpoint: Endpoint = endpoint.parse().with_context(|| ErrWithCause {
+        code: StatusCode::InternalError,
+        msg: format!("Failed to parse endpoint:{}", endpoint),
+    })?;
+    route.set_metric(table_name.to_string());
+    route.set_endpoint(endpoint.into());
+
+    Ok(route)
 }
 
 #[async_trait]
@@ -44,24 +103,13 @@ impl Router for ClusterBasedRouter {
 
         let mut routes = Vec::with_capacity(route_resp.entries.len());
 
+        self.route_for_missing_tables(&route_tables_req.table_names, &route_resp, &mut routes)
+            .await?;
         // Now we pick up the nodes who own the leader shard for the route response.
         for (table_name, route_entry) in route_resp.entries {
             for node_shard in route_entry.node_shards {
                 if node_shard.shard_info.is_leader() {
-                    let mut route = Route::default();
-                    let endpoint: Endpoint = match node_shard.endpoint.parse() {
-                        Ok(v) => v,
-                        Err(msg) => {
-                            warn!(
-                                "Ignore this endpoint for parsing failed:{}, endpoint:{}",
-                                msg, node_shard.endpoint
-                            );
-                            continue;
-                        }
-                    };
-                    route.set_metric(table_name.clone());
-                    route.set_endpoint(endpoint.into());
-
+                    let route = make_route(&table_name, &node_shard.endpoint)?;
                     routes.push(route);
                 }
             }

--- a/server/src/route/hash.rs
+++ b/server/src/route/hash.rs
@@ -8,8 +8,22 @@ use twox_hash::XxHash64;
 /// result!
 const HASH_SEED: u64 = 0;
 
-pub(crate) fn hash_metric(metric: &str) -> u64 {
+pub(crate) fn hash_table(table: &str) -> u64 {
     let mut hasher = XxHash64::with_seed(HASH_SEED);
-    metric.hash(&mut hasher);
+    table.hash(&mut hasher);
     hasher.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_table_to_determined_id() {
+        let tables = ["aaa", "bbb", "", "*x21"];
+        for table in tables {
+            let id = hash_table(table);
+            assert_eq!(id, hash_table(table));
+        }
+    }
 }

--- a/server/src/route/hash.rs
+++ b/server/src/route/hash.rs
@@ -1,0 +1,15 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::hash::{Hash, Hasher};
+
+use twox_hash::XxHash64;
+
+/// Hash seed to build hasher. Modify the seed will result in different route
+/// result!
+const HASH_SEED: u64 = 0;
+
+pub(crate) fn hash_metric(metric: &str) -> u64 {
+    let mut hasher = XxHash64::with_seed(HASH_SEED);
+    metric.hash(&mut hasher);
+    hasher.finish()
+}

--- a/server/src/route/mod.rs
+++ b/server/src/route/mod.rs
@@ -8,6 +8,7 @@ use ceresdbproto_deps::ceresdbproto::storage::{Route, RouteRequest};
 use crate::error::Result;
 
 pub mod cluster_based;
+pub(crate) mod hash;
 pub mod rule_based;
 
 pub use cluster_based::ClusterBasedRouter;

--- a/server/src/route/rule_based.rs
+++ b/server/src/route/rule_based.rs
@@ -113,7 +113,7 @@ impl RuleBasedRouter {
 
         if let Some(hash_rule) = rule_list.hash_rules.get(0) {
             let total_shards = hash_rule.shards.len();
-            let hash_value = hash::hash_metric(metric);
+            let hash_value = hash::hash_table(metric);
             let index = hash_value as usize % total_shards;
 
             return Some(hash_rule.shards[index]);
@@ -124,7 +124,7 @@ impl RuleBasedRouter {
 
     #[inline]
     fn route_by_hash(metric: &str, total_shards: usize) -> ShardId {
-        let hash_value = hash::hash_metric(metric);
+        let hash_value = hash::hash_table(metric);
         (hash_value as usize % total_shards) as ShardId
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 For a table that haven't been created, the cluster-based router will respond with no nodes, but that is unacceptable for creating table request.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
For a table that doesn't exist, the cluster-based router will pick one random node in the cluster for that.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Route request for non-existed table will be replied with a random node.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by manually with client.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
