### PR TITLE
fix: flush of one table might be triggered multiple times

### DIFF
--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -74,6 +74,18 @@ impl Instance {
             return Ok(false);
         }
 
+        worker_local
+            .validate_table_data(
+                &table_data.name,
+                table_data.id.as_u64() as usize,
+                self.write_group_worker_num,
+            )
+            .context(OperateByWriteWorker {
+                space_id: table_data.space_id,
+                table: &table_data.name,
+                table_id: table_data.id,
+            })?;
+
         // Fixme(xikai): Trigger a force flush so that the data of the table in the wal
         //  is marked for deletable. However, the overhead of the flushing can
         //  be avoided.

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -267,6 +267,14 @@ impl Instance {
         worker_local: &mut WorkerLocal,
         table_data: &TableDataRef,
     ) -> Result<TableFlushRequest> {
+        worker_local
+            .validate_table_data(
+                &table_data.name,
+                table_data.id.as_u64() as usize,
+                self.write_group_worker_num,
+            )
+            .context(BackgroundFlushFailed)?;
+
         let current_version = table_data.current_version();
         let last_sequence = table_data.last_sequence();
         // Switch (freeze) all mutable memtables. And update segment duration if

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -126,7 +126,7 @@ pub enum Error {
         "Failed to write/flush table data, this table:{} does not belong to this worker: {}",
         source
     ))]
-    DataNotLegal { table: String, worker_id: u64 },
+    DataNotLegal { table: String, worker_id: usize },
 }
 
 define_result!(Error);
@@ -321,7 +321,7 @@ impl Instance {
         let worker_id = worker_local.worker_id();
         let worker_num = space.write_group.worker_num();
         ensure!(
-            table_data.id.as_u64() % worker_num != worker_id,
+            table_data.id.as_u64() as usize % worker_num != worker_id,
             DataNotLegal {
                 table: &table_data.name,
                 worker_id: worker_id

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -321,7 +321,7 @@ impl Instance {
         let worker_id = worker_local.worker_id();
         let worker_num = space.write_group.worker_num();
         ensure!(
-            table_data.id.as_u64() % worker_id != worker_local.worker_id(),
+            table_data.id.as_u64() % worker_num != worker_id,
             DataNotLegal {
                 table: &table_data.name,
                 worker_id: worker_id

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -332,9 +332,10 @@ impl Instance {
             }
         }
 
+        let worker_index = worker_local.worker_id();
         if self.should_flush_instance() {
             if let Some(space) = self.space_store.find_maximum_memory_usage_space() {
-                if let Some(table) = space.find_maximum_memory_usage_table() {
+                if let Some(table) = space.find_maximum_memory_usage_table(worker_index) {
                     info!("Trying to flush table {} bytes {} in space {} because engine total memtable memory usage exceeds db_write_buffer_size {}.",
                           table.name,
                           table.memtable_memory_usage(),
@@ -347,7 +348,7 @@ impl Instance {
         }
 
         if space.should_flush_space() {
-            if let Some(table) = space.find_maximum_memory_usage_table() {
+            if let Some(table) = space.find_maximum_memory_usage_table(worker_index) {
                 info!("Trying to flush table {} bytes {} in space {} because space total memtable memory usage exceeds space_write_buffer_size {}.",
                       table.name,
                       table.memtable_memory_usage() ,

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -124,7 +124,8 @@ pub enum Error {
 
     #[snafu(display(
         "Failed to write/flush table data, this table:{} does not belong to this worker: {}",
-        source
+        table,
+        worker_id
     ))]
     DataNotLegal { table: String, worker_id: usize },
 }
@@ -324,7 +325,7 @@ impl Instance {
             table_data.id.as_u64() as usize % worker_num != worker_id,
             DataNotLegal {
                 table: &table_data.name,
-                worker_id: worker_id
+                worker_id
             }
         );
 

--- a/analytic_engine/src/instance/write_worker.rs
+++ b/analytic_engine/src/instance/write_worker.rs
@@ -285,6 +285,10 @@ impl WorkerLocal {
         let data = self.data.clone();
         CompactionNotifier::new(data)
     }
+
+    pub fn worker_id(&self) -> usize {
+        self.data.as_ref().id
+    }
 }
 
 /// Write table command.
@@ -642,6 +646,10 @@ impl WriteGroup {
         let worker_data = self.worker_datas[index].clone();
 
         WriteHandle { worker_data }
+    }
+
+    pub fn worker_num(&self) -> usize {
+        self.worker_datas.len()
     }
 }
 

--- a/analytic_engine/src/space.rs
+++ b/analytic_engine/src/space.rs
@@ -113,13 +113,15 @@ impl Space {
         self.write_buffer_size > 0 && self.memtable_memory_usage() >= self.write_buffer_size
     }
 
-    /// Find the table in space which it's memtable consumes maximum memory.
+    /// Find the table whose memtable consumes the most memory in the space by
+    /// specifying Worker.
     #[inline]
-    pub fn find_maximum_memory_usage_table(&self) -> Option<TableDataRef> {
+    pub fn find_maximum_memory_usage_table(&self, worker_index: usize) -> Option<TableDataRef> {
+        let worker_num = self.write_group.worker_num();
         self.table_datas
             .read()
             .unwrap()
-            .find_maximum_memory_usage_table()
+            .find_maximum_memory_usage_table(worker_num, worker_index)
     }
 
     #[inline]

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -529,10 +529,16 @@ impl TableDataSet {
         self.table_datas.len()
     }
 
-    /// Find the table which consumes maximum memtable memory usag.
-    pub fn find_maximum_memory_usage_table(&self) -> Option<TableDataRef> {
+    /// Find the table that the current WorkerLocal belongs to and consumes the
+    /// largest memtable memory usage.
+    pub fn find_maximum_memory_usage_table(
+        &self,
+        worker_num: usize,
+        worker_index: usize,
+    ) -> Option<TableDataRef> {
         self.table_datas
             .values()
+            .filter(|t| t.id.as_u64() as usize % worker_num == worker_index)
             .max_by_key(|t| t.memtable_memory_usage())
             .cloned()
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #183 

# Rationale for this change
 
* A table may be flushed multiple times.
* A table may be operated by another `WorkerLocal` which will break our concurrent invariant "The worker is single threaded and holding this is equivalent to holding a write lock"

# What changes are included in this PR?

I added the action to filter out the tables it owns based on the current `workerlocal`.

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
