### PR TITLE
fix:fix license check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           rustup component add rustfmt
       - name: Run
         run: |
+          make check-license
           make clippy
           make fmt
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ test-ut:
 fmt:
 	cd $(DIR); cargo fmt -- --check
 
+check-license:
+	cd $(DIR); sh scripts/check-license.sh
+
 clippy:
 	cd $(DIR); cargo clippy --all-targets --all-features --workspace -- -D warnings
 

--- a/analytic_engine/src/role_table/leader.rs
+++ b/analytic_engine/src/role_table/leader.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 use std::{
     collections::HashMap,
     sync::{

--- a/analytic_engine/src/role_table/mod.rs
+++ b/analytic_engine/src/role_table/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;

--- a/analytic_engine/src/sst/parquet/index.rs
+++ b/analytic_engine/src/sst/parquet/index.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::process::id;

--- a/etc/license.template
+++ b/etc/license.template
@@ -1,1 +1,0 @@
-// Copyright {\d+} CeresDB Project Authors. Licensed under Apache-2.0.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -10,5 +10,3 @@ format_code_in_doc_comments = true
 reorder_impl_items = true
 # Discard existing import groups, and create three groups for std, external crates, crates
 group_imports = "StdExternalCrate"
-
-license_template_path = "etc/license.template"

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Check all source files have a license header.
+set -eu
+
+for i in $(git ls-files --exclude-standard | grep "\.rs"); do
+    # first line -> match -> print line -> quit
+    matches=$(sed -n "1{/Copyright [0-9]\{4\} CeresDB Project Authors. Licensed under Apache-2.0./p;};q;" $i)
+    if [ -z "${matches}" ]; then
+        echo "License header is missing from $i."
+        exit 1
+    fi
+done
+
+echo "License check passed."

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 use async_trait::async_trait;
 use catalog::{
     manager::ManagerRef as CatalogManagerRef,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Referring to https://github.com/rust-lang/rustfmt/pull/5246, `rust fmt` no longer provides license checking.
 We need to check the file license in another way.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Use  a script to check the file license.
Refer to https://github.com/tikv/tikv/commit/8be0b14d34382eaa7ff9814714af19043547466e
Thanks tikv.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
