### PR TITLE
chore: fix submodule init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         rust: [nightly-2022-08-08]
     steps:
       - uses: actions/checkout@v3
-        # with:
-        #   submodules: true
+        with:
+          submodules: recursive
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${{ matrix.rust }} --profile minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
       - name: Run Tests
         run: |
           cp ${LOCK_FILE} ${LOCK_FILE}.bak
-          git clone https://github.com/apache/parquet-testing.git components/parquet-testing
           make test-ut
           echo "Checking if ${LOCK_FILE} has changed..."
           diff ${LOCK_FILE} ${LOCK_FILE}.bak

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          submodules: recursive
+          submodules: true
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${{ matrix.rust }} --profile minimal
@@ -82,8 +82,8 @@ jobs:
         rust: [nightly-2022-08-08]
     steps:
       - uses: actions/checkout@v3
-        # with:
-        #   submodule: true
+        with:
+          submodules: true
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${{ matrix.rust }} --profile minimal

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -8,6 +8,8 @@ on:
       - 'Dockerfile'
       - 'docker/**'
   push:
+    branches:
+      - main
     paths:
       - '.github/workflows/docker-build-image.yml'
       - 'Dockerfile'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 .DS_Store
 .idea/
 .vscode
+results.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ target
 .DS_Store
 .idea/
 .vscode
-results.json

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,8 @@ test-ut:
 	echo $(CARGO_INCREMENTAL)
 	echo $(RUSTFLAGS)
 	echo $(RUSTDOCFLAGS)
-#	cd $(DIR); cargo test --workspace -- -Z unstable-options --format json | tee results.json; \
-# 	cat results.json | cargo2junit > ${WORKSPACE}/testresult/TEST-all.xml
-	cd $(DIR); cargo test --workspace
+	cd $(DIR); cargo test --workspace -- -Z unstable-options --format json | tee results.json; \
+ 	cat results.json | cargo2junit > ${WORKSPACE}/testresult/TEST-all.xml
 
 fmt:
 	cd $(DIR); cargo fmt -- --check

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ test-ut:
 	echo $(CARGO_INCREMENTAL)
 	echo $(RUSTFLAGS)
 	echo $(RUSTDOCFLAGS)
-	cd $(DIR); cargo test --workspace -- -Z unstable-options --format json | tee results.json; \
- 	cat results.json | cargo2junit > ${WORKSPACE}/testresult/TEST-all.xml
+	#cd $(DIR); cargo test --workspace -- -Z unstable-options --format json | tee results.json; \
+ 	#cat results.json | cargo2junit > ${WORKSPACE}/testresult/TEST-all.xml
+	cargo test --workspace
 
 fmt:
 	cd $(DIR); cargo fmt -- --check


### PR DESCRIPTION
# Which issue does this PR close?

Closes #11 

# Rationale for this change
 Now the submodule is initialized by cloning the repo manually, and actually it can be fetched by checkout action.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Let the submodule be initialized by `checkout` action.
- Adjust the trigger condition (only when pushed to `main` branch) for `docker-build-image.yml`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No need to test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
