### PR TITLE
feat: add scan batch size options

### DIFF
--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -175,6 +175,8 @@ pub struct Instance {
     pub(crate) space_write_buffer_size: usize,
     /// replay wal batch size
     pub(crate) replay_batch_size: usize,
+    /// batch size for scan sst
+    pub(crate) scan_batch_size: usize,
 }
 
 impl Instance {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -88,6 +88,7 @@ impl Instance {
             db_write_buffer_size: ctx.config.db_write_buffer_size,
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
+            scan_batch_size: ctx.config.scan_batch_size,
         });
 
         Ok(instance)

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -94,7 +94,7 @@ impl Instance {
         // Collect metrics.
         table_data.metrics.on_read_request_begin();
 
-        let iter_options = IterOptions::default();
+        let iter_options = IterOptions::new(self.scan_batch_size);
         let table_options = table_data.table_options();
 
         if need_merge_sort_streams(&table_data.table_options(), &request) {

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -69,6 +69,9 @@ pub struct Config {
     pub db_write_buffer_size: usize,
     // End of global write buffer options.
 
+    // Batch size for scan sst
+    pub scan_batch_size: usize,
+
     // Obkv wal config.
     pub obkv_wal: ObkvWalConfig,
 }
@@ -95,6 +98,7 @@ impl Default for Config {
             /// Zero means disabling this param, give a positive value to enable
             /// it.
             db_write_buffer_size: 0,
+            scan_batch_size: 500,
             obkv_wal: ObkvWalConfig::default(),
         }
     }

--- a/analytic_engine/src/row_iter/mod.rs
+++ b/analytic_engine/src/row_iter/mod.rs
@@ -30,9 +30,15 @@ pub struct IterOptions {
     pub batch_size: usize,
 }
 
+impl IterOptions {
+    pub fn new(batch_size: usize) -> Self {
+        Self { batch_size }
+    }
+}
+
 impl Default for IterOptions {
     fn default() -> Self {
-        Self { batch_size: 500 }
+        Self::new(500)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
For now, iter scan size is hard coded, add an option to configure it.

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Start server with this config
```
[analytic]
wal_path = "/path/to/data"
sst_data_cache_cap = 10000
sst_meta_cache_cap = 10000
scan_batch_size = 10000
```
