### PR TITLE
fix: null buffer assert

### DIFF
--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -539,7 +539,7 @@ impl HybridRecordDecoder {
         // construct new expanded array
         let mut new_offsets_buffer = MutableBuffer::new(OFFSET_SIZE * values_num);
         let mut new_values_buffer = MutableBuffer::new(value_bytes as usize);
-        let mut new_null_buffer = hybrid::new_null_buffer_with_ones(values_num);
+        let mut new_null_buffer = hybrid::new_ones_buffer(values_num);
         let null_slice = new_null_buffer.as_slice_mut();
         let mut value_length_so_far: i32 = 0;
         new_offsets_buffer.push(value_length_so_far);
@@ -599,7 +599,7 @@ impl HybridRecordDecoder {
         let old_null_bitmap = array_ref.data().null_bitmap();
 
         let mut new_values_buffer = MutableBuffer::new(value_size * values_num);
-        let mut new_null_buffer = hybrid::new_null_buffer_with_ones(values_num);
+        let mut new_null_buffer = hybrid::new_ones_buffer(values_num);
         let null_slice = new_null_buffer.as_slice_mut();
         let mut length_so_far = 0;
 

--- a/analytic_engine/src/sst/parquet/hybrid.rs
+++ b/analytic_engine/src/sst/parquet/hybrid.rs
@@ -205,7 +205,7 @@ impl ListArrayBuilder {
         // null_bitmap is None
         //
         // Note: bit set to 1 means value is not null.
-        let mut null_buffer = new_null_buffer_with_ones(values_num);
+        let mut null_buffer = new_ones_buffer(values_num);
         let null_slice = null_buffer.as_slice_mut();
 
         let mut length_so_far: i32 = 0;
@@ -564,7 +564,7 @@ pub fn convert_to_hybrid_record(
 }
 
 /// Return a MutableBuffer with bits all set to 1
-pub fn new_null_buffer_with_ones(len: usize) -> MutableBuffer {
+pub fn new_ones_buffer(len: usize) -> MutableBuffer {
     let null_buffer = MutableBuffer::new_null(len);
     let buf_cap = null_buffer.capacity();
     null_buffer.with_bitset(buf_cap, true)
@@ -727,7 +727,7 @@ mod tests {
         let sizes = [1, 8, 11, 20, 511];
 
         for size in &sizes {
-            let _ = new_null_buffer_with_ones(*size);
+            let _ = new_ones_buffer(*size);
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #255 

# Rationale for this change
 
When `new_null` buffer, buffer capacity will be ceiled by 8, so its capacity will be less than what's passed in.

# What changes are included in this PR?

Add new method `new_null_buffer_with_ones` to create a null buffer filled with ones.

# Are there any user-facing changes?

No

# How does this change test

Add unit test `new_null_buffer_with_different_size`