### PR TITLE
feat: support default value option of column  like mysql

### DIFF
--- a/common_types/src/tests.rs
+++ b/common_types/src/tests.rs
@@ -95,6 +95,23 @@ fn default_value_schema_builder() -> schema::Builder {
                 .expect("should succeed build column schema"),
         )
         .unwrap()
+        .add_normal_column(
+            column_schema::Builder::new("field4".to_string(), DatumKind::UInt32)
+                .build()
+                .expect("should succeed build column schema"),
+        )
+        .unwrap()
+        .add_normal_column(
+            column_schema::Builder::new("field5".to_string(), DatumKind::UInt32)
+                .default_value(Some(Expr::BinaryOp {
+                    left: Box::new(Expr::Identifier("field4".into())),
+                    op: BinaryOperator::Plus,
+                    right: Box::new(Expr::Value(Value::Number("2".to_string(), false))),
+                }))
+                .build()
+                .expect("should succeed build column schema"),
+        )
+        .unwrap()
 }
 
 /// Build a schema for testing:
@@ -104,8 +121,12 @@ pub fn build_schema() -> Schema {
 }
 
 /// Build a schema for testing:
-/// (key1(varbinary), key2(timestamp), field1(int64, default 10),
-/// field2(uint32, default 20)), field3(uint32, default 1 + 2)
+/// key1(varbinary), key2(timestamp),
+/// field1(int64, default 10),
+/// field2(uint32, default 20),
+/// field3(uint32, default 1 + 2)
+/// field4(uint32),
+/// field5(uint32, default field4 + 2)
 pub fn build_default_value_schema() -> Schema {
     default_value_schema_builder().build().unwrap()
 }

--- a/server/src/grpc/write.rs
+++ b/server/src/grpc/write.rs
@@ -2,7 +2,7 @@
 
 //! Write handler
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use ceresdbproto::storage::{value, WriteEntry, WriteMetric, WriteRequest, WriteResponse};
 use common_types::{
@@ -260,7 +260,7 @@ fn write_metric_to_insert_plan(table: TableRef, write_metric: WriteMetric) -> Re
     Ok(InsertPlan {
         table,
         rows: row_group,
-        default_value_map: HashMap::new(),
+        default_value_map: BTreeMap::new(),
     })
 }
 

--- a/sql/src/plan.rs
+++ b/sql/src/plan.rs
@@ -124,7 +124,7 @@ pub struct InsertPlan {
     pub rows: RowGroup,
     /// Column indexes in schema to its default-value-expr which is used to fill
     /// values
-    pub default_value_map: HashMap<usize, DfLogicalExpr>,
+    pub default_value_map: BTreeMap<usize, DfLogicalExpr>,
 }
 
 #[derive(Debug)]

--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -11,7 +11,7 @@ use std::{
 
 use arrow::{
     compute::can_cast_types,
-    datatypes::{DataType as ArrowDataType, Schema as ArrowSchema},
+    datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
 };
 use common_types::{
     column_schema::{self, ColumnSchema},
@@ -28,7 +28,6 @@ use datafusion::{
     sql::planner::SqlToRel,
 };
 use datafusion_expr::expr_rewriter::ExprRewritable;
-use df_operator::visitor::find_columns_by_expr;
 use hashbrown::HashMap as NoStdHashMap;
 use log::debug;
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
@@ -336,9 +335,6 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
             .map(|col| Ok((col.name.value.as_str(), parse_column(col)?)))
             .collect::<Result<BTreeMap<_, _>>>()?;
 
-        // analyze default value options
-        analyze_column_default_value_options(&name_column_map, &self.meta_provider)?;
-
         // Tsid column is a reserved column.
         ensure!(
             !name_column_map.contains_key(TSID_COLUMN),
@@ -432,6 +428,9 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
 
         let options = parse_options(stmt.options)?;
 
+        // Analyze default values
+        analyze_column_default_value_options_v2(table_schema.columns(), &self.meta_provider)?;
+
         let plan = CreateTablePlan {
             engine: stmt.engine,
             if_not_exists: stmt.if_not_exists,
@@ -509,7 +508,7 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
                 // Index in insert values stmt of each column in table schema
                 let mut column_index_in_insert = Vec::with_capacity(schema.num_columns());
                 // Column index in schema to its default-value-expr
-                let mut default_value_map = HashMap::new();
+                let mut default_value_map = BTreeMap::new();
 
                 // Check all not null columns are provided in stmt, also init
                 // `column_index_in_insert`
@@ -834,39 +833,20 @@ fn parse_column(col: &ColumnDef) -> Result<ColumnSchema> {
 }
 
 // Analyze default value exprs.
-fn analyze_column_default_value_options<'a, P: MetaProvider>(
-    name_column_map: &BTreeMap<&str, ColumnSchema>,
+fn analyze_column_default_value_options_v2<'a, P: MetaProvider>(
+    columns: &[ColumnSchema],
     meta_provider: &ContextProviderAdapter<'a, P>,
 ) -> Result<()> {
     let df_planner = SqlToRel::new(meta_provider);
-    let df_fields = name_column_map
-        .iter()
-        .map(|(name, column_def)| {
-            DFField::new(
-                None,
-                name,
-                column_def.data_type.to_arrow_data_type(),
-                column_def.is_nullable,
-            )
-        })
-        .collect::<Vec<_>>();
-    let df_schema =
-        DFSchema::new_with_metadata(df_fields, HashMap::new()).context(DataFusionSchema)?;
-    for column_def in name_column_map.values() {
+    let mut df_schema = DFSchema::empty();
+    let mut arrow_schema = ArrowSchema::empty();
+
+    for column_def in columns.iter() {
         if let Some(expr) = &column_def.default_value {
             let df_logical_expr = df_planner
                 .sql_to_rex(expr.clone(), &df_schema, &mut NoStdHashMap::new())
                 .context(DataFusionExpr)?;
 
-            // Check input columns for the expr. Currently only support expr without input.
-            // Tracking issue: https://github.com/CeresDB/ceresdb/issues/252.
-            ensure!(
-                find_columns_by_expr(&df_logical_expr).is_empty(),
-                CreateWithComplexDefaultValue {
-                    name: column_def.name.clone(),
-                    default_value: expr.clone(),
-                }
-            );
             // Optimize expr
             let execution_props = ExecutionProps::default();
             let mut const_optimizer =
@@ -876,15 +856,12 @@ fn analyze_column_default_value_options<'a, P: MetaProvider>(
                 .context(DataFusionExpr)?;
 
             // Check if the return type of expr can cast to target type
-            let physical_expr = create_physical_expr(
-                &evaluated_expr,
-                &DFSchema::empty(),
-                &ArrowSchema::empty(),
-                &execution_props,
-            )
-            .context(DataFusionExpr)?;
+            let physical_expr =
+                create_physical_expr(&evaluated_expr, &df_schema, &arrow_schema, &execution_props)
+                    .context(DataFusionExpr)?;
+
             let from_type = physical_expr
-                .data_type(&ArrowSchema::empty())
+                .data_type(&arrow_schema)
                 .context(DataFusionDataType)?;
             ensure! {
                 can_cast_types(&from_type, &column_def.data_type.into()),
@@ -895,7 +872,20 @@ fn analyze_column_default_value_options<'a, P: MetaProvider>(
                 },
             }
         }
+
+        // Add evaluated column to schema
+        let new_arrow_field = ArrowField::try_from(column_def).unwrap();
+        let to_merged_df_schema = &DFSchema::new_with_metadata(
+            vec![DFField::from(new_arrow_field.clone())],
+            HashMap::new(),
+        )
+        .unwrap();
+        df_schema.merge(to_merged_df_schema);
+        arrow_schema =
+            ArrowSchema::try_merge(vec![arrow_schema, ArrowSchema::new(vec![new_arrow_field])])
+                .unwrap();
     }
+
     Ok(())
 }
 
@@ -916,6 +906,7 @@ mod tests {
         let mut statements = Parser::parse_sql(sql).unwrap();
         assert_eq!(statements.len(), 1);
         let plan = planner.statement_to_plan(statements.remove(0))?;
+        println!("{:#?}", plan);
         assert_eq!(format!("{:#?}", plan), expected);
         Ok(())
     }
@@ -981,8 +972,11 @@ mod tests {
     fn test_create_statement_to_plan() {
         let sql = "CREATE TABLE IF NOT EXISTS t(c1 string tag not null, 
                                                       ts timestamp not null, 
-                                                      c3 string, c4 uint32 Default 0, 
-                                                      c5 uint32 Default 1+1, timestamp key(ts),primary key(c1, ts)) \
+                                                      c3 string, 
+                                                      c4 uint32 Default 0, 
+                                                      c5 uint32 Default 1+1, 
+                                                      c6 String Default c3,
+                                                      timestamp key(ts),primary key(c1, ts)) \
         ENGINE=Analytic WITH (ttl='70d',update_mode='overwrite',arena_block_size='1KB')";
         quick_test(
             sql,
@@ -1071,6 +1065,23 @@ mod tests {
                             },
                         ),
                     },
+                    ColumnSchema {
+                        id: 6,
+                        name: "c6",
+                        data_type: String,
+                        is_nullable: true,
+                        is_tag: false,
+                        comment: "",
+                        escaped_name: "c6",
+                        default_value: Some(
+                            Identifier(
+                                Ident {
+                                    value: "c3",
+                                    quote_style: None,
+                                },
+                            ),
+                        ),
+                    },
                 ],
             },
             version: 1,
@@ -1088,13 +1099,13 @@ mod tests {
 
     #[test]
     fn test_create_table_failed() {
-        // Currently only support non-input expr as column default value.
-        // TODO(ygf11): remove this test after we support complex
-        // default-value-expr.
+        // CeresDB can reference other columns in default value expr, but it is mysql
+        // style, which only allow ti reference columns defined before it.
+        // Issue: https://github.com/CeresDB/ceresdb/issues/250
         let sql = "CREATE TABLE IF NOT EXISTS t(c1 string tag not null, 
                                                       ts timestamp not null, 
-                                                      c3 uint32 Default 0, 
-                                                      c4 uint32 Default c3, timestamp key(ts),primary key(c1, ts)) \
+                                                      c3 uint32 Default c4, 
+                                                      c4 uint32 Default 0, timestamp key(ts),primary key(c1, ts)) \
         ENGINE=Analytic WITH (ttl='70d',update_mode='overwrite',arena_block_size='1KB')";
         assert!(quick_test(sql, "").is_err());
 

--- a/tests/cases/local/03_dml/insert_mode.result
+++ b/tests/cases/local/03_dml/insert_mode.result
@@ -109,3 +109,23 @@ DROP TABLE `03_dml_insert_mode_table3`;
 
 affected_rows: 0
 
+DROP TABLE IF EXISTS `03_dml_insert_mode_table4`;
+
+affected_rows: 0
+
+CREATE TABLE `03_dml_insert_mode_table4` (    `timestamp` timestamp NOT NULL,    `c1` uint32,    `c2` string default '123',    `c3` uint32 default c1 + 1,    timestamp KEY (timestamp)) ENGINE=AnalyticWITH(	 enable_ttl='false');
+
+affected_rows: 0
+
+INSERT INTO `03_dml_insert_mode_table4` (`timestamp`, `c1`)    VALUES (1, 10), (2, 20), (3, 30);
+
+affected_rows: 3
+
+SELECT    *FROM    `03_dml_insert_mode_table4`ORDER BY    `c1` ASC;
+
+timestamp,tsid,c1,c2,c3,
+Timestamp(Timestamp(1)),Int64(0),Int64(10),String(StringBytes(b"123")),Int64(11),
+Timestamp(Timestamp(2)),Int64(0),Int64(20),String(StringBytes(b"123")),Int64(21),
+Timestamp(Timestamp(3)),Int64(0),Int64(30),String(StringBytes(b"123")),Int64(31),
+
+

--- a/tests/cases/local/03_dml/insert_mode.sql
+++ b/tests/cases/local/03_dml/insert_mode.sql
@@ -105,3 +105,28 @@ ORDER BY
     `value` ASC;
 
 DROP TABLE `03_dml_insert_mode_table3`;
+
+-- insert with missing columns
+DROP TABLE IF EXISTS `03_dml_insert_mode_table4`;
+
+CREATE TABLE `03_dml_insert_mode_table4` (
+    `timestamp` timestamp NOT NULL,
+    `c1` uint32,
+    `c2` string default '123',
+    `c3` uint32 default c1 + 1,
+    timestamp KEY (timestamp)) ENGINE=Analytic
+WITH(
+	 enable_ttl='false'
+);
+
+INSERT INTO `03_dml_insert_mode_table4` (`timestamp`, `c1`)
+    VALUES (1, 10), (2, 20), (3, 30);
+
+SELECT
+    *
+FROM
+    `03_dml_insert_mode_table4`
+ORDER BY
+    `c1` ASC;
+
+DROP TABLE `03_dml_insert_mode_table4`;    

--- a/tests/cases/local/05_ddl/create_tables.result
+++ b/tests/cases/local/05_ddl/create_tables.result
@@ -181,14 +181,14 @@ CREATE TABLE `05_create_tables_t8`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY) 
 
 Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to execute interpreter, query: CREATE TABLE `05_create_tables_t8`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic with (storage_format= 'unknown');. Caused by: Failed to execute create table, err:Failed to create table, name:05_create_tables_t8, err:Failed to create table, err:Invalid arguments, err:Invalid options, space_id:2, table:05_create_tables_t8, table_id:2199023255574, err:Unknown storage format. value:\"unknown\"." })
 
-CREATE TABLE `05_create_tables_t9`(c1 int, c2 bigint default 0, c3 uint32 default 1 + 1, c4 string default 'xxx',  t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
+CREATE TABLE `05_create_tables_t9`(c1 int, c2 bigint default 0, c3 uint32 default 1 + 1, c4 string default 'xxx', c5 uint32 default c3*2 + 1, t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
 
 affected_rows: 0
 
 show create table `05_create_tables_t9`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t9")),String(StringBytes(b"CREATE TABLE `05_create_tables_t9` (`t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, `c1` int, `c2` bigint DEFAULT 0, `c3` uint32 DEFAULT 1 + 1, `c4` string DEFAULT 'xxx', PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t9")),String(StringBytes(b"CREATE TABLE `05_create_tables_t9` (`t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, `c1` int, `c2` bigint DEFAULT 0, `c3` uint32 DEFAULT 1 + 1, `c4` string DEFAULT 'xxx', `c5` uint32 DEFAULT c3 * 2 + 1, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t9`;

--- a/tests/cases/local/05_ddl/create_tables.sql
+++ b/tests/cases/local/05_ddl/create_tables.sql
@@ -62,8 +62,9 @@ show create table `05_create_tables_t8`;
 drop table `05_create_tables_t8`;
 
 CREATE TABLE `05_create_tables_t8`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic with (storage_format= 'unknown');
+
 -- Default value options
-CREATE TABLE `05_create_tables_t9`(c1 int, c2 bigint default 0, c3 uint32 default 1 + 1, c4 string default 'xxx',  t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
+CREATE TABLE `05_create_tables_t9`(c1 int, c2 bigint default 0, c3 uint32 default 1 + 1, c4 string default 'xxx', c5 uint32 default c3*2 + 1, t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
 show create table `05_create_tables_t9`;
 drop table `05_create_tables_t9`;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #250

# Rationale for this change

Support default value expr. 


# What changes are included in this PR?

* When creating table, ceresdb can support to define normal expr which can reference other columns defined before it like mysql. 
* When insert into table, ceresdb will fill the missing columns which define default value expr.
* This pr depends on #187.

# Are there any user-facing changes?

* Support normal default value expr when create and insert into table.

# How does this change test

Add unit tests.
