### PR TITLE
feat: create schema in static routing

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -138,7 +138,7 @@ impl From<SchemaShardView> for SchemaConfig {
 #[derive(Debug, Default, Deserialize, Clone)]
 #[serde(default)]
 pub struct StaticTopologyConfig {
-    schema_shards: Vec<SchemaShardView>,
+    pub schema_shards: Vec<SchemaShardView>,
 }
 
 impl From<&StaticTopologyConfig> for ClusterView {

--- a/server/src/grpc/write.rs
+++ b/server/src/grpc/write.rs
@@ -134,7 +134,11 @@ async fn write_request_to_insert_plan<Q: QueryExecutor + 'static>(
             None => {
                 return ErrNoCause {
                     code: StatusCode::BAD_REQUEST,
-                    msg: format!("Table not found, table:{}", table_name),
+                    msg: format!(
+                        "Table not found, tenant:{}, table:{}",
+                        ctx.tenant(),
+                        table_name
+                    ),
                 }
                 .fail();
             }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -230,7 +230,7 @@ async fn create_static_topology_schema(
                 schema_shard_view.schema
             ));
         info!(
-            "Create static topology in default catalog:{} schema:{}",
+            "Create static topology in default catalog:{}, schema:{}",
             catalog_mgr.default_catalog_name(),
             &schema_shard_view.schema
         );

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -225,10 +225,7 @@ async fn create_static_topology_schema(
         default_catalog
             .create_schema(&schema_shard_view.schema)
             .await
-            .expect(&format!(
-                "Fail to create schema:{}",
-                schema_shard_view.schema
-            ));
+            .unwrap_or_else(|_| panic!("Fail to create schema:{}", schema_shard_view.schema));
         info!(
             "Create static topology in default catalog:{}, schema:{}",
             catalog_mgr.default_catalog_name(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
In `static routing` mode, ceresdb  should open the `schema`s defined in config.
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Open the `schema`s defined in config.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
