### PR TITLE
feat: enhance sql handle, accept both json and text request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,6 +5086,7 @@ dependencies = [
  "arrow 23.0.0",
  "async-trait",
  "avro-rs",
+ "bytes 1.2.1",
  "catalog",
  "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=224c393408ec60a3226bf7f6c41f607c26eca08e)",
  "cluster",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,6 +46,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { workspace = true }
 twox-hash = "1.6"
 warp = "0.3"
+bytes = "1.2.1"
 
 [dev-dependencies]
 sql = { workspace = true , features=["test"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -46,7 +46,7 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { workspace = true }
 twox-hash = "1.6"
 warp = "0.3"
-bytes = "1.2.1"
+bytes = { workspace = true }
 
 [dev-dependencies]
 sql = { workspace = true , features=["test"] }

--- a/server/src/handlers/sql.rs
+++ b/server/src/handlers/sql.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use arrow::error::Result as ArrowResult;
 use common_types::{
+    bytes::Bytes,
     datum::{Datum, DatumKind},
     request_id::RequestId,
 };
@@ -95,6 +96,12 @@ impl Serialize for ResponseRows {
 impl From<String> for Request {
     fn from(query: String) -> Self {
         Self { query }
+    }
+}
+
+impl From<Bytes> for Request {
+    fn from(bytes: Bytes) -> Self {
+        Request::from(String::from_utf8_lossy(&bytes).to_string())
     }
 }
 

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -134,8 +134,9 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
     fn sql(&self) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
         warp::path!("sql")
             .and(warp::post())
+            .and(warp::body::content_length_limit(MAX_BODY_SIZE))
             .and(warp::header("content-type"))
-            .and(warp::body::content_length_limit(MAX_BODY_SIZE).and(warp::body::bytes()))
+            .and(warp::body::bytes())
             .and(self.with_context())
             .and(self.with_instance())
             .and_then(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Fow now, HTTP endpoint `sql` only accept JSON request, it's not convenient to wrap sql inside `{"query": "sql"}`

# What changes are included in this PR?
Enhance sql handle endpoint, to accept both json and raw text request

# Are there any user-facing changes?

Yeah, you can make http request like this directly:
```
$ curl -d 'show tables' -H 'content-type: text/plain' 0:5440/sql
{"rows":[]}
```

# How does this change test

Manually