### PR TITLE
refactor: remove event handling from cluster

### DIFF
--- a/cluster/src/table_manager.rs
+++ b/cluster/src/table_manager.rs
@@ -10,7 +10,7 @@ use common_types::{
     schema::{CatalogName, SchemaId, SchemaName},
     table::TableId,
 };
-use meta_client::types::{CreateTableCmd, ShardId, ShardInfo, ShardTables, TableInfo};
+use meta_client::types::{ShardId, ShardInfo, ShardTables, TableInfo};
 use table_engine::table::TableRef;
 
 use crate::Result;
@@ -26,21 +26,6 @@ pub struct SchemaInfo {
 pub struct ShardTableInfo {
     pub shard_id: ShardId,
     pub table_info: TableInfo,
-}
-
-impl From<&CreateTableCmd> for ShardTableInfo {
-    fn from(cmd: &CreateTableCmd) -> Self {
-        let table_info = TableInfo {
-            id: cmd.id,
-            name: cmd.name.clone(),
-            schema_id: cmd.schema_id,
-            schema_name: cmd.schema_name.clone(),
-        };
-        ShardTableInfo {
-            shard_id: cmd.shard_id,
-            table_info,
-        }
-    }
 }
 
 /// [TableManager] manages information about tables, shards, schemas and their
@@ -163,6 +148,7 @@ impl TableManager {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn tokens_by_shard(&self, shard_id: ShardId) -> Vec<TableToken> {
         if let Some(tokens) = self.inner.read().unwrap().tokens_by_shard.get(&shard_id) {
             tokens.iter().cloned().collect()

--- a/meta_client/src/lib.rs
+++ b/meta_client/src/lib.rs
@@ -6,10 +6,9 @@ use async_trait::async_trait;
 use common_util::define_result;
 use snafu::{Backtrace, Snafu};
 use types::{
-    ActionCmd, AllocSchemaIdRequest, AllocSchemaIdResponse, CreateTableRequest,
-    CreateTableResponse, DropTableRequest, GetNodesRequest, GetNodesResponse,
-    GetShardTablesRequest, GetShardTablesResponse, RouteTablesRequest, RouteTablesResponse,
-    ShardInfo,
+    AllocSchemaIdRequest, AllocSchemaIdResponse, CreateTableRequest, CreateTableResponse,
+    DropTableRequest, GetNodesRequest, GetNodesResponse, GetShardTablesRequest,
+    GetShardTablesResponse, RouteTablesRequest, RouteTablesResponse, ShardInfo,
 };
 
 pub mod meta_impl;
@@ -26,32 +25,6 @@ pub enum Error {
 
     #[snafu(display("Missing header in rpc response.\nBacktrace:\n{}", backtrace))]
     MissingHeader { backtrace: Backtrace },
-
-    #[snafu(display(
-        "Failed to fetch action cmd, err:{}.\nBacktrace:\n{}",
-        source,
-        backtrace
-    ))]
-    FetchActionCmd {
-        source: Box<dyn std::error::Error + Send + Sync>,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display(
-        "Failed to init heartbeat stream, err:{}.\nBacktrace:\n{}",
-        source,
-        backtrace
-    ))]
-    InitHeartBeatStream {
-        source: Box<dyn std::error::Error + Send + Sync>,
-        backtrace: Backtrace,
-    },
-
-    #[snafu(display(
-        "Failed to get grpc client, grpc client is not inited.\nBacktrace:\n{}",
-        backtrace
-    ))]
-    FailGetGrpcClient { backtrace: Backtrace },
 
     #[snafu(display(
         "Failed to connect the service endpoint, err:{}\nBacktrace:\n{}",
@@ -75,7 +48,7 @@ pub enum Error {
     },
 
     #[snafu(display("Failed to alloc table id, err:{}", source))]
-    FailAllocTableId {
+    FailCreateTable {
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
@@ -95,43 +68,19 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Meta rpc error, resp code:{}, msg:{}.\nBacktrace:\n{}",
+        "Bad response, resp code:{}, msg:{}.\nBacktrace:\n{}",
         code,
         msg,
         backtrace
     ))]
-    MetaRpc {
+    BadResponse {
         code: u32,
         msg: String,
         backtrace: Backtrace,
     },
-
-    #[snafu(display(
-        "Handle event failed, handler:{}, event:{:?}, err:{}",
-        name,
-        event,
-        source
-    ))]
-    FailHandleEvent {
-        name: String,
-        event: ActionCmd,
-        source: Box<dyn std::error::Error + Send + Sync>,
-    },
 }
 
 define_result!(Error);
-
-pub type EventHandlerRef = Arc<dyn EventHandler + Send + Sync>;
-
-#[async_trait]
-pub trait EventHandler {
-    fn name(&self) -> &str;
-
-    async fn handle(
-        &self,
-        event: &ActionCmd,
-    ) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>;
-}
 
 /// MetaClient is the abstraction of client used to communicate with CeresMeta
 /// cluster.

--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -19,8 +19,8 @@ use crate::{
         GetShardTablesResponse, NodeInfo, NodeMetaInfo, RequestHeader, RouteTablesRequest,
         RouteTablesResponse, ShardInfo,
     },
-    FailAllocSchemaId, FailAllocTableId, FailConnect, FailDropTable, FailGetTables,
-    FailRouteTables, FailSendHeartbeat, MetaClient, MetaClientRef, MetaRpc, MissingHeader, Result,
+    BadResponse, FailAllocSchemaId, FailConnect, FailCreateTable, FailDropTable, FailGetTables,
+    FailRouteTables, FailSendHeartbeat, MetaClient, MetaClientRef, MissingHeader, Result,
 };
 
 type MetaServiceGrpcClient = CeresmetaRpcServiceClient<tonic::transport::Channel>;
@@ -127,7 +127,7 @@ impl MetaClient for MetaClientImpl {
             .create_table(pb_req)
             .await
             .map_err(|e| Box::new(e) as _)
-            .context(FailAllocTableId)?
+            .context(FailCreateTable)?
             .into_inner();
 
         info!("Meta client finish creating table, resp:{:?}", pb_resp);
@@ -249,7 +249,7 @@ fn check_response_header(header: &Option<ResponseHeader>) -> Result<()> {
     if header.code == 0 {
         Ok(())
     } else {
-        MetaRpc {
+        BadResponse {
             code: header.code,
             msg: header.error.clone(),
         }

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -136,54 +136,6 @@ pub enum ShardRole {
     PendingFollower,
 }
 
-// TODO: now some commands are empty and fill the concrete information into
-// them.
-#[derive(Debug, Clone)]
-pub enum ActionCmd {
-    MetaNoneCmd(NoneCmd),
-    MetaOpenCmd(OpenCmd),
-    MetaSplitCmd(SplitCmd),
-    MetaCloseCmd(CloseCmd),
-    MetaChangeRoleCmd(ChangeRoleCmd),
-
-    CreateTableCmd(CreateTableCmd),
-    DropTableCmd(DropTableCmd),
-}
-
-#[derive(Debug, Clone)]
-pub struct NoneCmd {}
-
-#[derive(Debug, Clone)]
-pub struct OpenCmd {
-    pub shard_ids: Vec<ShardId>,
-}
-
-#[derive(Debug, Clone)]
-pub struct SplitCmd {}
-
-#[derive(Debug, Clone)]
-pub struct CloseCmd {
-    pub shard_ids: Vec<ShardId>,
-}
-
-#[derive(Debug, Clone)]
-pub struct CreateTableCmd {
-    pub schema_name: String,
-    pub name: String,
-    pub shard_id: ShardId,
-    pub schema_id: SchemaId,
-    pub id: TableId,
-}
-
-#[derive(Debug, Clone)]
-pub struct DropTableCmd {
-    pub schema_name: String,
-    pub name: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct ChangeRoleCmd {}
-
 #[derive(Debug, Deserialize, Clone)]
 #[serde(default)]
 pub struct MetaClientConfig {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -100,6 +100,7 @@ impl<Q: QueryExecutor + 'static> Server<Q> {
             cluster.start().await.context(StartCluster)?;
         }
 
+        // TODO: Is it necessary to create default schema in cluster mode?
         self.create_default_schema_if_not_exists().await;
 
         self.mysql_service

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -127,9 +127,7 @@ where
         DeployMode::Standalone => {
             build_in_standalone_mode(&config, builder, analytic, engine_proxy).await
         }
-        DeployMode::Cluster => {
-            build_in_cluster_mode(&config, builder, &runtimes, engine_proxy).await
-        }
+        DeployMode::Cluster => build_in_cluster_mode(&config, builder, &runtimes).await,
     };
 
     // Build and start server
@@ -147,7 +145,6 @@ async fn build_in_cluster_mode<Q: Executor + 'static>(
     config: &Config,
     builder: Builder<Q>,
     runtimes: &EngineRuntimes,
-    engine_proxy: TableEngineRef,
 ) -> Builder<Q> {
     let meta_client = meta_impl::build_meta_client(
         config.cluster.meta_client.clone(),
@@ -161,7 +158,6 @@ async fn build_in_cluster_mode<Q: Executor + 'static>(
     let cluster = {
         let cluster_impl = ClusterImpl::new(
             meta_client,
-            engine_proxy,
             config.cluster.clone(),
             runtimes.meta_runtime.clone(),
         )


### PR DESCRIPTION
# Which issue does this PR close?

Part of #235

# Rationale for this change
 Remove the event handling from the cluster, and afterwards a service will be started in ceresdb-server, for handling rpc from CeresMeta.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Remove event handling from Cluster.
- Remove some unused types: `*Cmd`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Not ready for test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
