### PR TITLE
chore: fix CI cache key, release mode should not mix with debug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,11 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: rust-${{ runner.os }}-ci-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          key: debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            rust-${{ runner.os }}-ci-${{ hashFiles('rust-toolchain') }}-
-            rust-${{ runner.os }}-ci-
-            rust-${{ runner.os }}
+            debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
+            debug-${{ runner.os }}-
+            debug-${{ runner.os }}
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -92,4 +92,3 @@ jobs:
         run: |
           du -sh .
           df -h
-

--- a/.github/workflows/tsbs.yml
+++ b/.github/workflows/tsbs.yml
@@ -23,11 +23,11 @@ jobs:
           path: |
             ~/.cargo
             ./target
-          key: rust-${{ runner.os }}-release-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          key: release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
-            rust-${{ runner.os }}-release-${{ hashFiles('rust-toolchain') }}-
-            rust-${{ runner.os }}-release-
-            rust-${{ runner.os }}
+            release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
+            release-${{ runner.os }}-
+            release-${{ runner.os }}
       - name: Setup Build Environment
         run: |
           sudo apt update


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In current CI, the cache size is 4G after gzipped, which is too large, one issue for this is that the cache may contains both debug and release target, which is useless
- https://github.com/CeresDB/ceresdb/actions/runs/3224489192/jobs/5275667928

# What changes are included in this PR?

Update CI cache key, so release target will not be mixed with debug mode.

# Are there any user-facing changes?

No

# How does this change test

Not required.
