### PR TITLE
chore: rename ShardTables to TablesOfShard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=e31f3044bb305e716ea98f2d5d5439139ad6ef14#e31f3044bb305e716ea98f2d5d5439139ad6ef14"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=3c7aea3af87524154639b88a7c2acf048c4a2584#3c7aea3af87524154639b88a7c2acf048c4a2584"
 dependencies = [
  "prost",
  "tonic",
@@ -1003,8 +1003,7 @@ version = "0.1.0"
 dependencies = [
  "analytic_engine",
  "async-trait",
- "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=e31f3044bb305e716ea98f2d5d5439139ad6ef14)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=3c7aea3af87524154639b88a7c2acf048c4a2584)",
  "common_types 0.1.0",
  "common_util",
  "log",
@@ -3112,8 +3111,7 @@ name = "meta_client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=e31f3044bb305e716ea98f2d5d5439139ad6ef14)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=3c7aea3af87524154639b88a7c2acf048c4a2584)",
  "common_types 0.1.0",
  "common_util",
  "futures 0.3.21",
@@ -5070,7 +5068,7 @@ dependencies = [
  "avro-rs",
  "bytes 1.2.1",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=e31f3044bb305e716ea98f2d5d5439139ad6ef14)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=3c7aea3af87524154639b88a7c2acf048c4a2584)",
  "cluster",
  "common_types 0.1.0",
  "common_util",
@@ -5391,7 +5389,7 @@ version = "0.1.0"
 dependencies = [
  "arrow 23.0.0",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=e31f3044bb305e716ea98f2d5d5439139ad6ef14)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=3c7aea3af87524154639b88a7c2acf048c4a2584)",
  "common_types 0.1.0",
  "common_util",
  "datafusion 12.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ wal = { path = "wal" }
 
 [workspace.dependencies.ceresdbproto]
 git = "https://github.com/CeresDB/ceresdbproto.git"
-rev = "e31f3044bb305e716ea98f2d5d5439139ad6ef14"
+rev = "3c7aea3af87524154639b88a7c2acf048c4a2584"
 
 [workspace.dependencies.datafusion]
 git = "https://github.com/CeresDB/arrow-datafusion.git"

--- a/cluster/Cargo.toml
+++ b/cluster/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 [dependencies]
 analytic_engine = { workspace = true }
 async-trait = { workspace = true }
-catalog = { workspace = true }
 ceresdbproto = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -2,9 +2,9 @@
 
 //! Cluster sub-crate includes serval functionalities for supporting CeresDB
 //! server to running in the distribute mode. Including:
-//! - Catalog / Schema / Table's create, open, close and drop operations.
 //! - Request CeresMeta for reading topology or configuration.
-//! - Accept CeresMeta's command events like create/drop table etc,.
+//! - Accept CeresMeta's commands like open/close shard or create/drop table
+//!   etc.
 //!
 //! The core types are [Cluster] trait and its implementation [ClusterImpl].
 

--- a/meta_client/Cargo.toml
+++ b/meta_client/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
-catalog = { workspace = true }
 ceresdbproto = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }

--- a/meta_client/src/lib.rs
+++ b/meta_client/src/lib.rs
@@ -7,8 +7,8 @@ use common_util::define_result;
 use snafu::{Backtrace, Snafu};
 use types::{
     AllocSchemaIdRequest, AllocSchemaIdResponse, CreateTableRequest, CreateTableResponse,
-    DropTableRequest, GetNodesRequest, GetNodesResponse, GetShardTablesRequest,
-    GetShardTablesResponse, RouteTablesRequest, RouteTablesResponse, ShardInfo,
+    DropTableRequest, GetNodesRequest, GetNodesResponse, GetTablesOfShardsRequest,
+    GetTablesOfShardsResponse, RouteTablesRequest, RouteTablesResponse, ShardInfo,
 };
 
 pub mod meta_impl;
@@ -92,7 +92,10 @@ pub trait MetaClient: Send + Sync {
 
     async fn drop_table(&self, req: DropTableRequest) -> Result<()>;
 
-    async fn get_tables(&self, req: GetShardTablesRequest) -> Result<GetShardTablesResponse>;
+    async fn get_tables_of_shards(
+        &self,
+        req: GetTablesOfShardsRequest,
+    ) -> Result<GetTablesOfShardsResponse>;
 
     async fn route_tables(&self, req: RouteTablesRequest) -> Result<RouteTablesResponse>;
 

--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -15,8 +15,8 @@ use snafu::{OptionExt, ResultExt};
 use crate::{
     types::{
         AllocSchemaIdRequest, AllocSchemaIdResponse, CreateTableRequest, CreateTableResponse,
-        DropTableRequest, GetNodesRequest, GetNodesResponse, GetShardTablesRequest,
-        GetShardTablesResponse, NodeInfo, NodeMetaInfo, RequestHeader, RouteTablesRequest,
+        DropTableRequest, GetNodesRequest, GetNodesResponse, GetTablesOfShardsRequest,
+        GetTablesOfShardsResponse, NodeInfo, NodeMetaInfo, RequestHeader, RouteTablesRequest,
         RouteTablesResponse, ShardInfo,
     },
     BadResponse, FailAllocSchemaId, FailConnect, FailCreateTable, FailDropTable, FailGetTables,
@@ -155,15 +155,18 @@ impl MetaClient for MetaClientImpl {
         check_response_header(&pb_resp.header)
     }
 
-    async fn get_tables(&self, req: GetShardTablesRequest) -> Result<GetShardTablesResponse> {
-        let mut pb_req = meta_service::GetShardTablesRequest::from(req);
+    async fn get_tables_of_shards(
+        &self,
+        req: GetTablesOfShardsRequest,
+    ) -> Result<GetTablesOfShardsResponse> {
+        let mut pb_req = meta_service::GetTablesOfShardsRequest::from(req);
         pb_req.header = Some(self.request_header().into());
 
         debug!("Meta client try to get tables, req:{:?}", pb_req);
 
         let pb_resp = self
             .client()
-            .get_shard_tables(pb_req)
+            .get_tables_of_shards(pb_req)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(FailGetTables)?
@@ -173,7 +176,7 @@ impl MetaClient for MetaClientImpl {
 
         check_response_header(&pb_resp.header)?;
 
-        GetShardTablesResponse::try_from(pb_resp)
+        GetTablesOfShardsResponse::try_from(pb_resp)
     }
 
     async fn route_tables(&self, req: RouteTablesRequest) -> Result<RouteTablesResponse> {

--- a/server/src/route/cluster_based.rs
+++ b/server/src/route/cluster_based.rs
@@ -172,7 +172,7 @@ mod tests {
                 };
 
                 let shard_info = ShardInfo {
-                    shard_id: 0,
+                    id: 0,
                     role,
                     version: 0,
                 };


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 In the #295, @Rachelint proposes that the `ShardTables` is an ambiguous name, so let's rename it to `TablesOfShard`.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Renaming;
- Update the version of ceresdbproto for renaming protobuf struct name;
- Remove some unused depenecies;

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
CI.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
