### PR TITLE
fix: avoid running blocked-on task when building meta client

### DIFF
--- a/meta_client/src/lib.rs
+++ b/meta_client/src/lib.rs
@@ -27,11 +27,13 @@ pub enum Error {
     MissingHeader { backtrace: Backtrace },
 
     #[snafu(display(
-        "Failed to connect the service endpoint, err:{}\nBacktrace:\n{}",
+        "Failed to connect the service endpoint:{}, err:{}\nBacktrace:\n{}",
+        addr,
         source,
         backtrace
     ))]
     FailConnect {
+        addr: String,
         source: Box<dyn std::error::Error + Send + Sync>,
         backtrace: Backtrace,
     },

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -149,8 +149,8 @@ async fn build_in_cluster_mode<Q: Executor + 'static>(
     let meta_client = meta_impl::build_meta_client(
         config.cluster.meta_client.clone(),
         config.cluster.node.clone(),
-        runtimes.meta_runtime.clone(),
     )
+    .await
     .expect("fail to build meta client");
 
     let shard_table_manager = ShardTableManager::default();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #304 

# Rationale for this change
 A blocked-on task for building meta client is started in the init procedure, leading to the panic mentioned by #304.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Avoid running blocked-on task in the init procedure.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Now this is tested by manual.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
