### PR TITLE
feat: add async inner to `BatchLogIteratorAdapter`

### DIFF
--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -15,7 +15,7 @@ use table_engine::engine::OpenTableRequest;
 use tokio::sync::oneshot;
 use wal::{
     log_batch::LogEntry,
-    manager::{BatchLogIterator, ReadBoundary, ReadContext, ReadRequest, WalManagerRef},
+    manager::{ReadBoundary, ReadContext, ReadRequest, WalManagerRef},
 };
 
 use crate::{

--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -21,8 +21,8 @@ use tokio::sync::Mutex;
 use wal::{
     log_batch::LogEntry,
     manager::{
-        BatchLogIterator, BatchLogIteratorAdapter, ReadBoundary, ReadContext, ReadRequest,
-        RegionId, SequenceNumber, WalManagerRef, WriteContext,
+        BatchLogIteratorAdapter, ReadBoundary, ReadContext, ReadRequest, RegionId, SequenceNumber,
+        WalManagerRef, WriteContext,
     },
 };
 

--- a/analytic_engine/src/wal_synchronizer.rs
+++ b/analytic_engine/src/wal_synchronizer.rs
@@ -28,10 +28,7 @@ use tokio::{
 };
 use wal::{
     log_batch::LogEntry,
-    manager::{
-        BatchLogIterator, BatchLogIteratorAdapter, ReadBoundary, ReadContext, ReadRequest,
-        WalManagerRef,
-    },
+    manager::{BatchLogIteratorAdapter, ReadBoundary, ReadContext, ReadRequest, WalManagerRef},
 };
 
 use self::role_table::ReaderTable;

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -27,8 +27,8 @@ use crate::{
     kv_encoder::{LogEncoding, LogKey, MaxSeqMetaEncoding, MaxSeqMetaValue, MetaKey},
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
-        error::*, BatchLogIteratorAdapter, BlockingLogIterator, InnerIterator, ReadContext,
-        ReadRequest, RegionId, ScanContext, ScanRequest, WalManager, WriteContext, MAX_REGION_ID,
+        error::*, BatchLogIteratorAdapter, InnerIterator, ReadContext, ReadRequest, RegionId,
+        ScanContext, ScanRequest, SyncLogIterator, WalManager, WriteContext, MAX_REGION_ID,
     },
 };
 
@@ -553,7 +553,7 @@ impl RocksLogIterator {
     }
 }
 
-impl BlockingLogIterator for RocksLogIterator {
+impl SyncLogIterator for RocksLogIterator {
     fn next_log_entry(&mut self) -> Result<Option<LogEntry<&'_ [u8]>>> {
         if self.no_more_data {
             return Ok(None);
@@ -632,7 +632,7 @@ impl WalManager for RocksImpl {
         ctx: &ReadContext,
         req: &ReadRequest,
     ) -> Result<BatchLogIteratorAdapter> {
-        let blocking_iter = if let Some(region) = self.region(req.location.table_id) {
+        let sync_iter = if let Some(region) = self.region(req.location.table_id) {
             region.read(ctx, req)?
         } else {
             let iter = DBIterator::new(self.db.clone(), ReadOptions::default());
@@ -641,7 +641,7 @@ impl WalManager for RocksImpl {
         let runtime = self.runtime.clone();
 
         Ok(BatchLogIteratorAdapter::new(
-            InnerIterator::Blocking(Box::new(blocking_iter), runtime),
+            InnerIterator::Sync(Box::new(sync_iter), runtime),
             ctx.batch_size,
         ))
     }

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -27,8 +27,8 @@ use crate::{
     kv_encoder::{LogEncoding, LogKey, MaxSeqMetaEncoding, MaxSeqMetaValue, MetaKey},
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
-        error::*, BatchLogIteratorAdapter, InnerIterator, ReadContext, ReadRequest, RegionId,
-        ScanContext, ScanRequest, SyncLogIterator, WalManager, WriteContext, MAX_REGION_ID,
+        error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId, ScanContext,
+        ScanRequest, SyncLogIterator, WalManager, WriteContext, MAX_REGION_ID,
     },
 };
 
@@ -640,8 +640,9 @@ impl WalManager for RocksImpl {
         };
         let runtime = self.runtime.clone();
 
-        Ok(BatchLogIteratorAdapter::new(
-            InnerIterator::Sync(Box::new(sync_iter), runtime),
+        Ok(BatchLogIteratorAdapter::new_with_sync(
+            Box::new(sync_iter),
+            runtime,
             ctx.batch_size,
         ))
     }

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -27,8 +27,8 @@ use crate::{
     kv_encoder::{LogEncoding, LogKey, MaxSeqMetaEncoding, MaxSeqMetaValue, MetaKey},
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
-        error::*, BatchLogIteratorAdapter, BlockingLogIterator, ReadContext, ReadRequest, RegionId,
-        ScanContext, ScanRequest, WalManager, WriteContext, MAX_REGION_ID,
+        error::*, BatchLogIteratorAdapter, BlockingLogIterator, InnerIterator, ReadContext,
+        ReadRequest, RegionId, ScanContext, ScanRequest, WalManager, WriteContext, MAX_REGION_ID,
     },
 };
 
@@ -641,8 +641,7 @@ impl WalManager for RocksImpl {
         let runtime = self.runtime.clone();
 
         Ok(BatchLogIteratorAdapter::new(
-            Box::new(blocking_iter),
-            runtime,
+            InnerIterator::Blocking(Box::new(blocking_iter), runtime),
             ctx.batch_size,
         ))
     }

--- a/wal/src/table_kv_impl/region.rs
+++ b/wal/src/table_kv_impl/region.rs
@@ -25,7 +25,7 @@ use tokio::sync::Mutex;
 use crate::{
     kv_encoder::{LogEncoding, LogKey},
     log_batch::{LogEntry, LogWriteBatch},
-    manager::{self, BlockingLogIterator, ReadContext, ReadRequest, RegionId, SequenceNumber},
+    manager::{self, ReadContext, ReadRequest, RegionId, SequenceNumber, SyncLogIterator},
     table_kv_impl::{encoding, model::RegionEntry, namespace::BucketRef, WalRuntimes},
 };
 
@@ -661,7 +661,7 @@ impl<T: TableKv> TableLogIterator<T> {
     }
 }
 
-impl<T: TableKv> BlockingLogIterator for TableLogIterator<T> {
+impl<T: TableKv> SyncLogIterator for TableLogIterator<T> {
     fn next_log_entry(&mut self) -> manager::Result<Option<LogEntry<&'_ [u8]>>> {
         if self.no_more_data() {
             return Ok(None);

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -13,8 +13,8 @@ use table_kv::TableKv;
 use crate::{
     log_batch::LogWriteBatch,
     manager::{
-        self, error::*, BatchLogIteratorAdapter, InnerIterator, ReadContext, ReadRequest,
-        ScanContext, ScanRequest, WalManager,
+        self, error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext,
+        ScanRequest, WalManager,
     },
     table_kv_impl::{
         model::NamespaceConfig,
@@ -141,8 +141,9 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
             .context(Read)?;
         let runtime = self.namespace.read_runtime().clone();
 
-        Ok(BatchLogIteratorAdapter::new(
-            InnerIterator::Sync(Box::new(sync_iter), runtime),
+        Ok(BatchLogIteratorAdapter::new_with_sync(
+            Box::new(sync_iter),
+            runtime,
             ctx.batch_size,
         ))
     }

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -133,7 +133,7 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
         ctx: &ReadContext,
         req: &ReadRequest,
     ) -> Result<BatchLogIteratorAdapter> {
-        let blocking_iter = self
+        let sync_iter = self
             .namespace
             .read_log(ctx, req)
             .await
@@ -142,7 +142,7 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
         let runtime = self.namespace.read_runtime().clone();
 
         Ok(BatchLogIteratorAdapter::new(
-            InnerIterator::Blocking(Box::new(blocking_iter), runtime),
+            InnerIterator::Sync(Box::new(sync_iter), runtime),
             ctx.batch_size,
         ))
     }

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -13,8 +13,8 @@ use table_kv::TableKv;
 use crate::{
     log_batch::LogWriteBatch,
     manager::{
-        self, error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext,
-        ScanRequest, WalManager,
+        self, error::*, BatchLogIteratorAdapter, InnerIterator, ReadContext, ReadRequest,
+        ScanContext, ScanRequest, WalManager,
     },
     table_kv_impl::{
         model::NamespaceConfig,
@@ -142,8 +142,7 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
         let runtime = self.namespace.read_runtime().clone();
 
         Ok(BatchLogIteratorAdapter::new(
-            Box::new(blocking_iter),
-            runtime,
+            InnerIterator::Blocking(Box::new(blocking_iter), runtime),
             ctx.batch_size,
         ))
     }

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -20,10 +20,7 @@ use tempfile::TempDir;
 
 use crate::{
     log_batch::{LogWriteBatch, Payload, PayloadDecoder},
-    manager::{
-        BatchLogIterator, BatchLogIteratorAdapter, ReadContext, WalManager, WalManagerRef,
-        WriteContext,
-    },
+    manager::{BatchLogIteratorAdapter, ReadContext, WalManager, WalManagerRef, WriteContext},
     rocks_impl::{self, manager::RocksImpl},
     table_kv_impl::{model::NamespaceConfig, wal::WalNamespaceImpl, WalRuntimes},
 };


### PR DESCRIPTION
…and add its adapting logic to `BatchLogIteratorAdapter`.

# Which issue does this PR close?

Closes #

# Rationale for this change
 The `BatchLogIteratorAdapter` just support `BlockingLogIterator` as its inner. It is not enough, because in other wal implementation, the iterator return from `read_batch` may be originally async, the  `BatchLogIteratorAdapter` should take  it in consideration.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
+ Define a new trait  `AsyncLogIterator`.
+ Add its adapting logic to `BatchLogIteratorAdapter`.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
By exist ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
