### PR TITLE
chore: minimize release binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,8 @@ vergen = { version = "5", default-features = false, features = ["build", "git"] 
 
 [profile.release]
 debug = true
-opt-level = 2
+opt-level = "z"
+lto = true
 overflow-checks = true
 
 [profile.bench]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Minimize release binary size. 
Refer to [min-sized-rust](https://github.com/johnthagen/min-sized-rust).
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
* Enable [lto](https://doc.rust-lang.org/cargo/reference/profiles.html#lto).
* Set [opt-level](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level) to "z".
The new setting minimizes the release binary size from 1.3G to 510M.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
