### PR TITLE
Refactor: utilize datafuison to support filter before merge procedure

### DIFF
--- a/common_types/src/projected_schema.rs
+++ b/common_types/src/projected_schema.rs
@@ -132,7 +132,7 @@ impl ProjectedSchema {
         self.0.schema_with_key.clone()
     }
 
-    pub(crate) fn as_record_schema_with_key(&self) -> &RecordSchemaWithKey {
+    pub fn as_record_schema_with_key(&self) -> &RecordSchemaWithKey {
         &self.0.schema_with_key
     }
 

--- a/interpreters/src/insert.rs
+++ b/interpreters/src/insert.rs
@@ -41,13 +41,13 @@ use crate::{
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to generate datafusion expr, err:{}", source))]
-    DataFusionExpr { source: DataFusionError },
+    DatafusionExpr { source: DataFusionError },
 
     #[snafu(display(
         "Failed to get data type from datafusion physical expr, err:{}",
         source
     ))]
-    DataFusionDataType { source: DataFusionError },
+    DatafusionDataType { source: DataFusionError },
 
     #[snafu(display("Failed to get arrow schema, err:{}", source))]
     ArrowSchema { source: ArrowError },
@@ -56,7 +56,7 @@ pub enum Error {
     DatafusionSchema { source: DataFusionError },
 
     #[snafu(display("Failed to evaluate datafusion physical expr, err:{}", source))]
-    DataFusionExecutor { source: DataFusionError },
+    DatafusionExecutor { source: DataFusionError },
 
     #[snafu(display("Failed to build arrow record batch, err:{}", source))]
     BuildArrowRecordBatch { source: ArrowError },
@@ -211,11 +211,11 @@ fn fill_default_values(
         // Optimize logical expr
         let execution_props = ExecutionProps::default();
         let mut const_optimizer =
-            ConstEvaluator::try_new(&execution_props).context(DataFusionExpr)?;
+            ConstEvaluator::try_new(&execution_props).context(DatafusionExpr)?;
         let evaluated_expr = default_value_expr
             .clone()
             .rewrite(&mut const_optimizer)
-            .context(DataFusionExpr)?;
+            .context(DatafusionExpr)?;
 
         // Find input columns
         let required_column_idxes = find_columns_by_expr(&evaluated_expr)
@@ -243,11 +243,11 @@ fn fill_default_values(
             &input_arrow_schema,
             &execution_props,
         )
-        .context(DataFusionExpr)?;
+        .context(DatafusionExpr)?;
 
         let from_type = physical_expr
             .data_type(&input_arrow_schema)
-            .context(DataFusionDataType)?;
+            .context(DatafusionDataType)?;
         let to_type = row_groups.schema().column(*column_idx).data_type;
 
         let casted_physical_expr = if from_type != to_type.into() {
@@ -276,7 +276,7 @@ fn fill_default_values(
 
         let output = casted_physical_expr
             .evaluate(&input)
-            .context(DataFusionExecutor)?;
+            .context(DatafusionExecutor)?;
 
         fill_column_to_row_group(*column_idx, &output, row_groups)?;
 

--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -57,22 +57,22 @@ use crate::{
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to generate datafusion plan, err:{}", source))]
-    DataFusionPlan { source: DataFusionError },
+    DatafusionPlan { source: DataFusionError },
 
     #[snafu(display("Failed to create datafusion schema, err:{}", source))]
-    CreateDataFusionSchema { source: DataFusionError },
+    CreateDatafusionSchema { source: DataFusionError },
 
     #[snafu(display("Failed to merge arrow schema, err:{}", source))]
     MergeArrowSchema { source: ArrowError },
 
     #[snafu(display("Failed to generate datafusion expr, err:{}", source))]
-    DataFusionExpr { source: DataFusionError },
+    DatafusionExpr { source: DataFusionError },
 
     #[snafu(display(
         "Failed to get data type from datafusion physical expr, err:{}",
         source
     ))]
-    DataFusionDataType { source: DataFusionError },
+    DatafusionDataType { source: DataFusionError },
 
     // Statement is too large and complicate to carry in Error, so we
     // only return error here, so the caller should attach sql to its
@@ -293,7 +293,7 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
 
         let df_plan = df_planner
             .sql_statement_to_plan(sql_stmt)
-            .context(DataFusionPlan)?;
+            .context(DatafusionPlan)?;
 
         debug!("Sql statement to datafusion plan, df_plan:\n{:#?}", df_plan);
 
@@ -504,7 +504,7 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
                     })
                     .collect::<Vec<_>>();
                 let df_schema = DFSchema::new_with_metadata(df_fields, HashMap::new())
-                    .context(CreateDataFusionSchema)?;
+                    .context(CreateDatafusionSchema)?;
                 let df_planner = SqlToRel::new(&self.meta_provider);
 
                 // Index in insert values stmt of each column in table schema
@@ -532,7 +532,7 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
                             if let Some(expr) = &column.default_value {
                                 let expr = df_planner
                                     .sql_to_rex(expr.clone(), &df_schema, &mut NoStdHashMap::new())
-                                    .context(DataFusionExpr)?;
+                                    .context(DatafusionExpr)?;
 
                                 default_value_map.insert(idx, expr);
                                 column_index_in_insert.push(InsertMode::Auto);
@@ -847,7 +847,7 @@ fn ensure_column_default_value_valid<'a, P: MetaProvider>(
         if let Some(expr) = &column_def.default_value {
             let df_logical_expr = df_planner
                 .sql_to_rex(expr.clone(), &df_schema, &mut NoStdHashMap::new())
-                .context(DataFusionExpr)?;
+                .context(DatafusionExpr)?;
 
             // Create physical expr
             let execution_props = ExecutionProps::default();
@@ -857,11 +857,11 @@ fn ensure_column_default_value_valid<'a, P: MetaProvider>(
                 &arrow_schema,
                 &execution_props,
             )
-            .context(DataFusionExpr)?;
+            .context(DatafusionExpr)?;
 
             let from_type = physical_expr
                 .data_type(&arrow_schema)
-                .context(DataFusionDataType)?;
+                .context(DatafusionDataType)?;
             ensure! {
                 can_cast_types(&from_type, &column_def.data_type.into()),
                 InvalidDefaultValueCoercion::<Expr, ArrowDataType, ArrowDataType>{
@@ -878,7 +878,7 @@ fn ensure_column_default_value_valid<'a, P: MetaProvider>(
             vec![DFField::from(new_arrow_field.clone())],
             HashMap::new(),
         )
-        .context(CreateDataFusionSchema)?;
+        .context(CreateDatafusionSchema)?;
         df_schema.merge(to_merged_df_schema);
         arrow_schema =
             ArrowSchema::try_merge(vec![arrow_schema, ArrowSchema::new(vec![new_arrow_field])])


### PR DESCRIPTION
# Which issue does this PR close?

Closes #256

# Rationale for this change
It is more maintainable to utilize datafusion than implementing the filter logic manually.

# What changes are included in this PR?

* refactor `filter_stream` with datafusion.
* remove filter operator from pipeline, since we pushdown all filter now.

# Are there any user-facing changes?
No

# How does this change test
Existing Unit tests.

