### PR TITLE
chore: add quick release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,11 +131,22 @@ tracing_util = { workspace = true }
 [build-dependencies]
 vergen = { version = "5", default-features = false, features = ["build", "git"] }
 
+[profile.bench]
+debug = true
+
+# This profile optimizes for runtime performance and small binary size at the expense of longer
+# build times. It's most suitable for final release builds.
 [profile.release]
 debug = true
 opt-level = "z"
 lto = true
 overflow-checks = true
 
-[profile.bench]
-debug = true
+# This profile optimizes for short build times at the expense of larger binary size and slower
+# runtime performance. It's most suitable for development iterations.
+[profile.quick-release]
+inherits = "release"
+opt-level = 2
+lto = false
+codegen-units = 16
+incremental = true


### PR DESCRIPTION
# Which issue does this PR close?

Part of #294 

# Rationale for this change
 
After #322, release build will fail on host with only 8G memory, this PR introduce a quick-release profile to fix this.

```
Compiling rocksdb v0.3.0 (https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7)
   Compiling wal v0.4.0-alpha (/home/changcheng/app/before-sql/ceresdb-main/wal)
   Compiling analytic_engine v0.4.0-alpha (/home/changcheng/app/before-sql/ceresdb-main/analytic_engine)
   Compiling cluster v0.4.0-alpha (/home/changcheng/app/before-sql/ceresdb-main/cluster)
   Compiling catalog_impls v0.4.0-alpha (/home/changcheng/app/before-sql/ceresdb-main/catalog_impls)
   Compiling server v0.4.0-alpha (/home/changcheng/app/before-sql/ceresdb-main/server)
error: could not compile `ceresdb`
Caused by:
  process didn't exit successfully: `rustc --crate-name ceresdb_server --edition=2021 src/bin/ceresdb-server.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C opt-level=z -C lto -C debuginfo=2 -C overflow-checks=on -C metadata=3331f95d29e36aa2 -C extra-filename=-3331f95d29e36aa2 --out-dir /home/changcheng/app/before-sql/ceresdb-main/target/release/deps -L dependency=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps --extern analytic_engine=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libanalytic_engine-74f8435ebaa9dc49.rlib --extern catalog=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libcatalog-2be2aef2ea062ae2.rlib --extern catalog_impls=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libcatalog_impls-2fb630939ed7ccc8.rlib --extern ceresdb=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libceresdb-db51967f9d7a05b2.rlib --extern clap=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libclap-d8a1fec94c4b5776.rlib --extern cluster=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libcluster-a2ba2f9787620410.rlib --extern common_util=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libcommon_util-14c0279fcfca0ac0.rlib --extern df_operator=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libdf_operator-376b3a0bd05af91a.rlib --extern log=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/liblog-3f23057933df41c1.rlib --extern logger=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/liblogger-524f8c23b52e5474.rlib --extern meta_client=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libmeta_client-44756beed67af053.rlib --extern query_engine=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libquery_engine-249ad94b9624b3f5.rlib --extern server=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libserver-e9acc40e00671ee5.rlib --extern signal_hook=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libsignal_hook-76c76ab809c25c02.rlib --extern table_engine=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libtable_engine-0a9abbe26052618c.rlib --extern tracing_util=/home/changcheng/app/before-sql/ceresdb-main/target/release/deps/libtracing_util-f626b5e6f033af05.rlib -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/libz-sys-c9804bf031ee4714/out/lib -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/libz-sys-c9804bf031ee4714/out/lib -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/lz4-sys-985f632354922bc7/out -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/zstd-sys-d8272bc4e11bba0a/out -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/blake3-109a8b72bc224a42/out -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/blake3-109a8b72bc224a42/out -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/rust-crypto-7eada5308f7705d0/out -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/librocksdb_sys-12a3fe8ad791b6dc/out/build -L native=/opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8 -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/librocksdb_sys-12a3fe8ad791b6dc/out -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/bzip2-sys-641ab008a902862f/out/lib -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/libtitan_sys-fe01d5d81f7d76ea/out/build -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/snappy-sys-0dcc8f98c00b4252/out/build -L native=/home/changcheng/app/before-sql/ceresdb-main/target/release/build/jemalloc-sys-9d61a1a3d2be6579/out/build/lib` (signal: 9, SIGKILL: kill)
```
# What changes are included in this PR?

A new profile

# Are there any user-facing changes?

Yes, users can invoke new profile like this

```
cargo build --profile quick-release
```

# How does this change test

Manually 
