### PR TITLE
fix: use right table manipulator when setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,6 +862,7 @@ dependencies = [
  "cluster",
  "common_util",
  "df_operator",
+ "interpreters",
  "log",
  "logger",
  "meta_client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ server = { workspace = true }
 signal-hook = "0.3"
 table_engine = { workspace = true }
 tracing_util = { workspace = true }
+interpreters = { workspace = true }
 
 [build-dependencies]
 vergen = { version = "5", default-features = false, features = ["build", "git"] }

--- a/interpreters/src/table_manipulator/meta_based.rs
+++ b/interpreters/src/table_manipulator/meta_based.rs
@@ -21,6 +21,12 @@ pub struct TableManipulatorImpl {
     meta_client: MetaClientRef,
 }
 
+impl TableManipulatorImpl {
+    pub fn new(meta_client: MetaClientRef) -> Self {
+        Self { meta_client }
+    }
+}
+
 #[async_trait]
 impl TableManipulator for TableManipulatorImpl {
     async fn create_table(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Now the table manipulator is hard coded when setup.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Choose correct table manipulator when setup ceresdb-server.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by manual.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
