### PR TITLE
fix: create default schema automatically

### DIFF
--- a/catalog/src/manager.rs
+++ b/catalog/src/manager.rs
@@ -9,7 +9,14 @@ use snafu::Snafu;
 use crate::{schema::NameRef, CatalogRef};
 
 #[derive(Debug, Snafu)]
-pub struct Error;
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("Failed to do initialization, msg:{}, err:{}", msg, source))]
+    Init {
+        msg: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
 
 define_result!(Error);
 

--- a/catalog_impls/src/volatile.rs
+++ b/catalog_impls/src/volatile.rs
@@ -78,7 +78,6 @@ impl Manager for ManagerImpl {
 
 impl ManagerImpl {
     async fn maybe_create_default_catalog_and_schema(&mut self) -> manager::Result<()> {
-        // TODO: we should delegate this operation to the [TableManager].
         // Try to get default catalog, create it if not exists.
         let default_catalog = match self.catalogs.get(consts::DEFAULT_CATALOG).cloned() {
             Some(v) => v.clone(),
@@ -88,6 +87,7 @@ impl ManagerImpl {
             }
         };
 
+        // Try to create default catalog if it does not exist.
         let default_schema_exists = default_catalog
             .schema_by_name(consts::DEFAULT_SCHEMA)
             .map_err(|e| Box::new(e) as _)

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -162,14 +162,15 @@ async fn build_in_cluster_mode<Q: Executor + 'static>(
             config.cluster.clone(),
             runtimes.meta_runtime.clone(),
         )
-        .unwrap();
+        .expect("Should succeed in initializing cluster");
         Arc::new(cluster_impl)
     };
 
-    let catalog_manager = Arc::new(volatile::ManagerImpl::new(
-        shard_tables_cache,
-        meta_client.clone(),
-    ));
+    let catalog_manager = Arc::new(
+        volatile::ManagerImpl::init(shard_tables_cache, meta_client.clone())
+            .await
+            .expect("Should succeed in initializing catalog manager"),
+    );
     let table_manipulator = Arc::new(meta_based::TableManipulatorImpl::new(meta_client));
     let router = Arc::new(ClusterBasedRouter::new(cluster.clone()));
     let schema_config_provider = Arc::new(ClusterBasedProvider::new(cluster.clone()));


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 For now, the default schema won't be created when setting up ceresdb-server, which leads to the following failures.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Create default schema when setting up ceresdb-server.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test with meta.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
