### PR TITLE
edit: column order use user define

### DIFF
--- a/analytic_engine/src/meta/meta_update.rs
+++ b/analytic_engine/src/meta/meta_update.rs
@@ -238,7 +238,6 @@ impl TryFrom<meta_pb::AddTableMeta> for AddTableMeta {
     fn try_from(mut src: meta_pb::AddTableMeta) -> Result<Self> {
         let table_schema = src.take_schema();
         let opts = src.take_options();
-
         Ok(Self {
             space_id: src.space_id,
             table_id: TableId::from(src.table_id),

--- a/proto/protos/common.proto
+++ b/proto/protos/common.proto
@@ -54,6 +54,8 @@ message TableSchema {
     uint32 timestamp_index = 4;
     // Enable auto generated tsid as primary key
     bool enable_tsid_primary_key = 5;
+    // Primary key index
+    repeated uint64 primary_key_index = 6;
 }
 
 // Time range of [start, end)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #187 

# Rationale for this change
 
Table' columns order is not what user define when create table

# What changes are included in this PR?

I modified the 'add_key_column' and 'add_normal_column' methods in 'schema.builder' and added 'primary_key_index' to record additional field primary key information.

But I had a serialization problem, so the job wasn't done.

In my understanding, these changes are sufficient, but when I test the new table, I find that the primary_key_index is empty in the data re-read by wal log. I need more time to check the reason

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
