### PR TITLE
fix: adopt new parquet api

### DIFF
--- a/analytic_engine/src/sst/parquet/mod.rs
+++ b/analytic_engine/src/sst/parquet/mod.rs
@@ -3,8 +3,6 @@
 //! Sst implementation based on parquet.
 
 pub mod builder;
-#[allow(deprecated)]
 pub mod encoding;
 mod hybrid;
-#[allow(deprecated)]
 pub mod reader;

--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -71,7 +71,7 @@ pub async fn read_sst_meta(
         })?;
 
     // generate the file reader
-    let file_reader = CacheableSerializedFileReader::new(
+    let file_reader = CacheableSerializedFileReader::try_new(
         path.to_string(),
         bytes,
         meta_cache.clone(),

--- a/components/parquet_ext/src/lib.rs
+++ b/components/parquet_ext/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 pub mod cache;
-#[allow(deprecated)]
 pub mod reverse_reader;
 mod serialized_reader;
 #[cfg(test)]

--- a/components/parquet_ext/src/serialized_reader.rs
+++ b/components/parquet_ext/src/serialized_reader.rs
@@ -115,6 +115,20 @@ impl<R: 'static + ChunkReader> CacheableSerializedFileReader<R> {
     }
 }
 
+impl<R: 'static + ChunkReader> Length for CacheableSerializedFileReader<R> {
+    fn len(&self) -> u64 {
+        self.chunk_reader.len()
+    }
+}
+
+impl<R: 'static + ChunkReader> ChunkReader for CacheableSerializedFileReader<R> {
+    type T = R::T;
+
+    fn get_read(&self, start: u64, length: usize) -> Result<Self::T> {
+        self.chunk_reader.get_read(start, length)
+    }
+}
+
 impl<R: 'static + ChunkReader> FileReader for CacheableSerializedFileReader<R> {
     fn metadata(&self) -> &ParquetMetaData {
         &self.metadata


### PR DESCRIPTION
# Which issue does this PR close?

Closes #271

# Rationale for this change
 
After #269, some parquet API is deprecated, this PR adopt to the new API.

# What changes are included in this PR?

Replace ParquetFileArrowReader with ParquetRecordBatchReader

# Are there any user-facing changes?

No
# How does this change test

Existing UT 