### PR TITLE
feat: add async parquet reader

### DIFF
--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -13,7 +13,10 @@ use table_engine::predicate::PredicateRef;
 use crate::{
     sst::{
         builder::SstBuilder,
-        parquet::{builder::ParquetSstBuilder, reader::ParquetSstReader},
+        parquet::{
+            builder::ParquetSstBuilder, reader::ParquetSstReader, AsyncParquetReader,
+            ThreadedReader,
+        },
         reader::SstReader,
     },
     table_options::Compression,
@@ -70,7 +73,16 @@ impl Factory for FactoryImpl {
         storage: &'a ObjectStoreRef,
     ) -> Option<Box<dyn SstReader + Send + 'a>> {
         match options.sst_type {
-            SstType::Parquet => Some(Box::new(ParquetSstReader::new(path, storage, options))),
+            SstType::Parquet => {
+                // FIXME: pass from reader options
+                if std::env::var("ASYNC_PARQUET_READER").unwrap_or_default() == "true" {
+                    let reader = AsyncParquetReader::new(path, storage, options);
+                    let reader = ThreadedReader::new(reader, options.runtime.clone());
+                    Some(Box::new(reader))
+                } else {
+                    Some(Box::new(ParquetSstReader::new(path, storage, options)))
+                }
+            }
         }
     }
 

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -1,0 +1,559 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Sst reader implementation based on parquet.
+
+use std::{
+    ops::Range,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use common_types::{
+    projected_schema::ProjectedSchema,
+    record_batch::{ArrowRecordBatchProjector, RecordBatchWithKey},
+};
+use common_util::{runtime::Runtime, time::InstantExt};
+use datafusion::{
+    datasource::{file_format, object_store::ObjectStoreUrl},
+    execution::context::TaskContext,
+    physical_plan::{
+        display::DisplayableExecutionPlan,
+        execute_stream,
+        file_format::{
+            FileMeta, FileScanConfig, ParquetExec, ParquetFileMetrics, ParquetFileReaderFactory,
+        },
+        metrics::ExecutionPlanMetricsSet,
+        ExecutionPlan, SendableRecordBatchStream, Statistics,
+    },
+    prelude::{SessionConfig, SessionContext},
+};
+use futures::{
+    future::{self, BoxFuture},
+    FutureExt, Stream, StreamExt, TryFutureExt,
+};
+use log::{debug, error, info};
+use object_store::{ObjectMeta, ObjectStoreRef, Path};
+use parquet::arrow::async_reader::AsyncFileReader;
+use parquet_ext::{DataCacheRef, MetaCacheRef};
+use snafu::{ensure, OptionExt, ResultExt};
+use table_engine::predicate::PredicateRef;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+
+use crate::{
+    sst::{
+        factory::SstReaderOptions,
+        file::SstMetaData,
+        parquet::encoding::{self, ParquetDecoder},
+        reader::{error::*, Result, SstReader},
+    },
+    table_options::StorageFormatOptions,
+};
+
+const CERESDB_SCHEME: &str = "ceresdb";
+const CERESDB_HOST: &str = "ceresdb";
+
+pub struct Reader<'a> {
+    /// The path where the data is persisted.
+    path: &'a Path,
+    /// The storage where the data is persist.
+    storage: &'a ObjectStoreRef,
+    projected_schema: ProjectedSchema,
+    reader_factory: Arc<dyn ParquetFileReaderFactory>,
+    meta_cache: Option<MetaCacheRef>,
+    predicate: PredicateRef,
+    batch_size: usize,
+
+    df_plan: Option<Arc<dyn ExecutionPlan>>,
+
+    /// init this field in `init_if_necessary`
+    meta_data: Option<SstMetaData>,
+}
+
+impl<'a> Reader<'a> {
+    pub fn new(path: &'a Path, storage: &'a ObjectStoreRef, options: &SstReaderOptions) -> Self {
+        let reader_factory = Arc::new(CachableParquetFileReaderFactory {
+            storage: storage.clone(),
+            data_cache: options.data_cache.clone(),
+        });
+        let batch_size = options.read_batch_row_num;
+
+        Self {
+            path,
+            storage,
+            reader_factory,
+            projected_schema: options.projected_schema.clone(),
+            meta_cache: options.meta_cache.clone(),
+            predicate: options.predicate.clone(),
+            batch_size,
+            df_plan: None,
+            meta_data: None,
+        }
+    }
+
+    async fn fetch_record_batch_stream(&mut self) -> Result<SendableRecordBatchStream> {
+        assert!(self.meta_data.is_some());
+
+        let meta_data = self.meta_data.as_ref().unwrap();
+        let object_meta = ObjectMeta {
+            location: self.path.clone(),
+            // we don't care modified time
+            last_modified: Default::default(),
+            size: meta_data.size as usize,
+        };
+
+        let schema = meta_data.schema.clone();
+        let arrow_schema = schema.to_arrow_schema_ref();
+        let row_projector = self
+            .projected_schema
+            .try_project_with_key(&meta_data.schema)
+            .map_err(|e| Box::new(e) as _)
+            .context(Projection)?;
+        let scan_config = FileScanConfig {
+            object_store_url: ObjectStoreUrl::parse(format!(
+                "{}://{}",
+                CERESDB_SCHEME, CERESDB_HOST
+            ))
+            .expect("valid object store URL"),
+            file_schema: arrow_schema,
+            file_groups: vec![vec![object_meta.clone().into()]],
+            statistics: Statistics::default(),
+            projection: Some(row_projector.existed_source_projection()),
+            limit: None,
+            table_partition_cols: vec![],
+        };
+        let filter_expr = self.predicate.to_df_expr(schema.timestamp_name());
+        debug!(
+            "send record_batch, object_meta:{:?}, filter:{:?}, scan_config:{:?}",
+            object_meta, filter_expr, scan_config
+        );
+
+        let exec = ParquetExec::new(scan_config, Some(filter_expr), Some(object_meta.size))
+            .with_parquet_file_reader_factory(self.reader_factory.clone());
+        let exec = Arc::new(exec);
+
+        // There are some options can be configured for execution, such as
+        // `DATAFUSION_EXECUTION_BATCH_SIZE`. More refer:
+        // https://arrow.apache.org/datafusion/user-guide/configs.html
+        let session_ctx =
+            SessionContext::with_config(SessionConfig::from_env().with_batch_size(self.batch_size));
+        let task_ctx = Arc::new(TaskContext::from(&session_ctx));
+        task_ctx.runtime_env().register_object_store(
+            CERESDB_SCHEME,
+            CERESDB_HOST,
+            self.storage.clone(),
+        );
+
+        self.df_plan = Some(exec.clone());
+        execute_stream(exec, task_ctx)
+            .await
+            .context(DataFusionError {})
+    }
+
+    async fn init_if_necessary(&mut self) -> Result<()> {
+        if self.meta_data.is_some() {
+            return Ok(());
+        }
+
+        let sst_meta = Self::read_sst_meta(
+            self.storage,
+            self.path,
+            &self.meta_cache,
+            &self.reader_factory,
+        )
+        .await?;
+        self.meta_data = Some(sst_meta);
+
+        Ok(())
+    }
+
+    pub async fn read_sst_meta(
+        storage: &ObjectStoreRef,
+        path: &Path,
+        meta_cache: &Option<MetaCacheRef>,
+        reader_factory: &Arc<dyn ParquetFileReaderFactory>,
+    ) -> Result<SstMetaData> {
+        let object_meta = storage.head(path).await.context(ObjectStoreError {})?;
+        let file_size = object_meta.size;
+
+        let get_metadata_from_storage = || async {
+            let mut reader = reader_factory
+                // We don't care partition_index
+                .create_reader(
+                    Default::default(),
+                    object_meta.into(),
+                    None,
+                    &ExecutionPlanMetricsSet::new(),
+                )
+                .context(DataFusionError {})?;
+            let metadata = reader.get_metadata().await.context(ParquetError {})?;
+
+            if let Some(cache) = meta_cache {
+                cache.put(path.to_string(), metadata.clone());
+            }
+            Ok(metadata)
+        };
+
+        let metadata = if let Some(cache) = meta_cache {
+            if let Some(cached_data) = cache.get(path.as_ref()) {
+                cached_data
+            } else {
+                get_metadata_from_storage().await?
+            }
+        } else {
+            get_metadata_from_storage().await?
+        };
+
+        let kv_metas = metadata
+            .file_metadata()
+            .key_value_metadata()
+            .context(SstMetaNotFound)?;
+        ensure!(!kv_metas.is_empty(), EmptySstMeta);
+
+        let mut sst_meta = encoding::decode_sst_meta_data(&kv_metas[0])
+            .map_err(|e| Box::new(e) as _)
+            .context(DecodeSstMeta)?;
+        // size in sst_meta is always 0, so overwrite it here
+        // https://github.com/CeresDB/ceresdb/issues/321
+        sst_meta.size = file_size as u64;
+        Ok(sst_meta)
+    }
+
+    #[allow(dead_code)]
+    #[cfg(test)]
+    pub(crate) async fn row_groups(&mut self) -> Vec<parquet::file::metadata::RowGroupMetaData> {
+        let object_meta = self.storage.head(self.path).await.unwrap();
+        let mut reader = self
+            .reader_factory
+            .create_reader(0, object_meta.into(), None, &ExecutionPlanMetricsSet::new())
+            .unwrap();
+
+        let metadata = reader.get_metadata().await.unwrap();
+        metadata.row_groups().to_vec()
+    }
+}
+
+impl<'a> Drop for Reader<'a> {
+    fn drop(&mut self) {
+        if self.df_plan.is_none() {
+            return;
+        }
+
+        let df_plan = self.df_plan.take().unwrap();
+        info!(
+            "Reader plan metrics:\n{}",
+            DisplayableExecutionPlan::with_metrics(&*df_plan)
+                .indent()
+                .to_string()
+        );
+    }
+}
+
+#[derive(Debug)]
+pub struct CachableParquetFileReaderFactory {
+    storage: ObjectStoreRef,
+    data_cache: Option<DataCacheRef>,
+}
+
+impl CachableParquetFileReaderFactory {
+    pub fn new(storage: ObjectStoreRef, data_cache: Option<DataCacheRef>) -> Self {
+        Self {
+            storage,
+            data_cache,
+        }
+    }
+}
+
+impl ParquetFileReaderFactory for CachableParquetFileReaderFactory {
+    fn create_reader(
+        &self,
+        partition_index: usize,
+        file_meta: FileMeta,
+        metadata_size_hint: Option<usize>,
+        metrics: &ExecutionPlanMetricsSet,
+    ) -> datafusion::error::Result<Box<dyn AsyncFileReader + Send>> {
+        let parquet_file_metrics =
+            ParquetFileMetrics::new(partition_index, file_meta.location().as_ref(), metrics);
+
+        Ok(Box::new(CachableParquetFileReader::new(
+            self.storage.clone(),
+            self.data_cache.clone(),
+            file_meta.object_meta,
+            parquet_file_metrics,
+            metadata_size_hint,
+        )))
+    }
+}
+
+struct CachableParquetFileReader {
+    storage: ObjectStoreRef,
+    data_cache: Option<DataCacheRef>,
+    meta: ObjectMeta,
+    metrics: ParquetFileMetrics,
+    metadata_size_hint: Option<usize>,
+    cache_hit: usize,
+    cache_miss: usize,
+}
+
+impl CachableParquetFileReader {
+    fn new(
+        storage: ObjectStoreRef,
+        data_cache: Option<DataCacheRef>,
+        meta: ObjectMeta,
+        metrics: ParquetFileMetrics,
+        metadata_size_hint: Option<usize>,
+    ) -> Self {
+        Self {
+            storage,
+            data_cache,
+            meta,
+            metrics,
+            metadata_size_hint,
+            cache_hit: 0,
+            cache_miss: 0,
+        }
+    }
+
+    fn cache_key(name: &str, start: usize, end: usize) -> String {
+        format!("{}_{}_{}", name, start, end)
+    }
+}
+
+impl Drop for CachableParquetFileReader {
+    fn drop(&mut self) {
+        info!(
+            "CachableParquetFileReader meta_size_hint:{:?}, cache_hit:{}, cache_miss:{}, bytes_scanned:{}",
+            self.metadata_size_hint, self.cache_hit, self.cache_miss, self.metrics.bytes_scanned.value()
+        );
+    }
+}
+
+impl AsyncFileReader for CachableParquetFileReader {
+    fn get_bytes(&mut self, range: Range<usize>) -> BoxFuture<'_, parquet::errors::Result<Bytes>> {
+        self.metrics.bytes_scanned.add(range.end - range.start);
+
+        let key = Self::cache_key(self.meta.location.as_ref(), range.start, range.end);
+        if let Some(cache) = &self.data_cache {
+            if let Some(cached_bytes) = cache.get(&key) {
+                self.cache_hit += 1;
+                return Box::pin(future::ok(Bytes::from(cached_bytes.to_vec())));
+            };
+        }
+
+        self.cache_miss += 1;
+        self.storage
+            .get_range(&self.meta.location, range)
+            .map_ok(|bytes| {
+                if let Some(cache) = &self.data_cache {
+                    cache.put(key, Arc::new(bytes.to_vec()));
+                }
+                bytes
+            })
+            .map_err(|e| {
+                parquet::errors::ParquetError::General(format!(
+                    "CachableParquetFileReader::get_bytes error: {}",
+                    e
+                ))
+            })
+            .boxed()
+    }
+
+    fn get_metadata(
+        &mut self,
+    ) -> BoxFuture<'_, parquet::errors::Result<Arc<parquet::file::metadata::ParquetMetaData>>> {
+        Box::pin(async move {
+            let metadata = file_format::parquet::fetch_parquet_metadata(
+                self.storage.as_ref(),
+                &self.meta,
+                self.metadata_size_hint,
+            )
+            .await
+            .map_err(|e| {
+                parquet::errors::ParquetError::General(format!(
+                    "CachableParquetFileReader::get_metadata error: {}",
+                    e
+                ))
+            })?;
+            Ok(Arc::new(metadata))
+        })
+    }
+}
+
+struct RecordBatchProjector {
+    stream: SendableRecordBatchStream,
+    row_projector: ArrowRecordBatchProjector,
+    storage_format_opts: StorageFormatOptions,
+
+    row_num: usize,
+    start_time: Instant,
+}
+
+impl RecordBatchProjector {
+    fn new(
+        stream: SendableRecordBatchStream,
+        row_projector: ArrowRecordBatchProjector,
+        storage_format_opts: StorageFormatOptions,
+    ) -> Self {
+        Self {
+            stream,
+            row_projector,
+            storage_format_opts,
+            row_num: 0,
+            start_time: Instant::now(),
+        }
+    }
+}
+
+impl Drop for RecordBatchProjector {
+    fn drop(&mut self) {
+        info!(
+            "RecordBatchProjector read {} rows, cost:{}ms",
+            self.row_num,
+            self.start_time.saturating_elapsed().as_millis(),
+        );
+    }
+}
+
+impl Stream for RecordBatchProjector {
+    type Item = Result<RecordBatchWithKey>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let projector = self.get_mut();
+
+        match projector.stream.poll_next_unpin(cx) {
+            Poll::Ready(Some(record_batch)) => {
+                match record_batch
+                    .map_err(|e| Box::new(e) as _)
+                    .context(DecodeRecordBatch {})
+                {
+                    Err(e) => Poll::Ready(Some(Err(e))),
+                    Ok(record_batch) => {
+                        let parquet_decoder =
+                            ParquetDecoder::new(projector.storage_format_opts.clone());
+                        let record_batch = parquet_decoder
+                            .decode_record_batch(record_batch)
+                            .map_err(|e| Box::new(e) as _)
+                            .context(DecodeRecordBatch)?;
+
+                        projector.row_num += record_batch.num_rows();
+
+                        let projected_batch = projector
+                            .row_projector
+                            .project_to_record_batch_with_key(record_batch)
+                            .map_err(|e| Box::new(e) as _)
+                            .context(DecodeRecordBatch {});
+
+                        Poll::Ready(Some(projected_batch))
+                    }
+                }
+            }
+            // expected struct `RecordBatchWithKey`, found struct `arrow::record_batch::RecordBatch`
+            // other => other
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+#[async_trait]
+impl<'a> SstReader for Reader<'a> {
+    async fn meta_data(&mut self) -> Result<&SstMetaData> {
+        self.init_if_necessary().await?;
+
+        Ok(self.meta_data.as_ref().unwrap())
+    }
+
+    async fn read(
+        &mut self,
+    ) -> Result<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>> {
+        self.init_if_necessary().await?;
+
+        let stream = self.fetch_record_batch_stream().await?;
+        let metadata = &self.meta_data.as_ref().unwrap();
+        let row_projector = self
+            .projected_schema
+            .try_project_with_key(&metadata.schema)
+            .map_err(|e| Box::new(e) as _)
+            .context(Projection)?;
+        let row_projector = ArrowRecordBatchProjector::from(row_projector);
+        let storage_format_opts = metadata.storage_format_opts.clone();
+
+        Ok(Box::new(RecordBatchProjector::new(
+            stream,
+            row_projector,
+            storage_format_opts,
+        )))
+    }
+}
+
+struct RecordBatchReceiver {
+    rx: Receiver<Result<RecordBatchWithKey>>,
+}
+
+impl Stream for RecordBatchReceiver {
+    type Item = Result<RecordBatchWithKey>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.as_mut().rx.poll_recv(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+
+const DEFAULT_CHANNEL_CAP: usize = 1024;
+
+/// Spawn a new thread to read record_batches
+pub struct ThreadedReader<'a> {
+    inner: Reader<'a>,
+    runtime: Arc<Runtime>,
+
+    channel_cap: usize,
+}
+
+impl<'a> ThreadedReader<'a> {
+    pub fn new(reader: Reader<'a>, runtime: Arc<Runtime>) -> Self {
+        Self {
+            inner: reader,
+            runtime,
+            channel_cap: DEFAULT_CHANNEL_CAP,
+        }
+    }
+
+    async fn read_record_batches(&mut self, tx: Sender<Result<RecordBatchWithKey>>) -> Result<()> {
+        let mut stream = self.inner.read().await?;
+        self.runtime.spawn(async move {
+            while let Some(batch) = stream.next().await {
+                if let Err(e) = tx.send(batch).await {
+                    error!("fail to send the fetched record batch result, err:{}", e);
+                }
+            }
+        });
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<'a> SstReader for ThreadedReader<'a> {
+    async fn meta_data(&mut self) -> Result<&SstMetaData> {
+        self.inner.meta_data().await
+    }
+
+    async fn read(
+        &mut self,
+    ) -> Result<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>> {
+        let (tx, rx) = mpsc::channel::<Result<RecordBatchWithKey>>(self.channel_cap);
+        self.read_record_batches(tx).await?;
+
+        Ok(Box::new(RecordBatchReceiver { rx }))
+    }
+}

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -173,7 +173,7 @@ mod tests {
         row_iter::tests::build_record_batch_with_key,
         sst::{
             factory::{Factory, FactoryImpl, SstBuilderOptions, SstReaderOptions, SstType},
-            parquet::reader::ParquetSstReader,
+            parquet::{reader::ParquetSstReader, AsyncParquetReader},
             reader::{tests::check_stream, SstReader},
         },
         table_options::{self, StorageFormatOptions},
@@ -193,6 +193,26 @@ mod tests {
         runtime: Arc<Runtime>,
         num_rows_per_row_group: usize,
         expected_num_rows: Vec<i64>,
+    ) {
+        parquet_write_and_then_read_back_inner(
+            runtime.clone(),
+            num_rows_per_row_group,
+            expected_num_rows.clone(),
+            false,
+        );
+        parquet_write_and_then_read_back_inner(
+            runtime,
+            num_rows_per_row_group,
+            expected_num_rows,
+            true,
+        );
+    }
+
+    fn parquet_write_and_then_read_back_inner(
+        runtime: Arc<Runtime>,
+        num_rows_per_row_group: usize,
+        expected_num_rows: Vec<i64>,
+        async_reader: bool,
     ) {
         runtime.block_on(async {
             let sst_factory = FactoryImpl;
@@ -263,8 +283,23 @@ mod tests {
                 runtime: runtime.clone(),
             };
 
-            let mut reader = ParquetSstReader::new(&sst_file_path, &store, &sst_reader_options);
-            assert_eq!(reader.meta_data().await.unwrap(), &sst_meta);
+            let mut reader: Box<dyn SstReader + Send> = if async_reader {
+                let mut reader =
+                    AsyncParquetReader::new(&sst_file_path, &store, &sst_reader_options);
+                let sst_meta_readback = {
+                    // FIXME: size of SstMetaData is not what this file's size, so overwrite it
+                    // https://github.com/CeresDB/ceresdb/issues/321
+                    let mut meta = reader.meta_data().await.unwrap().clone();
+                    meta.size = sst_meta.size;
+                    meta
+                };
+                assert_eq!(&sst_meta_readback, &sst_meta);
+                Box::new(reader)
+            } else {
+                let mut reader = ParquetSstReader::new(&sst_file_path, &store, &sst_reader_options);
+                assert_eq!(reader.meta_data().await.unwrap(), &sst_meta);
+                Box::new(reader)
+            };
             assert_eq!(
                 expected_num_rows,
                 reader

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -294,21 +294,32 @@ mod tests {
                     meta
                 };
                 assert_eq!(&sst_meta_readback, &sst_meta);
+                assert_eq!(
+                    expected_num_rows,
+                    reader
+                        .row_groups()
+                        .await
+                        .iter()
+                        .map(|g| g.num_rows())
+                        .collect::<Vec<_>>()
+                );
+
                 Box::new(reader)
             } else {
                 let mut reader = ParquetSstReader::new(&sst_file_path, &store, &sst_reader_options);
                 assert_eq!(reader.meta_data().await.unwrap(), &sst_meta);
+                assert_eq!(
+                    expected_num_rows,
+                    reader
+                        .row_groups()
+                        .await
+                        .iter()
+                        .map(|g| g.num_rows())
+                        .collect::<Vec<_>>()
+                );
+
                 Box::new(reader)
             };
-            assert_eq!(
-                expected_num_rows,
-                reader
-                    .row_groups()
-                    .await
-                    .iter()
-                    .map(|g| g.num_rows())
-                    .collect::<Vec<_>>()
-            );
 
             let mut stream = reader.read().await.unwrap();
             let mut expect_rows = vec![];

--- a/analytic_engine/src/sst/parquet/mod.rs
+++ b/analytic_engine/src/sst/parquet/mod.rs
@@ -2,7 +2,10 @@
 
 //! Sst implementation based on parquet.
 
+pub mod async_reader;
 pub mod builder;
 pub mod encoding;
 mod hybrid;
 pub mod reader;
+
+pub use async_reader::{Reader as AsyncParquetReader, ThreadedReader};

--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -230,12 +230,6 @@ impl<'a> ParquetSstReader<'a> {
 
         Ok(())
     }
-
-    #[cfg(test)]
-    pub(crate) async fn row_groups(&mut self) -> &[RowGroupMetaData] {
-        self.init_if_necessary().await.unwrap();
-        self.file_reader.as_ref().unwrap().metadata().row_groups()
-    }
 }
 
 /// A reader for projection and filter on the parquet file.
@@ -395,5 +389,16 @@ impl<'a> SstReader for ParquetSstReader<'a> {
         self.read_record_batches(tx)?;
 
         Ok(Box::new(RecordBatchReceiver { rx }))
+    }
+
+    #[cfg(test)]
+    async fn row_groups(&mut self) -> Vec<RowGroupMetaData> {
+        self.init_if_necessary().await.unwrap();
+        self.file_reader
+            .as_ref()
+            .unwrap()
+            .metadata()
+            .row_groups()
+            .to_vec()
     }
 }

--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -230,6 +230,12 @@ impl<'a> ParquetSstReader<'a> {
 
         Ok(())
     }
+
+    #[cfg(test)]
+    pub(crate) async fn row_groups(&mut self) -> &[RowGroupMetaData] {
+        self.init_if_necessary().await.unwrap();
+        self.file_reader.as_ref().unwrap().metadata().row_groups()
+    }
 }
 
 /// A reader for projection and filter on the parquet file.
@@ -389,16 +395,5 @@ impl<'a> SstReader for ParquetSstReader<'a> {
         self.read_record_batches(tx)?;
 
         Ok(Box::new(RecordBatchReceiver { rx }))
-    }
-
-    #[cfg(test)]
-    async fn row_groups(&mut self) -> Vec<RowGroupMetaData> {
-        self.init_if_necessary().await.unwrap();
-        self.file_reader
-            .as_ref()
-            .unwrap()
-            .metadata()
-            .row_groups()
-            .to_vec()
     }
 }

--- a/analytic_engine/src/sst/reader.rs
+++ b/analytic_engine/src/sst/reader.rs
@@ -84,10 +84,6 @@ pub trait SstReader {
     async fn read(
         &mut self,
     ) -> Result<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>>;
-
-    // Expose parquet related info here just for testing
-    #[cfg(test)]
-    async fn row_groups(&mut self) -> Vec<parquet::file::metadata::RowGroupMetaData>;
 }
 
 #[cfg(test)]

--- a/analytic_engine/src/sst/reader.rs
+++ b/analytic_engine/src/sst/reader.rs
@@ -48,6 +48,24 @@ pub mod error {
         #[snafu(display("Invalid schema, err:{}", source))]
         InvalidSchema { source: common_types::schema::Error },
 
+        #[snafu(display("Meet a datafusion error, err:{}\nBacktrace:\n{}", source, backtrace))]
+        DataFusionError {
+            source: datafusion::error::DataFusionError,
+            backtrace: Backtrace,
+        },
+
+        #[snafu(display("Meet a object store error, err:{}\nBacktrace:\n{}", source, backtrace))]
+        ObjectStoreError {
+            source: object_store::ObjectStoreError,
+            backtrace: Backtrace,
+        },
+
+        #[snafu(display("Meet a parquet error, err:{}\nBacktrace:\n{}", source, backtrace))]
+        ParquetError {
+            source: parquet::errors::ParquetError,
+            backtrace: Backtrace,
+        },
+
         #[snafu(display("Other kind of error:{}", source))]
         Other {
             source: Box<dyn std::error::Error + Send + Sync>,

--- a/analytic_engine/src/sst/reader.rs
+++ b/analytic_engine/src/sst/reader.rs
@@ -84,6 +84,10 @@ pub trait SstReader {
     async fn read(
         &mut self,
     ) -> Result<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>>;
+
+    // Expose parquet related info here just for testing
+    #[cfg(test)]
+    async fn row_groups(&mut self) -> Vec<parquet::file::metadata::RowGroupMetaData>;
 }
 
 #[cfg(test)]

--- a/common_types/src/time.rs
+++ b/common_types/src/time.rs
@@ -286,9 +286,9 @@ impl TimeRange {
     pub fn to_df_expr(&self, column_name: impl AsRef<str>) -> Expr {
         let ts_start = ScalarValue::TimestampMillisecond(Some(self.inclusive_start.as_i64()), None);
         let ts_end = ScalarValue::TimestampMillisecond(Some(self.exclusive_end.as_i64()), None);
-
-        let ts_low = col(column_name.as_ref().gt_eq(lit(ts_start));
-        let ts_high = col(column_name.as_ref()).lt(lit(ts_end));
+        let column_name = column_name.as_ref();
+        let ts_low = col(column_name).gt_eq(lit(ts_start));
+        let ts_high = col(column_name).lt(lit(ts_end));
 
         ts_low.and(ts_high)
     }

--- a/common_types/src/time.rs
+++ b/common_types/src/time.rs
@@ -287,7 +287,7 @@ impl TimeRange {
         let ts_start = ScalarValue::TimestampMillisecond(Some(self.inclusive_start.as_i64()), None);
         let ts_end = ScalarValue::TimestampMillisecond(Some(self.exclusive_end.as_i64()), None);
 
-        let ts_low = lit(ts_start).lt_eq(col(column_name.as_ref()));
+        let ts_low = col(column_name.as_ref().gt_eq(lit(ts_start));
         let ts_high = col(column_name.as_ref()).lt(lit(ts_end));
 
         ts_low.and(ts_high)

--- a/common_types/src/time.rs
+++ b/common_types/src/time.rs
@@ -9,6 +9,10 @@ use std::{
     time::{self, Duration, SystemTime},
 };
 
+use datafusion::{
+    prelude::{col, lit, Expr},
+    scalar::ScalarValue,
+};
 use proto::common as common_pb;
 use snafu::{Backtrace, OptionExt, Snafu};
 
@@ -275,6 +279,18 @@ impl TimeRange {
             self.inclusive_start.max(other.inclusive_start),
             self.exclusive_end.min(other.exclusive_end),
         )
+    }
+
+    /// Creates expression like:
+    /// start <= time && time < end
+    pub fn to_df_expr(&self, column_name: impl AsRef<str>) -> Expr {
+        let ts_start = ScalarValue::TimestampMillisecond(Some(self.inclusive_start.as_i64()), None);
+        let ts_end = ScalarValue::TimestampMillisecond(Some(self.exclusive_end.as_i64()), None);
+
+        let ts_low = lit(ts_start).lt_eq(col(column_name.as_ref()));
+        let ts_high = col(column_name.as_ref()).lt(lit(ts_end));
+
+        ts_low.and(ts_high)
     }
 }
 

--- a/table_engine/src/predicate.rs
+++ b/table_engine/src/predicate.rs
@@ -205,6 +205,18 @@ impl Predicate {
     pub fn time_range(&self) -> TimeRange {
         self.time_range
     }
+
+    /// Return a DataFusion [`Expr`] predicate representing the
+    /// combination of AND'ing all (`exprs`) and timestamp restriction
+    /// in this Predicate.
+    pub fn to_df_expr(&self, time_column_name: impl AsRef<str>) -> Expr {
+        self.exprs
+            .iter()
+            .cloned()
+            .fold(self.time_range.to_df_expr(time_column_name), |acc, expr| {
+                acc.and(expr)
+            })
+    }
 }
 
 /// Builder for [Predicate]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
In #312, performance has regression, so we can't replace old reader with the async reader, this PR add an async reader beside the old reader, which can be chosen by environment below
```
export ASYNC_PARQUET_READER=true
```

# What changes are included in this PR?

Add a new parquet reader based on DataFusion's ParquetExec, which use `ParquetRecordBatchStream` to parse parquet file.

# Are there any user-facing changes?

No

# How does this change test

UT `test_parquet_build_and_read`