### PR TITLE
docs: update dynamic cluster mode doc

### DIFF
--- a/docs/example-cluster-0.toml
+++ b/docs/example-cluster-0.toml
@@ -24,7 +24,7 @@ port = 8831
 [cluster.meta_client]
 # Only support "defaultCluster" currently.
 cluster_name = "defaultCluster"
-meta_addr = "{meta_addr}:2379"
+meta_addr = "http://{meta_addr}:2379"
 lease = "10s"
 timeout = "5s"
 

--- a/docs/example-cluster-1.toml
+++ b/docs/example-cluster-1.toml
@@ -24,7 +24,7 @@ port = 8832
 [cluster.meta_client]
 # Only support "defaultCluster" currently.
 cluster_name = "defaultCluster"
-meta_addr = "{meta_addr}:2379"
+meta_addr = "http://{meta_addr}:2379"
 lease = "10s"
 timeout = "5s"
 

--- a/docs/guides/src/SUMMARY.md
+++ b/docs/guides/src/SUMMARY.md
@@ -24,6 +24,7 @@
 - [Deployment](deploy/README.md)
     - [Supported Platform](deploy/platform.md)
     - [Static Routing](deploy/static_routing.md)
+    - [Dynamic Routing](deploy/dynamic_routing.md)
 - [Develop Kits](sdk.md)
 - [Protocol](protocol.md)
 - [Operation](operation/README.md)

--- a/docs/guides/src/deploy/dynamic_routing.md
+++ b/docs/guides/src/deploy/dynamic_routing.md
@@ -7,7 +7,7 @@ First, let's assume that our target is to deploy a cluster consisting of two Cer
 ## Start CeresDBs
 You can use the following command to create a CeresDB cluster with two instances.
 1. Start CeresMeta first
-   `CeresMeta` is ,Refer to [CeresMeta](https://github.com/CeresDB/ceresmeta)
+   Refer to [CeresMeta](https://github.com/CeresDB/ceresmeta)
 
 2. Prepare config of CeresDB
 * Replace `{meta_addr}` with the actual address of CeresMeta in config file

--- a/docs/guides/src/deploy/dynamic_routing.md
+++ b/docs/guides/src/deploy/dynamic_routing.md
@@ -7,11 +7,11 @@ First, let's assume that our target is to deploy a cluster consisting of two Cer
 ## Start CeresDBs
 You can use the following command to create a CeresDB cluster with two instances.
 1. Start CeresMeta first
-   Refer to [CeresMeta](https://github.com/CeresDB/ceresmeta)
+   `CeresMeta` is ,Refer to [CeresMeta](https://github.com/CeresDB/ceresmeta)
 
 2. Prepare config of CeresDB
 * Replace `{meta_addr}` with the actual address of CeresMeta in config file
- 
+
 ```toml
 # {project_path}/docs/example-cluster-0.toml
 bind_addr = "0.0.0.0"
@@ -40,7 +40,7 @@ port = 8831
 [cluster.meta_client]
 # Only support "defaultCluster" currently.
 cluster_name = "defaultCluster"
-meta_addr = "{meta_addr}:2379"
+meta_addr = "http://{meta_addr}:2379"
 lease = "10s"
 timeout = "5s"
 ```
@@ -73,7 +73,7 @@ port = 8832
 [cluster.meta_client]
 # Only support "defaultCluster" currently.
 cluster_name = "defaultCluster"
-meta_addr = "{meta_addr}:2379"
+meta_addr = "http://{meta_addr}:2379"
 lease = "10s"
 timeout = "5s"
 ```


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
CeresDB with dynamic cluster mode has been released in last week, but deploy document has not been updated, which is supported in this pull request.

# What changes are included in this PR?
* Add dynamic routing deploy document.
* Update cluster config example, Emphasize that the `meta_addr` is in http format.

# Are there any user-facing changes?
Supported dynamic cluster mode deploy document for user.

# How does this change test
It's has been tested before v0.4 released.