### PR TITLE
fix: apply missing filtering on parquet reader

### DIFF
--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -23,11 +23,10 @@ use log::{debug, error, trace};
 use object_store::{ObjectStoreRef, Path};
 use parquet::{
     arrow::{arrow_reader::ParquetRecordBatchReaderBuilder, ProjectionMask},
-    file::{metadata::RowGroupMetaData, reader::FileReader},
+    file::metadata::{ParquetMetaData, RowGroupMetaData},
 };
 use parquet_ext::{
-    reverse_reader::Builder as ReverseRecordBatchReaderBuilder, CacheableSerializedFileReader,
-    DataCacheRef, MetaCacheRef,
+    reverse_reader::Builder as ReverseRecordBatchReaderBuilder, DataCacheRef, MetaCacheRef,
 };
 use snafu::{ensure, OptionExt, ResultExt};
 use table_engine::predicate::PredicateRef;
@@ -45,12 +44,24 @@ use crate::{
 
 const DEFAULT_CHANNEL_CAP: usize = 1000;
 
-pub async fn read_sst_meta(
-    storage: &ObjectStoreRef,
-    path: &Path,
-    meta_cache: &Option<MetaCacheRef>,
-    data_cache: &Option<DataCacheRef>,
-) -> Result<(CacheableSerializedFileReader<Bytes>, SstMetaData)> {
+/// Filters row groups according to the predicate function, and returns the
+/// indexes of the filtered row groups.
+pub fn filter_row_groups(
+    metadata: &ParquetMetaData,
+    predicate: &dyn Fn(&RowGroupMetaData, usize) -> bool,
+) -> Vec<usize> {
+    let row_groups = metadata.row_groups();
+    let mut filtered_row_groups = Vec::with_capacity(row_groups.len());
+    for (i, row_group_metadata) in row_groups.iter().enumerate() {
+        if predicate(row_group_metadata, i) {
+            filtered_row_groups.push(i);
+        }
+    }
+
+    filtered_row_groups
+}
+
+pub async fn make_sst_chunk_reader(storage: &ObjectStoreRef, path: &Path) -> Result<Bytes> {
     let get_result = storage
         .get(path)
         .await
@@ -62,42 +73,35 @@ pub async fn read_sst_meta(
     // read. So under this situation it would be better to pass a local file to
     // it, avoiding consumes lots of memory. Once parquet support stream data source
     // we can feed the `GetResult` to it directly.
-    let bytes = get_result
+    get_result
         .bytes()
         .await
         .map_err(|e| Box::new(e) as _)
         .context(ReadPersist {
             path: path.to_string(),
-        })?;
+        })
+}
 
-    // generate the file reader
-    let file_reader = CacheableSerializedFileReader::try_new(
-        path.to_string(),
-        bytes,
-        meta_cache.clone(),
-        data_cache.clone(),
-    )
-    .map_err(|e| Box::new(e) as _)
-    .with_context(|| ReadPersist {
-        path: path.to_string(),
-    })?;
+pub fn make_sst_reader_builder(
+    chunk_reader: Bytes,
+) -> Result<ParquetRecordBatchReaderBuilder<Bytes>> {
+    ParquetRecordBatchReaderBuilder::try_new(chunk_reader)
+        .map_err(|e| Box::new(e) as _)
+        .context(DecodeRecordBatch)
+}
 
+pub fn read_sst_meta(metadata: &ParquetMetaData) -> Result<SstMetaData> {
     // parse sst meta data
-    let sst_meta = {
-        let kv_metas = file_reader
-            .metadata()
-            .file_metadata()
-            .key_value_metadata()
-            .context(SstMetaNotFound)?;
+    let kv_metas = metadata
+        .file_metadata()
+        .key_value_metadata()
+        .context(SstMetaNotFound)?;
 
-        ensure!(!kv_metas.is_empty(), EmptySstMeta);
+    ensure!(!kv_metas.is_empty(), EmptySstMeta);
 
-        encoding::decode_sst_meta_data(&kv_metas[0])
-            .map_err(|e| Box::new(e) as _)
-            .context(DecodeSstMeta)?
-    };
-
-    Ok((file_reader, sst_meta))
+    encoding::decode_sst_meta_data(&kv_metas[0])
+        .map_err(|e| Box::new(e) as _)
+        .context(DecodeSstMeta)
 }
 
 /// The implementation of sst based on parquet and object storage.
@@ -109,14 +113,17 @@ pub struct ParquetSstReader<'a> {
     projected_schema: ProjectedSchema,
     predicate: PredicateRef,
     meta_data: Option<SstMetaData>,
-    file_reader: Option<CacheableSerializedFileReader<Bytes>>,
+    chunk_reader: Option<Bytes>,
+    reader_builder: Option<ParquetRecordBatchReaderBuilder<Bytes>>,
     /// The batch of rows in one `record_batch`.
     batch_size: usize,
     /// Read the rows in reverse order.
     reverse: bool,
     channel_cap: usize,
 
+    #[allow(unused)]
     meta_cache: Option<MetaCacheRef>,
+    #[allow(unused)]
     data_cache: Option<DataCacheRef>,
 
     runtime: Arc<Runtime>,
@@ -130,7 +137,8 @@ impl<'a> ParquetSstReader<'a> {
             projected_schema: options.projected_schema.clone(),
             predicate: options.predicate.clone(),
             meta_data: None,
-            file_reader: None,
+            chunk_reader: None,
+            reader_builder: None,
             batch_size: options.read_batch_row_num,
             reverse: options.reverse,
             channel_cap: DEFAULT_CHANNEL_CAP,
@@ -147,20 +155,25 @@ impl<'a> ParquetSstReader<'a> {
             return Ok(());
         }
 
-        let (file_reader, sst_meta) =
-            read_sst_meta(self.storage, self.path, &self.meta_cache, &self.data_cache).await?;
+        let chunk_reader = make_sst_chunk_reader(self.storage, self.path).await?;
+        let reader_builder = make_sst_reader_builder(chunk_reader.clone())?;
+        let meta_data = read_sst_meta(reader_builder.metadata())?;
 
-        self.file_reader = Some(file_reader);
-        self.meta_data = Some(sst_meta);
+        self.reader_builder = Some(reader_builder);
+        self.meta_data = Some(meta_data);
+        self.chunk_reader = Some(chunk_reader);
 
         Ok(())
     }
 
     fn read_record_batches(&mut self, tx: Sender<Result<RecordBatchWithKey>>) -> Result<()> {
         let path = self.path.to_string();
-        ensure!(self.file_reader.is_some(), ReadAgain { path });
+        ensure!(self.reader_builder.is_some(), ReadAgain { path });
+        ensure!(self.chunk_reader.is_some(), ReadAgain { path });
+        ensure!(self.meta_data.is_some(), ReadAgain { path });
 
-        let file_reader = self.file_reader.take().unwrap();
+        let reader_builder = self.reader_builder.take();
+        let chunk_reader = self.chunk_reader.take().unwrap();
         let batch_size = self.batch_size;
         let schema = {
             let meta_data = self.meta_data.as_ref().unwrap();
@@ -194,7 +207,8 @@ impl<'a> ParquetSstReader<'a> {
 
             let reader = ProjectAndFilterReader {
                 file_path: path.clone(),
-                file_reader: Some(file_reader),
+                chunk_reader,
+                reader_builder,
                 schema,
                 projected_schema,
                 row_projector,
@@ -234,14 +248,19 @@ impl<'a> ParquetSstReader<'a> {
     #[cfg(test)]
     pub(crate) async fn row_groups(&mut self) -> &[RowGroupMetaData] {
         self.init_if_necessary().await.unwrap();
-        self.file_reader.as_ref().unwrap().metadata().row_groups()
+        self.reader_builder
+            .as_ref()
+            .unwrap()
+            .metadata()
+            .row_groups()
     }
 }
 
 /// A reader for projection and filter on the parquet file.
 struct ProjectAndFilterReader {
     file_path: String,
-    file_reader: Option<CacheableSerializedFileReader<Bytes>>,
+    chunk_reader: Bytes,
+    reader_builder: Option<ParquetRecordBatchReaderBuilder<Bytes>>,
     schema: Schema,
     projected_schema: ProjectedSchema,
     row_projector: RowProjector,
@@ -254,9 +273,14 @@ struct ProjectAndFilterReader {
 impl ProjectAndFilterReader {
     #[allow(clippy::type_complexity)]
     fn build_row_group_predicate(&self) -> Box<dyn Fn(&RowGroupMetaData, usize) -> bool + 'static> {
-        assert!(self.file_reader.is_some());
+        assert!(self.reader_builder.is_some());
 
-        let row_groups = self.file_reader.as_ref().unwrap().metadata().row_groups();
+        let row_groups = self
+            .reader_builder
+            .as_ref()
+            .unwrap()
+            .metadata()
+            .row_groups();
         let filter_results = self.predicate.filter_row_groups(&self.schema, row_groups);
 
         trace!("Finish build row group predicate, predicate:{:?}, schema:{:?}, filter_results:{:?}, row_groups meta data:{:?}", self.predicate, self.schema, filter_results, row_groups);
@@ -269,15 +293,20 @@ impl ProjectAndFilterReader {
     fn project_and_filter_reader(
         &mut self,
     ) -> Result<Box<dyn Iterator<Item = ArrowResult<RecordBatch>>>> {
-        assert!(self.file_reader.is_some());
+        assert!(self.reader_builder.is_some());
 
         let row_group_predicate = self.build_row_group_predicate();
-        let mut file_reader = self.file_reader.take().unwrap();
-        file_reader.filter_row_groups(&row_group_predicate);
+        let reader_builder = self.reader_builder.take().unwrap();
+        let filtered_row_groups =
+            filter_row_groups(reader_builder.metadata(), &row_group_predicate);
 
         if self.reverse {
-            let mut builder =
-                ReverseRecordBatchReaderBuilder::new(Arc::new(file_reader), self.batch_size);
+            let mut builder = ReverseRecordBatchReaderBuilder::new(
+                reader_builder.metadata(),
+                self.chunk_reader.clone(),
+                self.batch_size,
+            )
+            .filtered_row_groups(Some(filtered_row_groups));
             if !self.projected_schema.is_all_projection() {
                 builder = builder.projection(Some(self.row_projector.existed_source_projection()));
             }
@@ -289,14 +318,7 @@ impl ProjectAndFilterReader {
 
             Ok(Box::new(reverse_reader))
         } else {
-            let filtered_row_groups = file_reader
-                .filtered_row_group_indexes()
-                .expect("filtered row groups must exist after filtering")
-                .to_vec();
-
-            let builder = ParquetRecordBatchReaderBuilder::try_new(file_reader)
-                .map_err(|e| Box::new(e) as _)
-                .context(DecodeRecordBatch)?
+            let builder = reader_builder
                 .with_batch_size(self.batch_size)
                 .with_row_groups(filtered_row_groups);
 

--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -289,10 +289,16 @@ impl ProjectAndFilterReader {
 
             Ok(Box::new(reverse_reader))
         } else {
+            let filtered_row_groups = file_reader
+                .filtered_row_group_indexes()
+                .expect("filtered row groups must exist after filtering")
+                .to_vec();
+
             let builder = ParquetRecordBatchReaderBuilder::try_new(file_reader)
                 .map_err(|e| Box::new(e) as _)
                 .context(DecodeRecordBatch)?
-                .with_batch_size(self.batch_size);
+                .with_batch_size(self.batch_size)
+                .with_row_groups(filtered_row_groups);
 
             let builder = if self.projected_schema.is_all_projection() {
                 builder

--- a/components/parquet_ext/src/serialized_reader.rs
+++ b/components/parquet_ext/src/serialized_reader.rs
@@ -65,6 +65,7 @@ pub struct CacheableSerializedFileReader<R: ChunkReader> {
     name: String,
     chunk_reader: Arc<R>,
     metadata: Arc<ParquetMetaData>,
+    filtered_row_group_indexes: Option<Vec<usize>>,
     data_cache: Option<DataCacheRef>,
 }
 
@@ -95,23 +96,37 @@ impl<R: 'static + ChunkReader> CacheableSerializedFileReader<R> {
             name,
             chunk_reader: Arc::new(chunk_reader),
             metadata,
+            filtered_row_group_indexes: None,
             data_cache,
         })
     }
 
+    /// Returns the indexes of the filtered row groups.
+    ///
+    /// [`None`] will be returned if `filter_row_groups` has not been called
+    /// yet.
+    pub fn filtered_row_group_indexes(&self) -> Option<&[usize]> {
+        self.filtered_row_group_indexes.as_deref()
+    }
+
     /// Filters row group metadata to only those row groups,
-    /// for which the predicate function returns true
+    /// for which the predicate function returns true.
     pub fn filter_row_groups(&mut self, predicate: &dyn Fn(&RowGroupMetaData, usize) -> bool) {
-        let mut filtered_row_groups = Vec::<RowGroupMetaData>::new();
-        for (i, row_group_metadata) in self.metadata.row_groups().iter().enumerate() {
+        let row_groups = self.metadata.row_groups();
+        let mut filtered_row_group_indexes = Vec::with_capacity(row_groups.len());
+        let mut filtered_row_groups = Vec::with_capacity(row_groups.len());
+        for (i, row_group_metadata) in row_groups.iter().enumerate() {
             if predicate(row_group_metadata, i) {
                 filtered_row_groups.push(row_group_metadata.clone());
+                filtered_row_group_indexes.push(i);
             }
         }
         self.metadata = Arc::new(ParquetMetaData::new(
             self.metadata.file_metadata().clone(),
             filtered_row_groups,
         ));
+
+        self.filtered_row_group_indexes = Some(filtered_row_group_indexes);
     }
 }
 

--- a/components/parquet_ext/src/serialized_reader.rs
+++ b/components/parquet_ext/src/serialized_reader.rs
@@ -612,9 +612,8 @@ mod tests {
         assert_eq!(metadata.num_row_groups(), 1);
 
         // test filtering out all row groups
-        reader.filter_row_groups(&|_, _| false);
-        let metadata = reader.metadata();
-        assert_eq!(metadata.num_row_groups(), 0);
+        let filtered_row_groups = reader.filter_row_groups(&|_, _| false);
+        assert!(filtered_row_groups.is_empty());
 
         Ok(())
     }

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -65,7 +65,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let storage = LocalFileSystem::new_with_prefix(args.store_path).expect("invalid path");
     let storage = Arc::new(storage) as _;
     let input_path = Path::from(args.input);
-    let sst_meta = sst_util::meta_from_sst(&storage, &input_path, &None, &None).await;
+    let sst_meta = sst_util::meta_from_sst(&storage, &input_path).await;
     let factory = FactoryImpl;
     let reader_opts = SstReaderOptions {
         sst_type: SstType::Parquet,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #363 

# Rationale for this change
 After #351, the filter result about the row groups is not pushed down to parquet reading procedure.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Apply the missing filtering results to the parquet reader.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Current module will be updated in the recent future, and more UT should be added later.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
