### PR TITLE
feat: add tools sst-convert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,9 @@ name = "anyhow"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arc-swap"
@@ -463,7 +466,7 @@ dependencies = [
  "arrow 23.0.0",
  "arrow2",
  "base64 0.13.0",
- "clap",
+ "clap 3.2.23",
  "common_types 0.4.0",
  "common_util",
  "criterion",
@@ -859,7 +862,7 @@ dependencies = [
  "analytic_engine",
  "catalog",
  "catalog_impls",
- "clap",
+ "clap 3.2.23",
  "cluster",
  "common_util",
  "df_operator",
@@ -984,10 +987,49 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1242,7 +1284,7 @@ checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -3839,6 +3881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+
+[[package]]
 name = "oss-rust-sdk"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5649,12 +5697,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -5914,6 +5968,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -6353,6 +6413,24 @@ dependencies = [
  "prost-build",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tools"
+version = "0.4.0"
+dependencies = [
+ "analytic_engine",
+ "anyhow",
+ "clap 3.2.23",
+ "common_types 0.4.0",
+ "common_util",
+ "env_logger",
+ "futures 0.3.21",
+ "object_store 0.4.0",
+ "parquet 23.0.0",
+ "parquet_ext",
+ "table_engine",
+ "tokio 1.20.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "system_catalog",
     "table_engine",
     "tests/harness",
+    "tools",
     "wal",
 ]
 
@@ -61,6 +62,7 @@ bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
 chrono = "0.4"
+clap = "3.0"
 cluster = { path = "cluster" }
 criterion = "0.3"
 common_types = { path = "common_types" }
@@ -117,7 +119,7 @@ rev = "d84ea9c79c9e83ff0b4dadf8880a4983af59ef48"
 analytic_engine = { workspace = true }
 catalog = { workspace = true }
 catalog_impls = { workspace = true }
-clap = "2.0"
+clap = { workspace = true }
 cluster = { workspace = true }
 common_util = { workspace = true }
 df_operator = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -12,7 +12,7 @@ arrow2 = { version = "0.12.0", features = [ "io_parquet" ] }
 arrow = { workspace = true }
 analytic_engine = { workspace = true }
 base64 = { workspace = true }
-clap = "2.0"
+clap = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }
 env_logger = { workspace = true }

--- a/benchmarks/src/bin/sst-tools.rs
+++ b/benchmarks/src/bin/sst-tools.rs
@@ -40,7 +40,7 @@ fn main() {
     let matches = App::new("SST Tools")
         .arg(
             Arg::with_name("config")
-                .short("c")
+                .short('c')
                 .long("config")
                 .required(true)
                 .takes_value(true)

--- a/src/bin/ceresdb-server.rs
+++ b/src/bin/ceresdb-server.rs
@@ -38,7 +38,7 @@ fn main() {
         .version(version.as_str())
         .arg(
             Arg::with_name("config")
-                .short("c")
+                .short('c')
                 .long("config")
                 .required(false)
                 .takes_value(true)

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "tools"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+analytic_engine = { workspace = true }
+common_types = { workspace = true }
+common_util = { workspace = true }
+env_logger = { workspace = true }
+object_store = { workspace = true }
+tokio = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+anyhow = { version = "1.0", features = ["backtrace"] }
+parquet = { workspace = true }
+parquet_ext = { workspace = true }
+table_engine = { workspace = true }
+futures = { workspace = true }

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -1,0 +1,107 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! A cli to convert ssts between different options
+
+use std::{error::Error, sync::Arc};
+
+use analytic_engine::{
+    sst::factory::{Factory, FactoryImpl, SstBuilderOptions, SstReaderOptions, SstType},
+    table_options::Compression,
+};
+use anyhow::{Context, Result};
+use clap::Parser;
+use common_types::{projected_schema::ProjectedSchema, request_id::RequestId};
+use common_util::runtime::{self, Runtime};
+use futures::stream::StreamExt;
+use object_store::{LocalFileSystem, Path};
+use table_engine::predicate::Predicate;
+use tools::sst_util;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Root dir of storage
+    #[clap(short, long, required(true))]
+    store_path: String,
+
+    /// Input sst file(relative to store_path)
+    #[clap(short, long, required(true))]
+    input: String,
+
+    /// Output sst file(relative to store_path)
+    #[clap(short, long, required(true))]
+    output: String,
+
+    /// Compression of new sst file(values: uncompressed/lz4/snappy/zstd)
+    #[clap(short, long, default_value = "uncompressed")]
+    compression: String,
+
+    /// Row group size of new sst file
+    #[clap(short, long, default_value_t = 8192)]
+    batch_size: usize,
+}
+
+fn new_runtime(thread_num: usize) -> Runtime {
+    runtime::Builder::default()
+        .thread_name("tools")
+        .worker_threads(thread_num)
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn main() {
+    let args = Args::parse();
+    let rt = Arc::new(new_runtime(4));
+    let rt2 = rt.clone();
+    rt.block_on(async move {
+        if let Err(e) = run(args, rt2).await {
+            eprintln!("Convert failed, err:{}", e);
+        }
+    });
+}
+
+async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
+    let storage = LocalFileSystem::new_with_prefix(args.store_path).expect("invalid path");
+    let storage = Arc::new(storage) as _;
+    let input_path = Path::from(args.input);
+    let sst_meta = sst_util::meta_from_sst(&storage, &input_path, &None, &None).await;
+    let factory = FactoryImpl;
+    let reader_opts = SstReaderOptions {
+        sst_type: SstType::Parquet,
+        read_batch_row_num: 8192,
+        reverse: false,
+        projected_schema: ProjectedSchema::no_projection(sst_meta.schema.clone()),
+        predicate: Arc::new(Predicate::empty()),
+        meta_cache: None,
+        data_cache: None,
+        runtime,
+    };
+    let mut reader = factory
+        .new_sst_reader(&reader_opts, &input_path, &storage)
+        .expect("no sst reader found");
+
+    let builder_opts = SstBuilderOptions {
+        sst_type: SstType::Parquet,
+        num_rows_per_row_group: args.batch_size,
+        compression: Compression::parse_from(&args.compression)
+            .with_context(|| format!("invalid compression:{}", args.compression))?,
+    };
+    let output = Path::from(args.output);
+    let mut builder = factory
+        .new_sst_builder(&builder_opts, &output, &storage)
+        .expect("no sst builder found");
+    let sst_stream = reader
+        .read()
+        .await
+        .unwrap()
+        .map(|batch| batch.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>));
+    let sst_stream = Box::new(sst_stream) as _;
+    let sst_info = builder
+        .build(RequestId::next_id(), &sst_meta, sst_stream)
+        .await?;
+
+    println!("Write success, info:{:?}", sst_info);
+
+    Ok(())
+}

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod sst_util;

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,1 +1,3 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 pub mod sst_util;

--- a/tools/src/sst_util.rs
+++ b/tools/src/sst_util.rs
@@ -1,0 +1,16 @@
+use analytic_engine::sst::{file::SstMetaData, parquet::reader};
+use object_store::{ObjectStoreRef, Path};
+use parquet_ext::{DataCacheRef, MetaCacheRef};
+
+pub async fn meta_from_sst(
+    store: &ObjectStoreRef,
+    sst_path: &Path,
+    meta_cache: &Option<MetaCacheRef>,
+    data_cache: &Option<DataCacheRef>,
+) -> SstMetaData {
+    let (_, sst_meta) = reader::read_sst_meta(store, sst_path, meta_cache, data_cache)
+        .await
+        .unwrap();
+
+    sst_meta
+}

--- a/tools/src/sst_util.rs
+++ b/tools/src/sst_util.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 use analytic_engine::sst::{file::SstMetaData, parquet::reader};
 use object_store::{ObjectStoreRef, Path};
 use parquet_ext::{DataCacheRef, MetaCacheRef};


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
For now, we need to test different sst options to determine which is best for performance, but there is no fast way to convert existing sst to other options, so this PR add a cli to do this job.  

# What changes are included in this PR?

Add tools workspace member, and there is one cli: `sst-convert`, 
```
cargo run --bin sst-convert -- -h

tools 0.4.0
CeresDB Authors <ceresdbservice@gmail.com>

USAGE:
    sst-convert [OPTIONS] --store-path <STORE_PATH> --input <INPUT> --output <OUTPUT>

OPTIONS:
    -b, --batch-size <BATCH_SIZE>      Row group size of new sst file [default: 8192]
    -c, --compression <COMPRESSION>    Compression of new sst file(values:
                                       uncompressed/lz4/snappy/zstd) [default: uncompressed]
    -h, --help                         Print help information
    -i, --input <INPUT>                Input sst file(relative to store_path)
    -o, --output <OUTPUT>              Output sst file(relative to store_path)
    -s, --store-path <STORE_PATH>      Root dir of storage
    -V, --version                      Print version information
```
# Are there any user-facing changes?

No

# How does this change test

Manually
