### PR TITLE
feat: add bloom filter when write sst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "common_util",
  "datafusion 12.0.0",
  "env_logger",
+ "ethbloom",
  "futures 0.3.21",
  "lazy_static",
  "log",
@@ -1909,6 +1910,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "fail"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +1997,18 @@ dependencies = [
  "lazy_static",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions 1.1.0",
 ]
 
 [[package]]
@@ -2698,6 +2724,24 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4968,6 +5012,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes 1.2.1",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.3.0"
 source = "git+https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7e4d1901cbe3f2782c5c63cb7af628bac"
@@ -5064,6 +5118,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc-serialize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ common_types = { path = "common_types" }
 common_util = { path = "common_util" }
 df_operator = { path = "df_operator" }
 env_logger = "0.6"
+ethbloom = "0.13.0"
 futures = "0.3"
 lazy_static = "1.4.0"
 log = "0.4"

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -20,6 +20,7 @@ bytes = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }
 datafusion = { workspace = true }
+ethbloom = { workspace = true }
 futures = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -594,7 +594,6 @@ mod tests {
             file::SstMetaData,
             manager::{tests::LevelsControllerMockBuilder, LevelsController},
         },
-        table_options::StorageFormatOptions,
     };
 
     fn build_sst_meta_data(time_range: TimeRange, size: u64) -> SstMetaData {
@@ -606,7 +605,8 @@ mod tests {
             schema: build_schema(),
             size,
             row_num: 2,
-            storage_format_opts: StorageFormatOptions::default(),
+            storage_format_opts: Default::default(),
+            bloom_filter: Default::default(),
         }
     }
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -620,6 +620,7 @@ impl Instance {
                 storage_format_opts: StorageFormatOptions::new(
                     table_data.table_options().storage_format,
                 ),
+                bloom_filter: Default::default(),
             };
 
             let store = self.space_store.clone();
@@ -725,6 +726,7 @@ impl Instance {
             size: 0,
             row_num: 0,
             storage_format_opts: StorageFormatOptions::new(table_data.storage_format()),
+            bloom_filter: Default::default(),
         };
 
         // Alloc file id for next sst file

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -27,6 +27,7 @@ use common_util::{
     metric::Meter,
     runtime::{JoinHandle, Runtime},
 };
+use ethbloom::Bloom;
 use log::{debug, error, info};
 use object_store::ObjectStoreRef;
 use proto::{common as common_pb, sst as sst_pb};
@@ -440,11 +441,20 @@ pub struct SstMetaData {
     // total row number
     pub row_num: u64,
     pub storage_format_opts: StorageFormatOptions,
+    pub bloom_filters: Vec<Vec<Bloom>>,
 }
 
 impl SstMetaData {
     pub fn storage_format(&self) -> StorageFormat {
         self.storage_format_opts.format
+    }
+
+    fn bloom_filters_bytes(&self) -> Vec<u8> {
+        todo!()
+    }
+
+    fn parse_bloom_filters(buf: &[u8]) -> Result<Vec<Vec<Bloom>>> {
+        todo!()
     }
 }
 
@@ -459,6 +469,7 @@ impl From<SstMetaData> for sst_pb::SstMetaData {
             size: src.size,
             row_num: src.row_num,
             storage_format_opts: Some(src.storage_format_opts.into()),
+            bloom_filter: src.bloom_filters_bytes(),
         }
     }
 }
@@ -479,6 +490,8 @@ impl TryFrom<sst_pb::SstMetaData> for SstMetaData {
             src.storage_format_opts
                 .context(StorageFormatOptionsNotFound)?,
         );
+        let bloom_filters = Self::parse_bloom_filters(&src.bloom_filter).unwrap();
+
         Ok(Self {
             min_key: src.min_key.into(),
             max_key: src.max_key.into(),
@@ -488,6 +501,7 @@ impl TryFrom<sst_pb::SstMetaData> for SstMetaData {
             size: src.size,
             row_num: src.row_num,
             storage_format_opts,
+            bloom_filters,
         })
     }
 }

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -447,11 +447,14 @@ mod tests {
         // rows per group: 10
         let testcases = vec![
             // input, expected
+            (vec![], vec![]),
             (vec![10, 10], vec![10, 10]),
             (vec![10, 10, 1], vec![10, 10, 1]),
             (vec![10, 10, 21], vec![10, 10, 10, 10, 1]),
             (vec![5, 6, 10], vec![10, 10, 1]),
             (vec![5, 4, 4, 30], vec![10, 10, 10, 10, 3]),
+            (vec![20, 7, 23, 20], vec![10, 10, 10, 10, 10, 10, 10]),
+            (vec![21], vec![10, 10, 1]),
         ];
 
         for (input, expected) in testcases {

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -125,6 +125,7 @@ impl RecordBytesReader {
                         for records in std::mem::take(&mut current_batch) {
                             pending_record_batch.push_front(records);
                         }
+                        break;
                     }
                 }
             }

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -224,7 +224,7 @@ mod tests {
             parquet::{reader::ParquetSstReader, AsyncParquetReader},
             reader::{tests::check_stream, SstReader},
         },
-        table_options::{self},
+        table_options,
     };
 
     // TODO(xikai): add test for reverse reader

--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -903,6 +903,7 @@ mod tests {
             size: 10,
             row_num: 4,
             storage_format_opts,
+            bloom_filter: Default::default(),
         };
         let mut encoder =
             HybridRecordEncoder::try_new(100, Compression::ZSTD, meta_data.clone()).unwrap();

--- a/analytic_engine/src/table/version_edit.rs
+++ b/analytic_engine/src/table/version_edit.rs
@@ -100,6 +100,7 @@ impl TryFrom<meta_pb::AddFileMeta> for AddFile {
                     size: src.size,
                     row_num: src.row_num,
                     storage_format_opts: StorageFormatOptions::new(storage_format.into()),
+                    bloom_filter: Default::default(),
                 },
             },
         };

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -484,8 +484,24 @@ impl Datum {
         }
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
-        todo!("FIXME")
+    pub fn as_bytes(&self) -> Vec<u8> {
+        match self {
+            Datum::Double(v) => v.to_le_bytes().to_vec(),
+            Datum::Float(v) => v.to_le_bytes().to_vec(),
+            Datum::UInt64(v) => v.to_le_bytes().to_vec(),
+            Datum::UInt32(v) => v.to_le_bytes().to_vec(),
+            Datum::UInt16(v) => v.to_le_bytes().to_vec(),
+            Datum::UInt8(v) => v.to_le_bytes().to_vec(),
+            Datum::Int64(v) => v.to_le_bytes().to_vec(),
+            Datum::Int32(v) => v.to_le_bytes().to_vec(),
+            Datum::Int16(v) => v.to_le_bytes().to_vec(),
+            Datum::Int8(v) => v.to_le_bytes().to_vec(),
+            Datum::Boolean(v) => (if *v { 1u8 } else { 0u8 }).to_le_bytes().to_vec(),
+            Datum::Null => 0u8.to_le_bytes().to_vec(),
+            Datum::Timestamp(ts) => ts.as_i64().to_le_bytes().to_vec(),
+            Datum::Varbinary(b) => b.to_vec(),
+            Datum::String(string) => string.as_bytes().to_vec(),
+        }
     }
 
     /// Generate a negative datum if possible.

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -484,7 +484,7 @@ impl Datum {
         }
     }
 
-    pub fn as_bytes(&self) -> Vec<u8> {
+    pub fn to_bytes(&self) -> Vec<u8> {
         match self {
             Datum::Double(v) => v.to_le_bytes().to_vec(),
             Datum::Float(v) => v.to_le_bytes().to_vec(),

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -484,6 +484,10 @@ impl Datum {
         }
     }
 
+    pub fn as_bytes(&self) -> &[u8] {
+        todo!("FIXME")
+    }
+
     /// Generate a negative datum if possible.
     ///
     /// It will return `None` if:

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -496,8 +496,14 @@ impl Datum {
             Datum::Int32(v) => v.to_le_bytes().to_vec(),
             Datum::Int16(v) => v.to_le_bytes().to_vec(),
             Datum::Int8(v) => v.to_le_bytes().to_vec(),
-            Datum::Boolean(v) => (if *v { 1u8 } else { 0u8 }).to_le_bytes().to_vec(),
-            Datum::Null => 0u8.to_le_bytes().to_vec(),
+            Datum::Boolean(v) => {
+                if *v {
+                    vec![1]
+                } else {
+                    vec![0]
+                }
+            }
+            Datum::Null => vec![0],
             Datum::Timestamp(ts) => ts.as_i64().to_le_bytes().to_vec(),
             Datum::Varbinary(b) => b.to_vec(),
             Datum::String(string) => string.as_bytes().to_vec(),

--- a/proto/protos/sst.proto
+++ b/proto/protos/sst.proto
@@ -9,10 +9,10 @@ import "analytic_common.proto";
 
 message SstBloomFilter {
   message RowGroupFilter {
-    repeated bytes bloom_filter = 1;
+    repeated bytes column_filters = 1;
   };
 
-  repeated RowGroupFilter filters = 1;
+  repeated RowGroupFilter row_group_filters = 1;
 }
 
 message SstMetaData {

--- a/proto/protos/sst.proto
+++ b/proto/protos/sst.proto
@@ -7,6 +7,14 @@ package sst;
 import "common.proto";
 import "analytic_common.proto";
 
+message SstBloomFilter {
+  message RowGroupFilter {
+    repeated bytes bloom_filter = 1;
+  };
+
+  repeated RowGroupFilter filters = 1;
+}
+
 message SstMetaData {
   // Min key in the sst
   bytes min_key = 1;
@@ -20,6 +28,5 @@ message SstMetaData {
   uint64 size = 6;
   uint64 row_num = 7;
   analytic_common.StorageFormatOptions storage_format_opts = 8;
-  // Bloom filter for each row group
-  bytes bloom_filter = 9;
+  SstBloomFilter bloom_filter = 9;
 }

--- a/proto/protos/sst.proto
+++ b/proto/protos/sst.proto
@@ -20,4 +20,6 @@ message SstMetaData {
   uint64 size = 6;
   uint64 row_num = 7;
   analytic_common.StorageFormatOptions storage_format_opts = 8;
+  // Bloom filter for each row group
+  bytes bloom_filter = 9;
 }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #363 

# Rationale for this change
 
Described in #363, bloom filter is beneficial for columns with high cardinality, so this PR append bloom filter to sst's meta when write SST files.

# What changes are included in this PR?

Update sst write process, loop record batch twice:
- first to build bloom filter
- second to write to underlying storage.

> Note: for now, all columns is appended with bloom filter, some columns may not suitable for it, we can remove them in future to reduce meta size.
# Are there any user-facing changes?

No

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Add UT: test_partition_record_batch


After we support prune by bloom filter, we can add more test cases.