### PR TITLE
fix: add ignore to  test on message queue's kafka implementation.

### DIFF
--- a/components/message_queue/src/tests/cases.rs
+++ b/components/message_queue/src/tests/cases.rs
@@ -19,6 +19,7 @@ use crate::{
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore]
 async fn test_kafka() {
     let mut config = Config::default();
     config.client_config.boost_broker = Some("127.0.0.1:9011".to_string());

--- a/components/message_queue/src/tests/cases.rs
+++ b/components/message_queue/src/tests/cases.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore]
+#[ignore = "It can just run with a Kafka cluster"]
 async fn test_kafka() {
     let mut config = Config::default();
     config.client_config.boost_broker = Some("127.0.0.1:9011".to_string());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Tests on message queue's kafka implementation should not be run automatically.

# What changes are included in this PR?
Add `ignore` to message queue's tests.

# Are there any user-facing changes?
None.

# How does this change test
None.

