### PR TITLE
refactor: build row groups from record batch stream

### DIFF
--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -77,6 +77,11 @@ impl RecordBytesReader {
         Ok(())
     }
 
+    /// Fetch an integrate row group from the `self.record_stream`.
+    ///
+    /// Except the last one, every row group is ensured to contains exactly
+    /// `self.num_rows_per_row_group`. As for the last one, it will cover all
+    /// the left rows.
     async fn fetch_next_row_group(
         &mut self,
         prev_record_batch: &mut Option<RecordBatchWithKey>,


### PR DESCRIPTION
# Which issue does this PR close?

Refactor for #370

# Rationale for this change
 Previous implementation for building row groups from record batch is a little bit complex, and this pr will do some refactoring work for that.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Refactor the `partition_record_batch`;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
