### PR TITLE
feat: filter row groups by bloom filter

### DIFF
--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -448,6 +448,11 @@ impl BloomFilter {
     pub fn new(filters: Vec<Vec<Bloom>>) -> Self {
         Self { filters }
     }
+
+    #[inline]
+    pub fn filters(&self) -> &[Vec<Bloom>] {
+        &self.filters
+    }
 }
 
 impl From<BloomFilter> for sst_pb::SstBloomFilter {

--- a/analytic_engine/src/sst/parquet/mod.rs
+++ b/analytic_engine/src/sst/parquet/mod.rs
@@ -7,5 +7,6 @@ pub mod builder;
 pub mod encoding;
 mod hybrid;
 pub mod reader;
+pub(crate) mod row_group_filter;
 
 pub use async_reader::{Reader as AsyncParquetReader, ThreadedReader};

--- a/analytic_engine/src/sst/parquet/row_group_filter.rs
+++ b/analytic_engine/src/sst/parquet/row_group_filter.rs
@@ -49,6 +49,8 @@ impl<'a> RowGroupFilter<'a> {
 
     pub fn filter(&self) -> Vec<usize> {
         let filtered0 = self.filter_by_min_max();
+        // TODO: We can do continuous filtering based on the `filtered0` to reduce the
+        // filtering cost.
         let filtered1 = self.filter_by_bloom();
         Self::intersect_filtered_row_groups(&filtered0, &filtered1)
     }

--- a/analytic_engine/src/sst/parquet/row_group_filter.rs
+++ b/analytic_engine/src/sst/parquet/row_group_filter.rs
@@ -1,0 +1,104 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Filter for row groups.
+
+use std::cmp::Ordering;
+
+use arrow::datatypes::SchemaRef;
+use common_types::datum::Datum;
+use datafusion::{prelude::Expr, scalar::ScalarValue};
+use ethbloom::{Bloom, Input};
+use parquet::file::metadata::RowGroupMetaData;
+use parquet_ext::prune::{
+    equal::{self, ColumnPosition},
+    min_max,
+};
+use snafu::ensure;
+
+use crate::sst::reader::error::{OtherNoCause, Result};
+
+pub struct RowGroupFilter<'a> {
+    schema: &'a SchemaRef,
+    row_groups: &'a [RowGroupMetaData],
+    blooms: &'a [Vec<Bloom>],
+    predicates: &'a [Expr],
+}
+
+impl<'a> RowGroupFilter<'a> {
+    pub fn try_new(
+        schema: &'a SchemaRef,
+        row_groups: &'a [RowGroupMetaData],
+        blooms: &'a [Vec<Bloom>],
+        predicates: &'a [Expr],
+    ) -> Result<Self> {
+        ensure!(blooms.len() == row_groups.len(), OtherNoCause {
+            msg: format!("expect the same number of bloom filter as the number of row groups, num_bloom_filters:{}, num_row_groups:{}", blooms.len(), row_groups.len()),
+        });
+
+        Ok(Self {
+            schema,
+            row_groups,
+            blooms,
+            predicates,
+        })
+    }
+
+    pub fn filter(&self) -> Vec<usize> {
+        let filtered0 = self.filter_by_min_max();
+        let filtered1 = self.filter_by_bloom();
+        Self::intersect_filtered_row_groups(&filtered0, &filtered1)
+    }
+
+    fn filter_by_min_max(&self) -> Vec<usize> {
+        min_max::filter_row_groups(self.schema.clone(), self.predicates, self.row_groups)
+    }
+
+    fn filter_by_bloom(&self) -> Vec<usize> {
+        let is_equal =
+            |col_pos: ColumnPosition, val: &ScalarValue, negated: bool| -> Option<bool> {
+                let datum = Datum::from_scalar_value(val)?;
+                let col_bloom = self
+                    .blooms
+                    .get(col_pos.row_group_idx)?
+                    .get(col_pos.column_idx)?;
+                let exist = col_bloom.contains_input(Input::Raw(&datum.to_bytes()));
+                if exist {
+                    // bloom filter has false positivity, that is to say we are unsure whether this
+                    // value exists even if the bloom filter says it exists.
+                    None
+                } else {
+                    Some(negated)
+                }
+            };
+
+        equal::filter_row_groups(
+            self.schema.clone(),
+            self.predicates,
+            self.row_groups.len(),
+            is_equal,
+        )
+    }
+
+    /// Compute the intersection of the two row groups.
+    fn intersect_filtered_row_groups(row_groups0: &[usize], row_groups1: &[usize]) -> Vec<usize> {
+        let mut intersect = Vec::with_capacity(row_groups0.len().min(row_groups1.len()));
+
+        let (mut i0, mut i1) = (0, 0);
+        while i0 < row_groups0.len() && i1 < row_groups1.len() {
+            let idx0 = row_groups0[i0];
+            let idx1 = row_groups1[i1];
+
+            match idx0.cmp(&idx1) {
+                Ordering::Less => i0 += 1,
+                Ordering::Greater => i1 += 1,
+                Ordering::Equal => {
+                    intersect.push(idx0);
+                    i0 += 1;
+                    i1 += 1;
+                }
+            }
+        }
+
+        intersect
+    }
+}

--- a/analytic_engine/src/sst/reader.rs
+++ b/analytic_engine/src/sst/reader.rs
@@ -70,6 +70,9 @@ pub mod error {
         Other {
             source: Box<dyn std::error::Error + Send + Sync>,
         },
+
+        #[snafu(display("Other kind of error, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
+        OtherNoCause { msg: String, backtrace: Backtrace },
     }
 
     define_result!(Error);


### PR DESCRIPTION
# Which issue does this PR close?

Part of #363 

# Rationale for this change
 Utilize the bloom filter stored in the sst meta data to do filtering on the row groups according to the provided predicate.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Support filter row groups in when reading file.
- Update the `EqPruner`'s interface to make it more reasonable.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
New unit test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
