### PR TITLE
feat: read all bytes out before do async bench

### DIFF
--- a/benchmarks/src/bin/parquet-reader.rs
+++ b/benchmarks/src/bin/parquet-reader.rs
@@ -6,12 +6,13 @@ use benchmarks::{
     config::{self, BenchConfig},
     parquet_bench::ParquetBench,
 };
+use env_logger::Env;
 
 static INIT_LOG: Once = Once::new();
 
 pub fn init_bench() -> BenchConfig {
     INIT_LOG.call_once(|| {
-        env_logger::init();
+        env_logger::from_env(Env::default().default_filter_or("info")).init();
     });
 
     config::bench_config_from_env()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In parquet sync read, file is read out before iterate record batch, this PR update async read bench, to let it have same logic with sync version

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Not required

A benchmark for parquet file with 103951966 rows
```
[2022-11-14T09:03:56Z INFO  benchmarks::parquet_bench]                                                                                                               
ParquetBench Async total rows of sst:103951966, total batch num:12690,
                open cost:790.76716ms, filter cost:149.713098ms, iter cost:9.603906449s

[2022-11-14T09:31:39Z INFO  benchmarks::parquet_bench] 
ParquetBench Sync total rows of sst:103951966, total batch num:12690,
                open cost:969.653961ms, filter cost:165.7483ms, iter cost:9.981503914s
```
