### PR TITLE
fix: add meta client timeout

### DIFF
--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -61,7 +61,8 @@ impl MetaClientImpl {
                 .map_err(|e| Box::new(e) as _)
                 .context(FailConnect {
                     addr: &config.meta_addr,
-                })?;
+                })?
+                .timeout(config.timeout.0);
             MetaServiceGrpcClient::connect(endpoint)
                 .await
                 .map_err(|e| Box::new(e) as _)


### PR DESCRIPTION
# Which issue does this PR close?
None.

# Rationale for this change
CeresDB interacts with CeresMeta through grpc implemented in `meta_client`, and now the timeout of grpc is not set, this will cause CeresDB to be blocked when the network fails.

# What changes are included in this PR?
* Add timeout config in `meta_client`.


# Are there any user-facing changes?
None.

# How does this change test
Local manual test.
