### PR TITLE
feat: refacor existing wal implementations to support scanning logs of shard

### DIFF
--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -760,10 +760,13 @@ mod tests {
         }
 
         async fn open_manifest(&self) -> ManifestImpl {
-            let manifest_wal =
-                WalBuilder::with_default_rocksdb_config(self.dir.clone(), self.runtime.clone())
-                    .build()
-                    .unwrap();
+            let manifest_wal = WalBuilder::with_default_rocksdb_config(
+                self.dir.clone(),
+                self.runtime.clone(),
+                DEFAULT_SHARD_ID as RegionId,
+            )
+            .build()
+            .unwrap();
 
             ManifestImpl::open(Arc::new(manifest_wal), self.options.clone())
                 .await

--- a/wal/src/kv_encoder.rs
+++ b/wal/src/kv_encoder.rs
@@ -118,14 +118,17 @@ pub enum Namespace {
 }
 
 /// Log key in old wal design, map the `TableId` to `RegionId`
+#[allow(unused)]
 pub type LogKey = (RegionId, SequenceNumber);
 
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct LogKeyEncoder {
     pub version: u8,
     pub namespace: Namespace,
 }
 
+#[allow(unused)]
 impl LogKeyEncoder {
     /// Create newest version encoder.
     pub fn newest() -> Self {
@@ -202,11 +205,13 @@ impl Decoder<LogKey> for LogKeyEncoder {
     }
 }
 
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct LogValueEncoder {
     pub version: u8,
 }
 
+#[allow(unused)]
 impl LogValueEncoder {
     /// Create newest version encoder.
     pub fn newest() -> Self {
@@ -238,10 +243,12 @@ impl<T: Payload> Encoder<T> for LogValueEncoder {
     }
 }
 
+#[allow(unused)]
 pub struct LogValueDecoder {
     pub version: u8,
 }
 
+#[allow(unused)]
 impl LogValueDecoder {
     pub fn decode<'a>(&self, mut buf: &'a [u8]) -> Result<&'a [u8]> {
         let version = buf.try_get_u8().context(DecodeLogValueHeader)?;
@@ -471,6 +478,7 @@ impl MaxSeqMetaEncoding {
     }
 }
 
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct LogEncoding {
     key_enc: LogKeyEncoder,
@@ -479,6 +487,7 @@ pub struct LogEncoding {
     value_enc_version: u8,
 }
 
+#[allow(unused)]
 impl LogEncoding {
     pub fn newest() -> Self {
         Self {

--- a/wal/src/kv_encoder.rs
+++ b/wal/src/kv_encoder.rs
@@ -584,7 +584,7 @@ impl LogBatchEncoder {
 
 /// Common log key used in multiple wal implementation
 #[allow(unused)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct CommonLogKey {
     /// Id of region which the table belongs to,
     /// region may be mapped to table itself, shard, or others...

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -61,7 +61,7 @@ impl TableUnit {
     }
 
     #[inline]
-    /// Generate [LogKey] from `region_id', `table_id` and `sequence_num`
+    /// Generate [LogKey] from `region_id`, `table_id` and `sequence_num`.
     fn log_key(&self, region_id: RegionId, sequence_num: SequenceNumber) -> CommonLogKey {
         CommonLogKey::new(region_id, self.id, sequence_num)
     }

--- a/wal/src/table_kv_impl/encoding.rs
+++ b/wal/src/table_kv_impl/encoding.rs
@@ -120,16 +120,16 @@ mod tests {
     fn test_format_table_unit_meta() {
         let ns = "abcdef";
         let name = format_table_unit_meta_name(ns, 0);
-        assert_eq!("region_meta_abcdef_000000", name);
+        assert_eq!("table_unit_meta_abcdef_000000", name);
 
         let name = format_table_unit_meta_name(ns, 124);
-        assert_eq!("region_meta_abcdef_000124", name);
+        assert_eq!("table_unit_meta_abcdef_000124", name);
 
         let name = format_table_unit_meta_name(ns, 999999);
-        assert_eq!("region_meta_abcdef_999999", name);
+        assert_eq!("table_unit_meta_abcdef_999999", name);
 
         let name = format_table_unit_meta_name(ns, 1234567);
-        assert_eq!("region_meta_abcdef_1234567", name);
+        assert_eq!("table_unit_meta_abcdef_1234567", name);
     }
 
     #[test]

--- a/wal/src/table_kv_impl/encoding.rs
+++ b/wal/src/table_kv_impl/encoding.rs
@@ -3,11 +3,9 @@
 //! Constants and utils for encoding.
 
 use chrono::{TimeZone, Utc};
-use common_types::time::Timestamp;
+use common_types::{table::TableId, time::Timestamp};
 use common_util::config::ReadableDuration;
 use table_kv::{KeyBoundary, ScanRequest};
-
-use crate::manager::RegionId;
 
 /// Key prefix for namespace in meta table.
 const META_NAMESPACE_PREFIX: &str = "v1/namespace";
@@ -15,8 +13,8 @@ const META_NAMESPACE_PREFIX: &str = "v1/namespace";
 const META_BUCKET_PREFIX: &str = "v1/bucket";
 /// Format of bucket timestamp.
 const BUCKET_TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
-/// Key prefix of region meta.
-const REGION_META_PREFIX: &str = "v1/region";
+/// Key prefix of table unit meta.
+const TABLE_UNIT_META_PREFIX: &str = "v1/table";
 /// Format of timestamp in wal table name.
 const WAL_SHARD_TIMESTAMP_FORMAT: &str = "%Y%m%d%H%M%S";
 
@@ -61,8 +59,8 @@ pub fn format_permanent_bucket_key(namespace: &str) -> String {
 }
 
 #[inline]
-pub fn format_region_meta_name(namespace: &str, shard_id: usize) -> String {
-    format!("region_meta_{}_{:0>6}", namespace, shard_id)
+pub fn format_table_unit_meta_name(namespace: &str, shard_id: usize) -> String {
+    format!("table_unit_meta_{}_{:0>6}", namespace, shard_id)
 }
 
 #[inline]
@@ -83,8 +81,8 @@ pub fn format_permanent_wal_name(namespace: &str, shard_id: usize) -> String {
 }
 
 #[inline]
-pub fn format_region_key(region_id: RegionId) -> String {
-    format!("{}/{}", REGION_META_PREFIX, region_id)
+pub fn format_table_unit_key(table_id: TableId) -> String {
+    format!("{}/{}", TABLE_UNIT_META_PREFIX, table_id)
 }
 
 #[cfg(test)]
@@ -119,18 +117,18 @@ mod tests {
     }
 
     #[test]
-    fn test_format_region_meta() {
+    fn test_format_table_unit_meta() {
         let ns = "abcdef";
-        let name = format_region_meta_name(ns, 0);
+        let name = format_table_unit_meta_name(ns, 0);
         assert_eq!("region_meta_abcdef_000000", name);
 
-        let name = format_region_meta_name(ns, 124);
+        let name = format_table_unit_meta_name(ns, 124);
         assert_eq!("region_meta_abcdef_000124", name);
 
-        let name = format_region_meta_name(ns, 999999);
+        let name = format_table_unit_meta_name(ns, 999999);
         assert_eq!("region_meta_abcdef_999999", name);
 
-        let name = format_region_meta_name(ns, 1234567);
+        let name = format_table_unit_meta_name(ns, 1234567);
         assert_eq!("region_meta_abcdef_1234567", name);
     }
 
@@ -171,19 +169,19 @@ mod tests {
     }
 
     #[test]
-    fn test_format_region_key() {
-        let key = format_region_key(0);
-        assert_eq!("v1/region/0", key);
-        let key = format_region_key(1);
-        assert_eq!("v1/region/1", key);
+    fn test_format_table_unit_key() {
+        let key = format_table_unit_key(0);
+        assert_eq!("v1/table/0", key);
+        let key = format_table_unit_key(1);
+        assert_eq!("v1/table/1", key);
 
-        let key = format_region_key(12345);
-        assert_eq!("v1/region/12345", key);
+        let key = format_table_unit_key(12345);
+        assert_eq!("v1/table/12345", key);
 
-        let key = format_region_key(RegionId::MIN);
-        assert_eq!("v1/region/0", key);
+        let key = format_table_unit_key(RegionId::MIN);
+        assert_eq!("v1/table/0", key);
 
-        let key = format_region_key(RegionId::MAX);
-        assert_eq!("v1/region/18446744073709551615", key);
+        let key = format_table_unit_key(RegionId::MAX);
+        assert_eq!("v1/table/18446744073709551615", key);
     }
 }

--- a/wal/src/table_kv_impl/mod.rs
+++ b/wal/src/table_kv_impl/mod.rs
@@ -9,7 +9,7 @@ use common_util::runtime::Runtime;
 pub mod encoding;
 pub mod model;
 mod namespace;
-mod region;
+mod table_unit;
 mod timed_task;
 pub mod wal;
 

--- a/wal/src/table_kv_impl/model.rs
+++ b/wal/src/table_kv_impl/model.rs
@@ -639,7 +639,7 @@ mod tests {
 
         check_table_unit_entry_codec(
             &table_unit_entry,
-            r#"{"region_id":"0","start_sequence":"0"}"#,
+            r#"{"table_id":"0","start_sequence":"0"}"#,
         );
 
         let table_unit_entry = TableUnitEntry {
@@ -649,7 +649,7 @@ mod tests {
 
         check_table_unit_entry_codec(
             &table_unit_entry,
-            r#"{"region_id":"18446744073709551615","start_sequence":"18446744073709551615"}"#,
+            r#"{"table_id":"18446744073709551615","start_sequence":"18446744073709551615"}"#,
         );
 
         let table_unit_entry = TableUnitEntry {
@@ -659,7 +659,7 @@ mod tests {
 
         check_table_unit_entry_codec(
             &table_unit_entry,
-            r#"{"region_id":"12345","start_sequence":"5432"}"#,
+            r#"{"table_id":"12345","start_sequence":"5432"}"#,
         );
     }
 }

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -507,7 +507,7 @@ impl<T: TableKv> NamespaceInner<T> {
         self.open_table_unit(region_id, table_id).await
     }
 
-    // TODO(yingwen): Provide a close_talbe_unit() method.
+    // TODO(yingwen): Provide a close_table_unit() method.
     async fn open_table_unit(
         &self,
         region_id: RegionId,

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-//! Region in wal.
+//! Table unit in wal.
 
 use std::{
     cmp,
@@ -13,7 +13,7 @@ use std::{
     time::Duration,
 };
 
-use common_types::bytes::BytesMut;
+use common_types::{bytes::BytesMut, table::TableId};
 use common_util::{define_result, runtime::Runtime};
 use log::debug;
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
@@ -23,10 +23,10 @@ use table_kv::{
 use tokio::sync::Mutex;
 
 use crate::{
-    kv_encoder::{LogEncoding, LogKey},
+    kv_encoder::{CommonLogEncoding, CommonLogKey},
     log_batch::{LogEntry, LogWriteBatch},
     manager::{self, ReadContext, ReadRequest, RegionId, SequenceNumber, SyncLogIterator},
-    table_kv_impl::{encoding, model::RegionEntry, namespace::BucketRef, WalRuntimes},
+    table_kv_impl::{encoding, model::TableUnitEntry, namespace::BucketRef, WalRuntimes},
 };
 
 #[derive(Debug, Snafu)]
@@ -64,12 +64,14 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Sequence of region overflow, region_id:{}.\nBacktrace:\n{}",
+        "Sequence of region overflow, region_id:{}, table_id:{}.\nBacktrace:\n{}",
         region_id,
+        table_id,
         backtrace
     ))]
     SequenceOverflow {
         region_id: RegionId,
+        table_id: TableId,
         backtrace: Backtrace,
     },
 
@@ -88,7 +90,7 @@ pub enum Error {
         region_id,
         backtrace
     ))]
-    RegionNotExists {
+    TableUnitNotExists {
         region_id: RegionId,
         backtrace: Backtrace,
     },
@@ -108,17 +110,20 @@ define_result!(Error);
 /// Default batch size (100) to clean records.
 const DEFAULT_CLEAN_BATCH_SIZE: i32 = 100;
 
-struct RegionState {
+struct TableUnitState {
+    /// Region id of this table unit
     region_id: RegionId,
-    /// Start sequence (inclusive) of this region, update is protected by the
-    /// `writer` lock.
+    /// Table id of this table unit
+    table_id: TableId,
+    /// Start sequence (inclusive) of this table unit, update is protected by
+    /// the `writer` lock.
     start_sequence: AtomicU64,
-    /// Last sequence (inclusive) of this region, update is protected by the
+    /// Last sequence (inclusive) of this table unit, update is protected by the
     /// `writer` lock.
     last_sequence: AtomicU64,
 }
 
-impl RegionState {
+impl TableUnitState {
     #[inline]
     fn last_sequence(&self) -> SequenceNumber {
         self.last_sequence.load(Ordering::Relaxed)
@@ -135,9 +140,9 @@ impl RegionState {
     }
 
     #[inline]
-    fn region_entry(&self) -> RegionEntry {
-        RegionEntry {
-            region_id: self.region_id,
+    fn table_unit_entry(&self) -> TableUnitEntry {
+        TableUnitEntry {
+            table_id: self.table_id,
             start_sequence: self.start_sequence.load(Ordering::Relaxed),
         }
     }
@@ -158,92 +163,104 @@ impl Default for CleanContext {
     }
 }
 
-/// Region can be viewed as an append only log file.
-pub struct Region {
+/// Table unit can be viewed as an append only log file.
+pub struct TableUnit {
     runtimes: WalRuntimes,
-    state: RegionState,
-    writer: Mutex<RegionWriter>,
+    state: TableUnitState,
+    writer: Mutex<TableUnitWriter>,
 }
 
 // Async or non-blocking operations.
-impl Region {
-    /// Open region of given `region_id`, the caller should ensure the meta data
-    /// of this region is stored in `region_meta_table`, and the wal log
-    /// records are stored in `buckets`.
+impl TableUnit {
+    /// Open table unit of given `region_id` and `table_id`, the caller should
+    /// ensure the meta data of this table unit is stored in
+    /// `table_unit_meta_table`, and the wal log records are stored in
+    /// `buckets`.
     pub async fn open<T: TableKv>(
         runtimes: WalRuntimes,
         table_kv: &T,
         scan_ctx: ScanContext,
-        region_meta_table: &str,
+        table_unit_meta_table: &str,
         region_id: RegionId,
+        table_id: TableId,
         // Buckets ordered by time.
         buckets: Vec<BucketRef>,
-    ) -> Result<Option<Region>> {
+    ) -> Result<Option<TableUnit>> {
         let table_kv = table_kv.clone();
-        let region_meta_table = region_meta_table.to_string();
+        let table_unit_meta_table = table_unit_meta_table.to_string();
         let rt = runtimes.bg_runtime.clone();
 
         rt.spawn_blocking(move || {
-            // Load of create region entry.
-            let region_entry =
-                match Self::load_region_entry(&table_kv, &region_meta_table, region_id)? {
+            // Load of create table unit entry.
+            let table_unit_entry =
+                match Self::load_table_unit_entry(&table_kv, &table_unit_meta_table, table_id)? {
                     Some(v) => v,
                     None => return Ok(None),
                 };
 
-            // Load last sequence of this region.
-            let last_sequence = Self::load_last_sequence(&table_kv, scan_ctx, region_id, &buckets)?;
+            // Load last sequence of this table unit.
+            let last_sequence =
+                Self::load_last_sequence(&table_kv, scan_ctx, region_id, table_id, &buckets)?;
 
             Ok(Some(Self {
                 runtimes,
-                state: RegionState {
+                state: TableUnitState {
                     region_id,
-                    start_sequence: AtomicU64::new(region_entry.start_sequence),
+                    table_id,
+                    start_sequence: AtomicU64::new(table_unit_entry.start_sequence),
                     last_sequence: AtomicU64::new(last_sequence),
                 },
-                writer: Mutex::new(RegionWriter),
+                writer: Mutex::new(TableUnitWriter),
             }))
         })
         .await
         .context(RuntimeExec)?
     }
 
-    /// Similar to `open()`, open region of given `region_id`. If the region is
-    /// not exists, insert a new region entry into `region_meta_table`. Only
-    /// one writer is allowed to insert the new region entry.
+    /// Similar to `open()`, open table unit of given `region_id` and
+    /// `table_id`. If the table unit doesn't exists, insert a new table
+    /// unit entry into `table_unit_meta_table`. Only one writer is allowed to
+    /// insert the new table unit entry.
     pub async fn open_or_create<T: TableKv>(
         runtimes: WalRuntimes,
         table_kv: &T,
         scan_ctx: ScanContext,
-        region_meta_table: &str,
+        table_unit_meta_table: &str,
         region_id: RegionId,
+        table_id: TableId,
         // Buckets ordered by time.
         buckets: Vec<BucketRef>,
-    ) -> Result<Region> {
+    ) -> Result<TableUnit> {
         let table_kv = table_kv.clone();
-        let region_meta_table = region_meta_table.to_string();
+        let table_unit_meta_table = table_unit_meta_table.to_string();
         let rt = runtimes.bg_runtime.clone();
 
         rt.spawn_blocking(move || {
-            // Load of create region entry.
-            let mut writer = RegionWriter;
-            let region_entry =
-                match Self::load_region_entry(&table_kv, &region_meta_table, region_id)? {
+            // Load of create table unit entry.
+            let mut writer = TableUnitWriter;
+            let table_unit_entry =
+                match Self::load_table_unit_entry(&table_kv, &table_unit_meta_table, table_id)? {
                     Some(v) => v,
                     None => {
-                        let entry = RegionEntry::new(region_id);
-                        writer.insert_or_load_region_entry(&table_kv, &region_meta_table, entry)?
+                        let entry = TableUnitEntry::new(table_id);
+                        writer.insert_or_load_table_unit_entry(
+                            &table_kv,
+                            &table_unit_meta_table,
+                            entry,
+                        )?
                     }
                 };
 
-            // Load last sequence of this region.
-            let last_sequence = Self::load_last_sequence(&table_kv, scan_ctx, region_id, &buckets)?;
+            // Load last sequence of this table unit.
+            let last_sequence =
+                Self::load_last_sequence(&table_kv, scan_ctx, region_id, table_id, &buckets)?;
 
             Ok(Self {
                 runtimes,
-                state: RegionState {
+                state: TableUnitState {
                     region_id,
-                    start_sequence: AtomicU64::new(region_entry.start_sequence),
+                    table_id,
+                    start_sequence: AtomicU64::new(table_unit_entry.start_sequence),
                     last_sequence: AtomicU64::new(last_sequence),
                 },
                 writer: Mutex::new(writer),
@@ -285,23 +302,25 @@ impl Region {
         // during reading start/end sequence.
         let start_sequence = match request.start.as_start_sequence_number() {
             Some(request_start_sequence) => {
-                let region_start_sequence = self.state.start_sequence();
+                let table_unit_start_sequence = self.state.start_sequence();
                 // Avoid reading deleted log entries.
-                cmp::max(region_start_sequence, request_start_sequence)
+                cmp::max(table_unit_start_sequence, request_start_sequence)
             }
             None => return Ok(TableLogIterator::new_empty(table_kv.clone())),
         };
         let end_sequence = match request.end.as_end_sequence_number() {
             Some(request_end_sequence) => {
-                let region_last_sequence = self.state.last_sequence();
+                let table_unit_last_sequence = self.state.last_sequence();
                 // Avoid reading entries newer than current last sequence.
-                cmp::min(region_last_sequence, request_end_sequence)
+                cmp::min(table_unit_last_sequence, request_end_sequence)
             }
             None => return Ok(TableLogIterator::new_empty(table_kv.clone())),
         };
 
-        let min_log_key = (self.state.region_id, start_sequence);
-        let max_log_key = (self.state.region_id, end_sequence);
+        let region_id = self.state.region_id;
+        let table_id = self.state.table_id;
+        let min_log_key = CommonLogKey::new(region_id, table_id, start_sequence);
+        let max_log_key = CommonLogKey::new(region_id, table_id, end_sequence);
 
         let scan_ctx = ScanContext {
             timeout: ctx.timeout,
@@ -320,7 +339,7 @@ impl Region {
     pub async fn delete_entries_up_to<T: TableKv>(
         &self,
         table_kv: &T,
-        region_meta_table: &str,
+        table_unit_meta_table: &str,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         let mut writer = self.writer.lock().await;
@@ -329,10 +348,15 @@ impl Region {
                 &self.runtimes.write_runtime,
                 table_kv,
                 &self.state,
-                region_meta_table,
+                table_unit_meta_table,
                 sequence_num,
             )
             .await
+    }
+
+    #[inline]
+    pub fn table_id(&self) -> TableId {
+        self.state.table_id
     }
 
     #[inline]
@@ -347,18 +371,18 @@ impl Region {
 }
 
 // Blocking operations:
-impl Region {
-    fn load_region_entry<T: TableKv>(
+impl TableUnit {
+    fn load_table_unit_entry<T: TableKv>(
         table_kv: &T,
-        region_meta_table: &str,
-        region_id: RegionId,
-    ) -> Result<Option<RegionEntry>> {
-        let key = encoding::format_region_key(region_id);
+        table_unit_meta_table: &str,
+        table_id: TableId,
+    ) -> Result<Option<TableUnitEntry>> {
+        let key = encoding::format_table_unit_key(table_id);
         table_kv
-            .get(region_meta_table, key.as_bytes())
+            .get(table_unit_meta_table, key.as_bytes())
             .map_err(|e| Box::new(e) as _)
             .context(GetValue { key: &key })?
-            .map(|value| RegionEntry::decode(&value).context(Decode { key }))
+            .map(|value| TableUnitEntry::decode(&value).context(Decode { key }))
             .transpose()
     }
 
@@ -368,6 +392,7 @@ impl Region {
         table_kv: &T,
         scan_ctx: ScanContext,
         region_id: RegionId,
+        table_id: TableId,
         buckets: &[BucketRef],
     ) -> Result<SequenceNumber> {
         // Starts from the latest bucket, find last sequence of given region id.
@@ -380,6 +405,7 @@ impl Region {
                 scan_ctx.clone(),
                 table_name,
                 region_id,
+                table_id,
             )? {
                 last_sequence = seq;
             }
@@ -393,18 +419,20 @@ impl Region {
         scan_ctx: ScanContext,
         table_name: &str,
         region_id: RegionId,
+        table_id: TableId,
     ) -> Result<Option<SequenceNumber>> {
-        let log_encoding = LogEncoding::newest();
+        let log_encoding = CommonLogEncoding::newest();
         let mut encode_buf = BytesMut::new();
 
-        let start_log_key = (region_id, common_types::MIN_SEQUENCE_NUMBER);
+        let start_log_key =
+            CommonLogKey::new(region_id, table_id, common_types::MIN_SEQUENCE_NUMBER);
         log_encoding
             .encode_key(&mut encode_buf, &start_log_key)
             .context(LogCodec)?;
         let scan_start = KeyBoundary::included(&encode_buf);
 
         encode_buf.clear();
-        let end_log_key = (region_id, common_types::MAX_SEQUENCE_NUMBER);
+        let end_log_key = CommonLogKey::new(region_id, table_id, common_types::MAX_SEQUENCE_NUMBER);
         log_encoding
             .encode_key(&mut encode_buf, &end_log_key)
             .context(LogCodec)?;
@@ -432,9 +460,10 @@ impl Region {
 
         let log_key = log_encoding.decode_key(iter.key()).context(LogCodec)?;
 
-        Ok(Some(log_key.1))
+        Ok(Some(log_key.sequence_num))
     }
 
+    // TODO: unfortunately, we can just check and delete the
     pub fn clean_deleted_logs<T: TableKv>(
         &self,
         table_kv: &T,
@@ -442,12 +471,20 @@ impl Region {
         buckets: &[BucketRef],
     ) -> Result<()> {
         // Inclusive min log key.
-        let min_log_key = (self.state.region_id, common_types::MIN_SEQUENCE_NUMBER);
+        let min_log_key = CommonLogKey::new(
+            self.state.region_id,
+            self.state.table_id,
+            common_types::MIN_SEQUENCE_NUMBER,
+        );
         // Exlusive max log key.
-        let max_log_key = (self.state.region_id, self.state.start_sequence());
+        let max_log_key = CommonLogKey::new(
+            self.state.region_id,
+            self.state.table_id,
+            self.state.start_sequence(),
+        );
 
         let mut seek_key_buf = BytesMut::new();
-        let log_encoding = LogEncoding::newest();
+        let log_encoding = CommonLogEncoding::newest();
         log_encoding
             .encode_key(&mut seek_key_buf, &min_log_key)
             .context(LogCodec)?;
@@ -508,7 +545,7 @@ impl Region {
                     .write(WriteContext::default(), table_name, wb)
                     .map_err(|e| Box::new(e) as _)
                     .context(Delete {
-                        region_id: self.state.region_id,
+                        region_id: self.state.table_id,
                     })?;
             }
 
@@ -522,7 +559,7 @@ impl Region {
                     .write(WriteContext::default(), table_name, wb)
                     .map_err(|e| Box::new(e) as _)
                     .context(Delete {
-                        region_id: self.state.region_id,
+                        region_id: self.state.table_id,
                     })?;
 
                 break;
@@ -531,8 +568,8 @@ impl Region {
 
         if total_deleted > 0 {
             debug!(
-                "Clean logs of region, region_id:{}, table_name:{}, total_deleted:{}",
-                self.state.region_id, table_name, total_deleted
+                "Clean logs of table unit, region_id:{}, table_name:{}, total_deleted:{}",
+                self.state.table_id, table_name, total_deleted
             );
         }
 
@@ -540,22 +577,22 @@ impl Region {
     }
 }
 
-pub type RegionRef = Arc<Region>;
+pub type TableUnitRef = Arc<TableUnit>;
 
 #[derive(Debug)]
 pub struct TableLogIterator<T: TableKv> {
     buckets: Vec<BucketRef>,
     /// Inclusive max log key.
-    max_log_key: LogKey,
+    max_log_key: CommonLogKey,
     scan_ctx: ScanContext,
     table_kv: T,
 
-    current_log_key: LogKey,
+    current_log_key: CommonLogKey,
     // The iterator is exhausted if `current_bucket_index >= bucets.size()`.
     current_bucket_index: usize,
     // The `current_iter` should be either a valid iterator or None.
     current_iter: Option<T::ScanIter>,
-    log_encoding: LogEncoding,
+    log_encoding: CommonLogEncoding,
     // TODO(ygf11): Remove this after issue#120 is resolved.
     previous_value: Vec<u8>,
 }
@@ -564,21 +601,21 @@ impl<T: TableKv> TableLogIterator<T> {
     pub fn new_empty(table_kv: T) -> Self {
         Self {
             buckets: Vec::new(),
-            max_log_key: (0, 0),
+            max_log_key: CommonLogKey::new(0, 0, 0),
             scan_ctx: ScanContext::default(),
             table_kv,
-            current_log_key: (0, 0),
+            current_log_key: CommonLogKey::new(0, 0, 0),
             current_bucket_index: 0,
             current_iter: None,
-            log_encoding: LogEncoding::newest(),
+            log_encoding: CommonLogEncoding::newest(),
             previous_value: Vec::default(),
         }
     }
 
     fn new(
         buckets: Vec<BucketRef>,
-        min_log_key: LogKey,
-        max_log_key: LogKey,
+        min_log_key: CommonLogKey,
+        max_log_key: CommonLogKey,
         scan_ctx: ScanContext,
         table_kv: T,
     ) -> Self {
@@ -590,7 +627,7 @@ impl<T: TableKv> TableLogIterator<T> {
             current_log_key: min_log_key,
             current_bucket_index: 0,
             current_iter: None,
-            log_encoding: LogEncoding::newest(),
+            log_encoding: CommonLogEncoding::newest(),
             previous_value: Vec::default(),
         }
     }
@@ -621,7 +658,7 @@ impl<T: TableKv> TableLogIterator<T> {
     /// Scan buckets to find next valid iterator, returns true if such iterator
     /// has been found.
     fn scan_buckets(&mut self) -> Result<bool> {
-        let region_id = self.max_log_key.0;
+        let region_id = self.max_log_key.region_id;
         let scan_req = self.new_scan_request()?;
 
         while self.current_bucket_index < self.buckets.len() {
@@ -704,8 +741,8 @@ impl<T: TableKv> SyncLogIterator for TableLogIterator<T> {
             .context(manager::Read)?;
 
         let log_entry = LogEntry {
-            table_id: self.current_log_key.0,
-            sequence: self.current_log_key.1,
+            table_id: self.current_log_key.table_id,
+            sequence: self.current_log_key.sequence_num,
             payload: self.previous_value.as_slice(),
         };
 
@@ -713,55 +750,59 @@ impl<T: TableKv> SyncLogIterator for TableLogIterator<T> {
     }
 }
 
-struct RegionWriter;
+struct TableUnitWriter;
 
 // Blocking operations.
-impl RegionWriter {
-    fn insert_or_load_region_entry<T: TableKv>(
+impl TableUnitWriter {
+    fn insert_or_load_table_unit_entry<T: TableKv>(
         &mut self,
         table_kv: &T,
-        region_meta_table: &str,
-        region_entry: RegionEntry,
-    ) -> Result<RegionEntry> {
-        let key = encoding::format_region_key(region_entry.region_id);
-        let value = region_entry.encode().context(Encode { key: &key })?;
+        table_unit_meta_table: &str,
+        table_unit_entry: TableUnitEntry,
+    ) -> Result<TableUnitEntry> {
+        let key = encoding::format_table_unit_key(table_unit_entry.table_id);
+        let value = table_unit_entry.encode().context(Encode { key: &key })?;
 
         let mut batch = T::WriteBatch::default();
         batch.insert(key.as_bytes(), &value);
 
-        let res = table_kv.write(WriteContext::default(), region_meta_table, batch);
+        let res = table_kv.write(WriteContext::default(), table_unit_meta_table, batch);
 
         match &res {
-            Ok(()) => Ok(region_entry),
+            Ok(()) => Ok(table_unit_entry),
             Err(e) => {
                 if e.is_primary_key_duplicate() {
-                    Region::load_region_entry(table_kv, region_meta_table, region_entry.region_id)?
-                        .context(RegionNotExists {
-                            region_id: region_entry.region_id,
-                        })
+                    TableUnit::load_table_unit_entry(
+                        table_kv,
+                        table_unit_meta_table,
+                        table_unit_entry.table_id,
+                    )?
+                    .context(TableUnitNotExists {
+                        region_id: table_unit_entry.table_id,
+                    })
                 } else {
                     res.map_err(|e| Box::new(e) as _)
                         .context(WriteValue { key: &key })?;
 
-                    Ok(region_entry)
+                    Ok(table_unit_entry)
                 }
             }
         }
     }
 
-    fn update_region_entry<T: TableKv>(
+    fn update_table_unit_entry<T: TableKv>(
         table_kv: &T,
-        region_meta_table: &str,
-        region_entry: &RegionEntry,
+        table_unit_meta_table: &str,
+        table_unit_entry: &TableUnitEntry,
     ) -> Result<()> {
-        let key = encoding::format_region_key(region_entry.region_id);
-        let value = region_entry.encode().context(Encode { key: &key })?;
+        let key = encoding::format_table_unit_key(table_unit_entry.table_id);
+        let value = table_unit_entry.encode().context(Encode { key: &key })?;
 
         let mut batch = T::WriteBatch::default();
         batch.insert_or_update(key.as_bytes(), &value);
 
         table_kv
-            .write(WriteContext::default(), region_meta_table, batch)
+            .write(WriteContext::default(), table_unit_meta_table, batch)
             .map_err(|e| Box::new(e) as _)
             .context(WriteValue { key: &key })
     }
@@ -770,52 +811,56 @@ impl RegionWriter {
     /// [SequenceNumber] of the range [start, start + `number`].
     fn alloc_sequence_num(
         &mut self,
-        region_state: &RegionState,
+        table_unit_state: &TableUnitState,
         number: u64,
     ) -> Result<SequenceNumber> {
         ensure!(
-            region_state.last_sequence() < common_types::MAX_SEQUENCE_NUMBER,
+            table_unit_state.last_sequence() < common_types::MAX_SEQUENCE_NUMBER,
             SequenceOverflow {
-                region_id: region_state.region_id,
+                region_id: table_unit_state.region_id,
+                table_id: table_unit_state.table_id,
             }
         );
 
-        let last_sequence = region_state
+        let last_sequence = table_unit_state
             .last_sequence
             .fetch_add(number, Ordering::Relaxed);
         Ok(last_sequence + 1)
     }
 }
 
-impl RegionWriter {
+impl TableUnitWriter {
     async fn write_log<T: TableKv>(
         &mut self,
         runtime: &Runtime,
         table_kv: &T,
-        region_state: &RegionState,
+        table_unit_state: &TableUnitState,
         bucket: &BucketRef,
         ctx: &manager::WriteContext,
         log_batch: &LogWriteBatch,
     ) -> Result<SequenceNumber> {
         debug!(
-            "Wal region begin writing, ctx:{:?}, region_id:{}, log_entries_num:{}",
+            "Wal table unit begin writing, ctx:{:?}, region_id:{}, table_id:{}, log_entries_num:{}",
             ctx,
-            log_batch.location.table_id,
+            table_unit_state.region_id,
+            table_unit_state.table_id,
             log_batch.entries.len()
         );
 
-        let log_encoding = LogEncoding::newest();
+        let log_encoding = CommonLogEncoding::newest();
         let entries_num = log_batch.len() as u64;
+        let region_id = table_unit_state.region_id;
+        let table_id = table_unit_state.table_id;
         let (wb, max_sequence_num) = {
             let mut wb = T::WriteBatch::with_capacity(log_batch.len());
-            let mut next_sequence_num = self.alloc_sequence_num(region_state, entries_num)?;
+            let mut next_sequence_num = self.alloc_sequence_num(table_unit_state, entries_num)?;
             let mut key_buf = BytesMut::new();
 
             for entry in &log_batch.entries {
                 log_encoding
                     .encode_key(
                         &mut key_buf,
-                        &(log_batch.location.table_id, next_sequence_num),
+                        &CommonLogKey::new(region_id, table_id, next_sequence_num),
                     )
                     .context(LogCodec)?;
                 wb.insert(&key_buf, &entry.payload);
@@ -828,7 +873,6 @@ impl RegionWriter {
 
         let table_kv = table_kv.clone();
         let bucket = bucket.clone();
-        let region_id = log_batch.location.table_id;
         runtime
             .spawn_blocking(move || {
                 let table_name = bucket.wal_shard_table(region_id);
@@ -850,50 +894,51 @@ impl RegionWriter {
         &mut self,
         runtime: &Runtime,
         table_kv: &T,
-        region_state: &RegionState,
-        region_meta_table: &str,
+        table_unit_state: &TableUnitState,
+        table_unit_meta_table: &str,
         mut sequence_num: SequenceNumber,
     ) -> Result<()> {
         debug!(
-            "Try to delete entries, region_id:{}, sequence_num:{}",
-            region_state.region_id, sequence_num
+            "Try to delete entries, region_id:{}, table_id:{}, sequence_num:{}",
+            table_unit_state.region_id, table_unit_state.table_id, sequence_num
         );
 
         ensure!(
             sequence_num < common_types::MAX_SEQUENCE_NUMBER,
             SequenceOverflow {
-                region_id: region_state.region_id,
+                region_id: table_unit_state.region_id,
+                table_id: table_unit_state.table_id,
             }
         );
 
-        let last_sequence = region_state.last_sequence();
+        let last_sequence = table_unit_state.last_sequence();
         if sequence_num > last_sequence {
             sequence_num = last_sequence;
         }
 
         // Update min_sequence.
-        let mut region_entry = region_state.region_entry();
-        if region_entry.start_sequence <= sequence_num {
-            region_entry.start_sequence = sequence_num + 1;
+        let mut table_unit_entry = table_unit_state.table_unit_entry();
+        if table_unit_entry.start_sequence <= sequence_num {
+            table_unit_entry.start_sequence = sequence_num + 1;
         }
 
         debug!(
-            "Update region entry due to deletion, table:{}, region_entry:{:?}",
-            region_meta_table, region_entry
+            "Update table unit entry due to deletion, table:{}, table_unit_entry:{:?}",
+            table_unit_meta_table, table_unit_entry
         );
 
         let table_kv = table_kv.clone();
-        let region_meta_table = region_meta_table.to_string();
+        let table_unit_meta_table = table_unit_meta_table.to_string();
         runtime
             .spawn_blocking(move || {
-                // Persist modification to region meta table.
-                Self::update_region_entry(&table_kv, &region_meta_table, &region_entry)
+                // Persist modification to table unit meta table.
+                Self::update_table_unit_entry(&table_kv, &table_unit_meta_table, &table_unit_entry)
             })
             .await
             .context(RuntimeExec)??;
 
-        // Update region state in memory.
-        region_state.set_start_sequence(region_entry.start_sequence);
+        // Update table unit state in memory.
+        table_unit_state.set_start_sequence(table_unit_entry.start_sequence);
 
         Ok(())
     }

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -612,7 +612,7 @@ impl<T: TableKv> TableLogIterator<T> {
         }
     }
 
-    fn new(
+    pub fn new(
         buckets: Vec<BucketRef>,
         min_log_key: CommonLogKey,
         max_log_key: CommonLogKey,

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -101,7 +101,7 @@ impl<T> fmt::Debug for WalNamespaceImpl<T> {
 impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
     async fn sequence_num(&self, location: Location) -> Result<SequenceNumber> {
         self.namespace
-            .last_sequence(location.table_id)
+            .last_sequence(location)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(Read)
@@ -113,7 +113,7 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         self.namespace
-            .delete_entries(location.table_id, sequence_num)
+            .delete_entries(location, sequence_num)
             .await
             .map_err(|e| Box::new(e) as _)
             .context(Delete)

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -7,7 +7,7 @@ use std::{collections::VecDeque, path::Path, str::FromStr, sync::Arc};
 use async_trait::async_trait;
 use common_types::{
     bytes::{BufMut, SafeBuf, SafeBufMut},
-    table::Location,
+    table::{Location, DEFAULT_SHARD_ID},
     SequenceNumber,
 };
 use common_util::{
@@ -20,7 +20,9 @@ use tempfile::TempDir;
 
 use crate::{
     log_batch::{LogWriteBatch, Payload, PayloadDecoder},
-    manager::{BatchLogIteratorAdapter, ReadContext, WalManager, WalManagerRef, WriteContext},
+    manager::{
+        BatchLogIteratorAdapter, ReadContext, RegionId, WalManager, WalManagerRef, WriteContext,
+    },
     rocks_impl::{self, manager::RocksImpl},
     table_kv_impl::{model::NamespaceConfig, wal::WalNamespaceImpl, WalRuntimes},
 };
@@ -43,8 +45,11 @@ impl WalBuilder for RocksWalBuilder {
     type Wal = RocksImpl;
 
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
-        let wal_builder =
-            rocks_impl::manager::Builder::with_default_rocksdb_config(data_path, runtime);
+        let wal_builder = rocks_impl::manager::Builder::with_default_rocksdb_config(
+            data_path,
+            runtime,
+            DEFAULT_SHARD_ID as RegionId,
+        );
 
         Arc::new(
             wal_builder

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -76,7 +76,7 @@ impl WalBuilder for MemoryTableWalBuilder {
     async fn build(&self, _data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
         let config = NamespaceConfig {
             wal_shard_num: 2,
-            region_meta_shard_num: 2,
+            table_unit_meta_shard_num: 2,
             ttl: self.ttl,
             ..Default::default()
         };

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -2,12 +2,17 @@
 
 //! utilities for testing wal module.
 
-use std::{collections::VecDeque, path::Path, str::FromStr, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    path::Path,
+    str::FromStr,
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use common_types::{
     bytes::{BufMut, SafeBuf, SafeBufMut},
-    table::{Location, DEFAULT_SHARD_ID},
+    table::{Location, TableId, DEFAULT_SHARD_ID},
     SequenceNumber,
 };
 use common_util::{
@@ -174,41 +179,56 @@ impl<B: WalBuilder> TestEnv<B> {
         (payload_batch, log_batch)
     }
 
+    // pub async fn check_multiple_log_entries
+
     /// Check whether the log entries from the iterator equals the
     /// `write_batch`.
     pub async fn check_log_entries(
         &self,
-        max_seq: SequenceNumber,
-        payload_batch: &[TestPayload],
+        test_table_datas: Vec<TestTableData>,
         mut iter: BatchLogIteratorAdapter,
     ) {
-        let mut log_entries = VecDeque::with_capacity(payload_batch.len());
-        let mut buffer = VecDeque::new();
+        let mut table_log_entries: HashMap<TableId, VecDeque<_>> =
+            HashMap::with_capacity(test_table_datas.len());
+
         loop {
             let dec = TestPayloadDecoder;
-            buffer = iter
-                .next_log_entries(dec, buffer)
+            let log_entries = iter
+                .next_log_entries(dec, VecDeque::new())
                 .await
                 .expect("should succeed to fetch next log entry");
-            if buffer.is_empty() {
+            if log_entries.is_empty() {
                 break;
             }
 
-            log_entries.append(&mut buffer);
+            for log_entry in log_entries {
+                let log_entries = table_log_entries
+                    .entry(log_entry.table_id)
+                    .or_insert_with(VecDeque::default);
+                log_entries.push_back(log_entry);
+            }
         }
 
-        assert_eq!(payload_batch.len(), log_entries.len());
-        for (idx, (expect_log_write_entry, log_entry)) in payload_batch
-            .iter()
-            .zip(log_entries.iter())
-            .rev()
-            .enumerate()
-        {
-            // sequence
-            assert_eq!(max_seq - idx as u64, log_entry.sequence);
+        for test_table_data in test_table_datas {
+            let empty_log_entries = VecDeque::new();
+            let log_entries = table_log_entries
+                .get(&test_table_data.table_id)
+                .unwrap_or(&empty_log_entries);
 
-            // payload
-            assert_eq!(expect_log_write_entry, &log_entry.payload);
+            assert_eq!(test_table_data.payload_batch.len(), log_entries.len());
+            for (idx, (expect_log_write_entry, log_entry)) in test_table_data
+                .payload_batch
+                .iter()
+                .zip(log_entries.iter())
+                .rev()
+                .enumerate()
+            {
+                // sequence
+                assert_eq!(test_table_data.max_seq - idx as u64, log_entry.sequence);
+
+                // payload
+                assert_eq!(expect_log_write_entry, &log_entry.payload);
+            }
         }
     }
 }
@@ -247,5 +267,25 @@ impl PayloadDecoder for TestPayloadDecoder {
     fn decode<B: SafeBuf>(&self, buf: &mut B) -> Result<Self::Target, Self::Error> {
         let val = buf.try_get_u32().expect("should succeed to read u32");
         Ok(TestPayload { val })
+    }
+}
+
+pub struct TestTableData {
+    table_id: TableId,
+    payload_batch: Vec<TestPayload>,
+    max_seq: SequenceNumber,
+}
+
+impl TestTableData {
+    pub fn new(
+        table_id: TableId,
+        payload_batch: Vec<TestPayload>,
+        max_seq: SequenceNumber,
+    ) -> Self {
+        Self {
+            table_id,
+            payload_batch,
+            max_seq,
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #389 

# Rationale for this change
 
See #389.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
+ Replace old log format with common log format.
+ Rename `Region` to `TableUnit`.
+ Support scanning in two existing wal implementations.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
