### PR TITLE
chore: remove manual installation of protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,6 @@ jobs:
       - name: Ensure Disk Quota
         run: |
           make ensure-disk-quota
-      - name: Setup Build Environment
-        run: |
-          sudo apt update
-          sudo apt install --yes protobuf-compiler
       - name: Backup Lock File
         run: |
           cp ${LOCK_FILE} ${LOCK_FILE}.bak

--- a/.github/workflows/tsbs.yml
+++ b/.github/workflows/tsbs.yml
@@ -35,11 +35,6 @@ jobs:
       - name: Ensure Disk Quota
         run: |
           make ensure-disk-quota
-      - name: Setup Build Environment
-        run: |
-          sudo apt update
-          sudo apt install --yes protobuf-compiler
-          sudo rm -rf /var/lib/apt/lists/*
       - name: Build server
         run: |
           make build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4486,6 +4486,7 @@ name = "proto"
 version = "0.4.0"
 dependencies = [
  "prost",
+ "protoc-bin-vendored 3.0.0",
  "tonic-build",
 ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:${RUST_VERSION}-slim-bullseye as build
 # cache mounts below may already exist and owned by root
 USER root
 
-RUN apt update && apt install --yes gcc g++ libssl-dev pkg-config cmake protobuf-compiler && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install --yes gcc g++ libssl-dev pkg-config cmake && rm -rf /var/lib/apt/lists/*
 
 COPY . /ceresdb
 WORKDIR /ceresdb

--- a/docs/guides/src/dev/compile_run.md
+++ b/docs/guides/src/dev/compile_run.md
@@ -3,7 +3,7 @@ In order to compile CeresDB, some relevant dependencies(including the `Rust` too
 # Dependencies(Ubuntu20.04)
 Assuming the development environment is Ubuntu20.04, execute the following command to install the required dependencies:
 ```shell
-apt install git curl gcc g++ libssl-dev pkg-config cmake protobuf-compiler
+apt install git curl gcc g++ libssl-dev pkg-config cmake
 ```
 
 It should be noted that the compilation of the project has version requirements for dependencies such as cmake, gcc, g++, etc. If your development environment is an old Linux distribution, it is necessary to manually install these dependencies of a higher version.

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,3 +11,4 @@ prost = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.8"
+protoc-bin-vendored = "3.0.0"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,10 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Download the protoc and set the path for tonic_build.
+    let protoc_path = protoc_bin_vendored::protoc_bin_path().map_err(|e| Box::new(e))?;
+    std::env::set_var("PROTOC", protoc_path.as_os_str());
+
     tonic_build::configure().out_dir("./src").compile(
         &[
             "protos/analytic_common.proto",

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -2,7 +2,7 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Download the protoc and set the path for tonic_build.
-    let protoc_path = protoc_bin_vendored::protoc_bin_path().map_err(|e| Box::new(e))?;
+    let protoc_path = protoc_bin_vendored::protoc_bin_path().map_err(Box::new)?;
     std::env::set_var("PROTOC", protoc_path.as_os_str());
 
     tonic_build::configure().out_dir("./src").compile(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 #406 has updated the ceresdbproto to avoid its requirement for protoc, but the `proto` still needs the protoc. Let's introduce the `protoc-bin-vendored` for automatic installation of protoc.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Remove the installation of protoc.
- Introduce `protoc-bin-vendored` to install protoc by the crate itself.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
