### PR TITLE
feat: add memory based cache for object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2954,6 +2954,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-weighted-cache"
+version = "0.1.2"
+source = "git+https://github.com/jiacai2050/lru-weighted-cache.git?rev=1cf61aaf88469387e610dc7154fa318843491428#1cf61aaf88469387e610dc7154fa318843491428"
+
+[[package]]
 name = "lz4"
 version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3541,6 +3546,7 @@ dependencies = [
  "chrono",
  "futures 0.3.21",
  "lru",
+ "lru-weighted-cache",
  "object_store 0.5.1",
  "oss-rust-sdk",
  "serde",

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -16,6 +16,7 @@ snafu = { workspace = true }
 lru = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
+lru-weighted-cache = { git = "https://github.com/jiacai2050/lru-weighted-cache.git" , rev="1cf61aaf88469387e610dc7154fa318843491428"}
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/components/object_store/src/lib.rs
+++ b/components/object_store/src/lib.rs
@@ -11,5 +11,6 @@ pub use upstream::{
 
 pub mod aliyun;
 pub mod cache;
+pub mod mem_cache;
 
 pub type ObjectStoreRef = Arc<dyn ObjectStore>;

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -40,6 +40,8 @@ impl Partition {
     }
 }
 impl Partition {
+    // TODO(chenxiang): also support `&str`, this need to changes to
+    // lru_weighted_cache
     async fn get(&self, key: &String) -> Option<Bytes> {
         let mut guard = self.inner.lock().await;
         guard.get(key).map(|v| v.0.clone())

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -1,0 +1,185 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    fmt::Display,
+    hash::{Hash, Hasher},
+    ops::Range,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use lru_weighted_cache::{LruWeightedCache, Weighted};
+use tokio::{io::AsyncWrite, sync::Mutex};
+use upstream::{path::Path, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result};
+
+struct CachedBytes(Bytes);
+
+impl Weighted for CachedBytes {
+    fn weight(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[derive(Debug)]
+struct Partition {
+    inner: Mutex<LruWeightedCache<String, CachedBytes>>,
+}
+
+impl Partition {
+    fn new(mem_cap: usize) -> Self {
+        Self {
+            inner: Mutex::new(LruWeightedCache::new(1, mem_cap).expect("invalid params")),
+        }
+    }
+}
+impl Partition {
+    async fn get(&self, key: &String) -> Option<Bytes> {
+        let mut guard = self.inner.lock().await;
+        guard.get(key).map(|v| v.0.clone())
+    }
+
+    async fn insert(&self, key: String, value: Bytes) {
+        let mut guard = self.inner.lock().await;
+        // don't care error now.
+        _ = guard.insert(key, CachedBytes(value));
+    }
+}
+
+#[derive(Debug)]
+struct MemCache {
+    /// Max memory this store can use
+    mem_cap: usize,
+    partitions: Vec<Arc<Partition>>,
+    partition_mask: usize,
+}
+
+impl MemCache {
+    fn new(partition_bits: usize, mem_cap: usize) -> Self {
+        let partition_num = 1 << partition_bits;
+        let cap_per_part = mem_cap / partition_num;
+        let partitions = (0..partition_num)
+            .map(|_| Arc::new(Partition::new(cap_per_part)))
+            .collect::<Vec<_>>();
+
+        Self {
+            mem_cap,
+            partitions,
+            partition_mask: partition_num - 1,
+        }
+    }
+
+    fn locate_partition(&self, key: &String) -> Arc<Partition> {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        self.partitions[hasher.finish() as usize & self.partition_mask].clone()
+    }
+
+    async fn get(&self, key: &String) -> Option<Bytes> {
+        let partition = self.locate_partition(key);
+        partition.get(key).await
+    }
+
+    async fn insert(&self, key: String, value: Bytes) {
+        let partition = self.locate_partition(&key);
+        partition.insert(key, value).await;
+    }
+}
+
+impl Display for MemCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemCache")
+            .field("mem_cap", &self.mem_cap)
+            .field("mask", &self.partition_mask)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct CachedStore {
+    cache: MemCache,
+    inner: Arc<dyn ObjectStore>,
+}
+
+impl CachedStore {
+    pub fn new(
+        partition_bits: usize,
+        mem_cap: usize,
+        underlying_store: Arc<dyn ObjectStore>,
+    ) -> Self {
+        Self {
+            cache: MemCache::new(partition_bits, mem_cap),
+            inner: underlying_store,
+        }
+    }
+
+    fn cache_key(location: &Path, range: &Range<usize>) -> String {
+        format!("{}-{}-{}", location, range.start, range.end)
+    }
+}
+
+impl Display for CachedStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.cache.fmt(f)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for CachedStore {
+    async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
+        self.inner.put(location, bytes).await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn abort_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
+        self.inner.abort_multipart(location, multipart_id).await
+    }
+
+    async fn get(&self, location: &Path) -> Result<GetResult> {
+        self.inner.get(location).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
+        let cache_key = Self::cache_key(location, &range);
+        if let Some(bytes) = self.cache.get(&cache_key).await {
+            return Ok(bytes);
+        }
+
+        let bytes = self.inner.get_range(location, range).await;
+        if let Ok(bytes) = &bytes {
+            self.cache.insert(cache_key, bytes.clone()).await;
+        }
+
+        bytes
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        self.inner.delete(location).await
+    }
+
+    async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
+        self.inner.list(prefix).await
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -1,3 +1,9 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! An implementation of ObjectStore, which support
+//! 1. Cache based on memory, and support evict based on memory usage
+//! 2. Builtin Partition to reduce lock contention
+
 use std::{
     collections::hash_map::DefaultHasher,
     fmt::Display,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #391

# Rationale for this change

<!---
Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Add CachedStore in object store module, it can
- evict item based on configured memory capacity
- support partition to reduce lock contention

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

New unit test
- `test_mem_cache_evict`
- `test_mem_cache_partition`
