### PR TITLE
feat: add disk based object store cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3545,6 +3545,7 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "chrono",
+ "common_util",
  "futures 0.3.21",
  "log",
  "lru",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "proto 0.4.0",
  "serde",
  "serde_derive",
+ "serde_json",
  "snafu 0.6.10",
  "tempfile",
  "tokio 1.20.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,28 @@ dependencies = [
 
 [[package]]
 name = "object_store"
+version = "0.4.0"
+dependencies = [
+ "async-trait",
+ "bytes 1.2.1",
+ "chrono",
+ "futures 0.3.21",
+ "log",
+ "lru",
+ "lru-weighted-cache",
+ "object_store 0.5.1",
+ "oss-rust-sdk",
+ "prost",
+ "proto 0.4.0",
+ "serde",
+ "serde_derive",
+ "snafu 0.6.10",
+ "tempfile",
+ "tokio 1.20.1",
+]
+
+[[package]]
+name = "object_store"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce10a205d9f610ae3532943039c34c145930065ce0c4284134c897fe6073b1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,30 +3540,6 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.4.0"
-dependencies = [
- "async-trait",
- "bytes 1.2.1",
- "chrono",
- "common_util",
- "futures 0.3.21",
- "log",
- "lru",
- "lru-weighted-cache",
- "object_store 0.5.1",
- "oss-rust-sdk",
- "prost",
- "proto 0.4.0",
- "serde",
- "serde_derive",
- "serde_json",
- "snafu 0.6.10",
- "tempfile",
- "tokio 1.20.1",
-]
-
-[[package]]
-name = "object_store"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce10a205d9f610ae3532943039c34c145930065ce0c4284134c897fe6073b1"
@@ -3589,13 +3565,18 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "chrono",
+ "common_util",
  "futures 0.3.21",
+ "log",
  "lru",
  "lru-weighted-cache",
  "object_store 0.5.1",
  "oss-rust-sdk",
+ "prost",
+ "proto 1.0.0-alpha01",
  "serde",
  "serde_derive",
+ "serde_json",
  "snafu 0.6.10",
  "tempfile",
  "tokio 1.20.1",

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -89,15 +89,20 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
+        let root_path = "/tmp/ceresdb".to_string();
+
         Self {
             storage: StorageOptions {
                 mem_cache_capacity: ReadableSize::mb(512),
                 mem_cache_partition_bits: 1,
+                disk_cache_path: root_path.clone(),
+                disk_cache_capacity: ReadableSize::gb(5),
+                disk_cache_page_size: ReadableSize::mb(2),
                 object_store: ObjectStoreOptions::Local(LocalOptions {
-                    data_path: String::from("/tmp/ceresdb"),
+                    data_path: root_path.clone(),
                 }),
             },
-            wal_path: String::from("/tmp/ceresdb"),
+            wal_path: root_path,
             replay_batch_size: 500,
             max_replay_tables_per_batch: 64,
             write_group_worker_num: 8,

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -10,8 +10,8 @@ use common_util::define_result;
 use futures::Future;
 use message_queue::kafka::kafka_impl::KafkaImpl;
 use object_store::{
-    aliyun::AliyunOSS, cache::CachedStore, mem_cache::MemCacheStore, LocalFileSystem,
-    ObjectStoreRef,
+    aliyun::AliyunOSS, cache::CachedStore, disk_cache::DiskCacheStore, mem_cache::MemCacheStore,
+    LocalFileSystem, ObjectStoreRef,
 };
 use snafu::{Backtrace, ResultExt, Snafu};
 use table_engine::engine::{EngineRuntimes, TableEngineRef};
@@ -90,6 +90,7 @@ define_result!(Error);
 const WAL_DIR_NAME: &str = "wal";
 const MANIFEST_DIR_NAME: &str = "manifest";
 const STORE_DIR_NAME: &str = "store";
+const DISK_CACHE_DIR_NAME: &str = "sst_cache";
 
 /// Analytic engine builder.
 #[async_trait]
@@ -375,7 +376,7 @@ fn open_storage(
     opts: StorageOptions,
 ) -> Pin<Box<dyn Future<Output = Result<ObjectStoreRef>> + Send>> {
     Box::pin(async move {
-        let underlying_store = match opts.object_store {
+        let mut store = match opts.object_store {
             ObjectStoreOptions::Local(local_opts) => {
                 let data_path = Path::new(&local_opts.data_path);
                 let sst_path = data_path.join(STORE_DIR_NAME);
@@ -403,15 +404,31 @@ fn open_storage(
             }
         };
 
-        if opts.mem_cache_capacity.as_bytes() == 0 {
-            return Ok(underlying_store);
+        if opts.mem_cache_capacity.as_bytes() > 0 {
+            store = Arc::new(MemCacheStore::new(
+                opts.mem_cache_partition_bits,
+                opts.mem_cache_capacity.as_bytes() as usize,
+                store,
+            )) as _;
         }
 
-        let store = Arc::new(MemCacheStore::new(
-            opts.mem_cache_partition_bits,
-            opts.mem_cache_capacity.as_bytes() as usize,
-            underlying_store,
-        )) as _;
+        if opts.disk_cache_capacity.as_bytes() > 0 {
+            let path = Path::new(&opts.disk_cache_path).join(DISK_CACHE_DIR_NAME);
+            tokio::fs::create_dir_all(&path).await.context(CreateDir {
+                path: path.to_string_lossy().into_owned(),
+            })?;
+
+            store = Arc::new(
+                DiskCacheStore::try_new(
+                    path.to_string_lossy().into_owned(),
+                    opts.disk_cache_capacity.as_bytes() as usize,
+                    opts.disk_cache_page_size.as_bytes() as usize,
+                    store,
+                )
+                .await
+                .context(OpenObjectStore)?,
+            ) as _;
+        }
 
         Ok(store)
     })

--- a/analytic_engine/src/storage_options.rs
+++ b/analytic_engine/src/storage_options.rs
@@ -7,8 +7,13 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Deserialize)]
 /// Options for storage backend
 pub struct StorageOptions {
+    // 0 means disable mem cache
     pub mem_cache_capacity: ReadableSize,
     pub mem_cache_partition_bits: usize,
+    // 0 means disable disk cache
+    pub disk_cache_capacity: ReadableSize,
+    pub disk_cache_page_size: ReadableSize,
+    pub disk_cache_path: String,
     pub object_store: ObjectStoreOptions,
 }
 

--- a/analytic_engine/src/storage_options.rs
+++ b/analytic_engine/src/storage_options.rs
@@ -11,6 +11,7 @@ pub struct StorageOptions {
     pub mem_cache_capacity: ReadableSize,
     pub mem_cache_partition_bits: usize,
     // 0 means disable disk cache
+    // Note: disk_cache_capacity % disk_cache_page_size should be 0
     pub disk_cache_capacity: ReadableSize,
     pub disk_cache_page_size: ReadableSize,
     pub disk_cache_path: String,

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -405,6 +405,9 @@ impl Builder {
             storage: StorageOptions {
                 mem_cache_capacity: ReadableSize::mb(0),
                 mem_cache_partition_bits: 0,
+                disk_cache_path: "".to_string(),
+                disk_cache_capacity: ReadableSize::mb(0),
+                disk_cache_page_size: ReadableSize::mb(0),
                 object_store: ObjectStoreOptions::Local(LocalOptions {
                     data_path: dir.path().to_str().unwrap().to_string(),
                 }),
@@ -459,6 +462,9 @@ impl Default for RocksDBEngineContext {
             storage: StorageOptions {
                 mem_cache_capacity: ReadableSize::mb(0),
                 mem_cache_partition_bits: 0,
+                disk_cache_path: "".to_string(),
+                disk_cache_capacity: ReadableSize::mb(0),
+                disk_cache_page_size: ReadableSize::mb(0),
                 object_store: ObjectStoreOptions::Local(LocalOptions {
                     data_path: dir.path().to_str().unwrap().to_string(),
                 }),
@@ -481,6 +487,9 @@ impl Clone for RocksDBEngineContext {
         let storage = StorageOptions {
             mem_cache_capacity: ReadableSize::mb(0),
             mem_cache_partition_bits: 0,
+            disk_cache_path: "".to_string(),
+            disk_cache_capacity: ReadableSize::mb(0),
+            disk_cache_page_size: ReadableSize::mb(0),
             object_store: ObjectStoreOptions::Local(LocalOptions {
                 data_path: dir.path().to_str().unwrap().to_string(),
             }),
@@ -518,6 +527,9 @@ impl Default for MemoryEngineContext {
             storage: StorageOptions {
                 mem_cache_capacity: ReadableSize::mb(0),
                 mem_cache_partition_bits: 0,
+                disk_cache_path: "".to_string(),
+                disk_cache_capacity: ReadableSize::mb(0),
+                disk_cache_page_size: ReadableSize::mb(0),
                 object_store: ObjectStoreOptions::Local(LocalOptions {
                     data_path: dir.path().to_str().unwrap().to_string(),
                 }),

--- a/common_util/src/time.rs
+++ b/common_util/src/time.rs
@@ -48,6 +48,11 @@ pub fn current_time_millis() -> u64 {
     Utc::now().timestamp_millis() as u64
 }
 
+#[inline]
+pub fn current_as_rfc3339() -> String {
+    Utc::now().to_rfc3339()
+}
+
 #[cfg(test)]
 mod tests {
     use std::thread;

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -12,6 +12,7 @@ upstream = { package = "object_store", version = "0.5.1" }
 oss-rust-sdk = "0.4.0"
 serde = { workspace = true }
 serde_derive = { workspace = true }
+serde_json = { workspace = true }
 snafu = { workspace = true }
 lru = { workspace = true }
 chrono = { workspace = true }

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -17,6 +17,9 @@ lru = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
 lru-weighted-cache = { git = "https://github.com/jiacai2050/lru-weighted-cache.git" , rev="1cf61aaf88469387e610dc7154fa318843491428"}
+log = { workspace = true }
+proto = { workspace = true }
+prost = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 async-trait = { workspace = true }
 bytes = { workspace = true }
+common_util = { workspace = true }
 futures = { workspace = true }
 upstream = { package = "object_store", version = "0.5.1" }
 oss-rust-sdk = "0.4.0"

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -7,18 +7,18 @@
 //! Page is used for reasons below:
 //! - reduce file size in case of there are too many request with small range.
 
-use std::{fmt::Display, fs, ops::Range, sync::Arc};
+use std::{collections::BTreeMap, fmt::Display, fs, ops::Range, sync::Arc};
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures::stream::BoxStream;
-use log::error;
+use log::{error, info};
 use lru::LruCache;
 use prost::Message;
 use snafu::{Backtrace, ResultExt, Snafu};
 use tokio::{
     fs::File,
-    io::{AsyncReadExt, AsyncWrite},
+    io::{AsyncReadExt, AsyncWrite, AsyncWriteExt},
     sync::Mutex,
 };
 use upstream::{
@@ -34,9 +34,21 @@ enum Error {
         source,
         backtrace
     ))]
-    IoError {
+    Io {
         file: String,
         source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "Failed persist cache, file:{}, source:{}.\nbacktrace:\n{}",
+        file,
+        source,
+        backtrace
+    ))]
+    PersistCache {
+        file: String,
+        source: tokio::io::Error,
         backtrace: Backtrace,
     },
 
@@ -46,7 +58,7 @@ enum Error {
         source,
         backtrace
     ))]
-    DecodeError {
+    DecodeCache {
         file: String,
         source: prost::DecodeError,
         backtrace: Backtrace,
@@ -63,11 +75,14 @@ impl From<Error> for ObjectStoreError {
 }
 
 struct CachedBytes {
+    /// file where bytes is saved on disk
     file_path: String,
 }
 
 impl Drop for CachedBytes {
     fn drop(&mut self) {
+        info!("Remove disk cache, key:{}", &self.file_path);
+
         if let Err(e) = fs::remove_file(&self.file_path) {
             error!(
                 "Remove disk cache failed, key:{}, err:{}",
@@ -82,20 +97,35 @@ impl CachedBytes {
         Self { file_path }
     }
 
-    async fn persist(&self, _key: &str, _value: Bytes) -> Result<()> {
-        todo!()
+    async fn persist(&self, value: Bytes) -> Result<()> {
+        let mut f = File::create(&self.file_path).await.with_context(|| Io {
+            file: self.file_path.clone(),
+        })?;
+
+        let pb_bytes = proto::cache::Bytes {
+            key: "".to_string(),
+            value: value.to_vec(),
+        };
+
+        let bs = pb_bytes.encode_to_vec();
+
+        f.write_all(&bs).await.with_context(|| PersistCache {
+            file: self.file_path.clone(),
+        })?;
+
+        Ok(())
     }
 
     async fn to_bytes(&self) -> Result<Bytes> {
-        let mut f = File::open(&self.file_path).await.with_context(|| IoError {
+        let mut f = File::open(&self.file_path).await.with_context(|| Io {
             file: self.file_path.clone(),
         })?;
         let mut buf = Vec::new();
-        f.read_to_end(&mut buf).await.with_context(|| IoError {
+        f.read_to_end(&mut buf).await.with_context(|| Io {
             file: self.file_path.clone(),
         })?;
 
-        let bytes = proto::cache::Bytes::decode(&*buf).with_context(|| DecodeError {
+        let bytes = proto::cache::Bytes::decode(&*buf).with_context(|| DecodeCache {
             file: self.file_path.clone(),
         })?;
 
@@ -117,19 +147,15 @@ impl DiskCache {
         }
     }
 
-    fn normalize_filename(key: &str) -> String {
-        key.replace('/', "_")
-    }
-
     async fn insert(&self, key: String, value: Bytes) -> Result<()> {
         let mut cache = self.cache.lock().await;
         let file_path = std::path::Path::new(&self.root_dir)
-            .join(Self::normalize_filename(&key))
+            .join(&key)
             .into_os_string()
             .into_string()
             .unwrap();
         let bytes = CachedBytes::new(file_path);
-        bytes.persist(&key, value).await?;
+        bytes.persist(value).await?;
         cache.push(key, bytes);
 
         Ok(())
@@ -161,10 +187,12 @@ pub struct DiskCacheStore {
     // Max disk capacity cache use can
     cap: usize,
     page_size: usize,
+    size_cache: Arc<Mutex<LruCache<String, usize>>>,
     underlying_store: Arc<dyn ObjectStore>,
 }
 
 impl DiskCacheStore {
+    #[allow(dead_code)]
     pub fn new(
         root_dir: String,
         cap: usize,
@@ -172,24 +200,34 @@ impl DiskCacheStore {
         underlying_store: Arc<dyn ObjectStore>,
     ) -> Self {
         let cache = DiskCache::new(root_dir, cap);
+        let meta_cache = Arc::new(Mutex::new(LruCache::new(cap / page_size)));
 
         Self {
             cache,
+            size_cache: meta_cache,
             cap,
             page_size,
             underlying_store,
         }
     }
 
-    fn normalize_range(&self, range: &Range<usize>) -> Range<usize> {
+    fn normalize_range(&self, max_size: usize, range: &Range<usize>) -> Vec<Range<usize>> {
         let start = range.start / self.page_size * self.page_size;
-        let end = (range.end + self.page_size) / self.page_size * self.page_size;
+        let end = (range.end + self.page_size - 1) / self.page_size * self.page_size;
 
-        start..end
+        (start..end.min(max_size))
+            .step_by(self.page_size)
+            .map(|start| start..(start + self.page_size).min(max_size))
+            .collect::<Vec<_>>()
     }
 
     fn cache_key(location: &Path, range: &Range<usize>) -> String {
-        format!("{}-{}-{}", location, range.start, range.end)
+        format!(
+            "{}-{}-{}",
+            location.as_ref().replace('/', "-"),
+            range.start,
+            range.end
+        )
     }
 }
 
@@ -223,24 +261,78 @@ impl ObjectStore for DiskCacheStore {
     }
 
     // TODO(chenxiang): don't cache whole path for reasons below
-    // 1. cache key don't support overlapping
-    // 2. In sst module, we only use get_range, get is not used
+    // In sst module, we only use get_range, get is not used
     async fn get(&self, location: &Path) -> Result<GetResult> {
         self.underlying_store.get(location).await
     }
 
     async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
-        let cache_key = Self::cache_key(location, &range);
-        if let Some(bytes) = self.cache.get(&cache_key).await? {
-            return Ok(bytes);
+        // TODO: aligned_range will larger than real file size, need to truncate
+        let file_size = {
+            let mut size_cache = self.size_cache.lock().await;
+            if let Some(size) = size_cache.get(location.as_ref()) {
+                *size
+            } else {
+                // release lock before doing IO
+                drop(size_cache);
+
+                // TODO: multiple threads may go here, how to fix?
+                let object_meta = self.head(location).await?;
+                {
+                    let mut size_cache = self.size_cache.lock().await;
+                    size_cache.put(location.to_string(), object_meta.size);
+                }
+                object_meta.size
+            }
+        };
+
+        let aligned_ranges = self.normalize_range(file_size, &range);
+
+        let mut ranged_bytes = BTreeMap::new();
+        let mut missing_ranges = Vec::new();
+        for range in aligned_ranges {
+            let cache_key = Self::cache_key(location, &range);
+            if let Some(bytes) = self.cache.get(&cache_key).await? {
+                ranged_bytes.insert(range.start, bytes);
+            } else {
+                missing_ranges.push(range);
+            }
         }
 
-        let bytes = self.underlying_store.get_range(location, range).await;
-        if let Ok(bytes) = &bytes {
+        for range in missing_ranges {
+            let range_start = range.start;
+            let cache_key = Self::cache_key(location, &range);
+            let bytes = self.underlying_store.get_range(location, range).await?;
             self.cache.insert(cache_key, bytes.clone()).await?;
+            ranged_bytes.insert(range_start, bytes);
         }
 
-        bytes
+        // we get all bytes for each aligned_range, organize real bytes
+
+        // fast path
+        if ranged_bytes.len() == 1 {
+            let (range_start, bytes) = ranged_bytes.pop_first().unwrap();
+            let result = bytes.slice((range.start - range_start)..(range.end - range_start));
+            return Ok(result);
+        }
+
+        // there are multiple aligned ranges for one request, such as
+        // range = [3, 33), page_size = 16, then aligned ranges will be
+        // [0, 16), [16, 32), [32, 48)
+        // we need to combine those ranged bytes to get final result bytes
+
+        let mut byte_buf = BytesMut::with_capacity(range.end - range.start);
+        let (range_start, bytes) = ranged_bytes.pop_first().unwrap();
+        byte_buf.extend(bytes.slice((range.start - range_start)..));
+        let (range_start, bytes) = ranged_bytes.pop_last().unwrap();
+        let last_part = bytes.slice(..(range.end - range_start));
+
+        for bytes in ranged_bytes.into_values() {
+            byte_buf.extend(bytes);
+        }
+        byte_buf.extend(last_part);
+
+        Ok(byte_buf.freeze())
     }
 
     async fn head(&self, location: &Path) -> Result<ObjectMeta> {
@@ -283,13 +375,97 @@ mod test {
     }
 
     #[test]
-    fn test_normalize_range() {
-        let page_size = 4096;
-        let testcases = vec![(0..1, 0..4096), (0..4096, 0..8192)];
+    fn test_normalize_range_less_than_file_size() {
+        let page_size = 16;
+        let testcases = vec![
+            (0..1, vec![0..16]),
+            (0..16, vec![0..16]),
+            (0..17, vec![0..16, 16..32]),
+            (16..32, vec![16..32]),
+            (
+                16..100,
+                vec![16..32, 32..48, 48..64, 64..80, 80..96, 96..112],
+            ),
+        ];
 
         let store = prepare_store(page_size, 1000);
         for (input, expected) in testcases {
-            assert_eq!(store.normalize_range(&input), expected);
+            assert_eq!(store.normalize_range(1024, &input), expected);
         }
+    }
+
+    #[test]
+    fn test_normalize_range_great_than_file_size() {
+        let page_size = 16;
+        let testcases = vec![
+            (0..1, vec![0..16]),
+            (0..16, vec![0..16]),
+            (0..17, vec![0..16, 16..20]),
+            (16..32, vec![16..20]),
+            (32..100, vec![]),
+        ];
+
+        let store = prepare_store(page_size, 1000);
+        for (input, expected) in testcases {
+            assert_eq!(store.normalize_range(20, &input), expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_disk_cache_store_get_range() {
+        let page_size = 16;
+        // 51 byte
+        let data = b"a b c d e f g h i j k l m n o p q r s t u v w x y z";
+        let location = Path::from("1.sst");
+
+        let store = prepare_store(page_size, 1000);
+        let mut buf = BytesMut::with_capacity(data.len() * 4);
+        // put 4 times, then location will be 200 bytes
+        for _ in 0..4 {
+            buf.extend_from_slice(data);
+        }
+        store.put(&location, buf.freeze()).await.unwrap();
+
+        let testcases = vec![
+            (0..6, "a b c "),
+            (0..16, "a b c d e f g h "),
+            // len of aligned ranges will be 2
+            (0..17, "a b c d e f g h i"),
+            (16..17, "i"),
+            // len of aligned ranges will be 6
+            (16..100, "i j k l m n o p q r s t u v w x y za b c d e f g h i j k l m n o p q r s t u v w x y"),
+        ];
+
+        for (input, expected) in testcases {
+            assert_eq!(
+                store.get_range(&location, input).await.unwrap(),
+                Bytes::copy_from_slice(expected.as_bytes())
+            );
+        }
+
+        // remove cached values, then get again
+        {
+            let mut data_cache = store.cache.cache.lock().await;
+            for range in vec![0..16, 16..32, 32..48, 48..64, 64..80, 80..96, 96..112] {
+                assert!(data_cache.contains(DiskCacheStore::cache_key(&location, &range).as_str()));
+            }
+
+            assert!(data_cache
+                .pop(&DiskCacheStore::cache_key(&location, &(16..32)))
+                .is_some());
+            assert!(data_cache
+                .pop(&DiskCacheStore::cache_key(&location, &(48..64)))
+                .is_some());
+            assert!(data_cache
+                .pop(&DiskCacheStore::cache_key(&location, &(80..96)))
+                .is_some());
+        }
+
+        assert_eq!(
+            store.get_range(&location, 16..100).await.unwrap(),
+            Bytes::copy_from_slice(
+                b"i j k l m n o p q r s t u v w x y za b c d e f g h i j k l m n o p q r s t u v w x y"
+            )
+        );
     }
 }

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -528,7 +528,7 @@ mod test {
             ),
         ];
 
-        let store = prepare_store(page_size, 1000).await;
+        let store = prepare_store(page_size, 1024).await;
         for (input, expected) in testcases {
             assert_eq!(store.inner.normalize_range(1024, &input), expected);
         }
@@ -545,7 +545,7 @@ mod test {
             (32..100, vec![]),
         ];
 
-        let store = prepare_store(page_size, 1000).await;
+        let store = prepare_store(page_size, 1024).await;
         for (input, expected) in testcases {
             assert_eq!(store.inner.normalize_range(20, &input), expected);
         }
@@ -564,7 +564,7 @@ mod test {
         // 51 byte
         let data = b"a b c d e f g h i j k l m n o p q r s t u v w x y z";
         let location = Path::from("1.sst");
-        let store = prepare_store(page_size, 1000).await;
+        let store = prepare_store(page_size, 1024).await;
 
         let mut buf = BytesMut::with_capacity(data.len() * 4);
         // extend 4 times, then location will contain 200 bytes

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -1,0 +1,147 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! An ObjectStore implementation with disk as cache.
+//! The disk cache is a read-through caching, with page as its minimal cache
+//! unit.
+//!
+//! Page is used for reasons below:
+//! - reduce file size in case of there are too many request with small range.
+
+use std::{fmt::Display, ops::Range, sync::Arc};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use lru::LruCache;
+use tokio::{io::AsyncWrite, sync::Mutex};
+use upstream::{path::Path, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result};
+
+struct CachedBytes {
+    bytes: Bytes,
+}
+
+#[derive(Debug)]
+struct DiskCache {
+    path: String,
+    cache: Mutex<LruCache<String, Bytes>>,
+}
+
+impl DiskCache {
+    fn new(path: String, cap: usize) -> Self {
+        Self {
+            path,
+            cache: Mutex::new(LruCache::new(cap)),
+        }
+    }
+
+    async fn insert(&self, key: String, value: Bytes) -> Result<()> {
+        todo!()
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<Bytes>> {
+        todo!()
+    }
+}
+
+impl Display for DiskCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiskCache")
+            .field("path", &self.path)
+            .field("cache", &self.cache)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct DiskStore {
+    cache: DiskCache,
+    // Max disk capacity cache use can
+    cap: usize,
+    page_size: usize,
+    underlying_store: Arc<dyn ObjectStore>,
+}
+
+impl DiskStore {
+    fn normalize_range(&self, range: &Range<usize>) -> Range<usize> {
+        todo!()
+    }
+
+    fn cache_key(location: &Path, range: &Range<usize>) -> String {
+        format!("{}-{}-{}", location, range.start, range.end)
+    }
+}
+
+impl Display for DiskStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiskStore")
+            .field("page_size", &self.page_size)
+            .field("cap", &self.cap)
+            .field("cache", &self.cache)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl ObjectStore for DiskStore {
+    async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
+        self.underlying_store.put(location, bytes).await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        self.underlying_store.put_multipart(location).await
+    }
+
+    async fn abort_multipart(&self, location: &Path, multipart_id: &MultipartId) -> Result<()> {
+        self.underlying_store
+            .abort_multipart(location, multipart_id)
+            .await
+    }
+
+    // TODO(chenxiang): don't cache whole path for reasons below
+    // 1. cache key don't support overlapping
+    // 2. In sst module, we only use get_range, get is not used
+    async fn get(&self, location: &Path) -> Result<GetResult> {
+        self.underlying_store.get(location).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
+        let cache_key = Self::cache_key(location, &range);
+        if let Some(bytes) = self.cache.get(&cache_key).await? {
+            return Ok(bytes);
+        }
+
+        let bytes = self.underlying_store.get_range(location, range).await;
+        if let Ok(bytes) = &bytes {
+            self.cache.insert(cache_key, bytes.clone()).await?;
+        }
+
+        bytes
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.underlying_store.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        self.underlying_store.delete(location).await
+    }
+
+    async fn list(&self, prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
+        self.underlying_store.list(prefix).await
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.underlying_store.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.underlying_store.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.underlying_store.copy_if_not_exists(from, to).await
+    }
+}

--- a/components/object_store/src/lib.rs
+++ b/components/object_store/src/lib.rs
@@ -2,6 +2,8 @@
 
 //! Re-export of [object_store] crate.
 
+#![feature(map_first_last)]
+
 use std::sync::Arc;
 
 pub use upstream::{

--- a/components/object_store/src/lib.rs
+++ b/components/object_store/src/lib.rs
@@ -13,7 +13,7 @@ pub use upstream::{
 
 pub mod aliyun;
 pub mod cache;
-mod disk_cache;
+pub mod disk_cache;
 pub mod mem_cache;
 
 pub type ObjectStoreRef = Arc<dyn ObjectStore>;

--- a/components/object_store/src/lib.rs
+++ b/components/object_store/src/lib.rs
@@ -11,6 +11,7 @@ pub use upstream::{
 
 pub mod aliyun;
 pub mod cache;
+mod disk_cache;
 pub mod mem_cache;
 
 pub type ObjectStoreRef = Arc<dyn ObjectStore>;

--- a/docs/harness.toml
+++ b/docs/harness.toml
@@ -14,6 +14,9 @@ sst_meta_cache_cap = 10000
 [analytic.storage]
 mem_cache_capacity = '1G'
 mem_cache_partition_bits = 0
+disk_cache_path = "/tmp/ceresdb"
+disk_cache_capacity = '2G'
+disk_cache_page_size = '1M'
 
 [analytic.storage.object_store]
 type = "Local"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "protos/sys_catalog.proto",
             "protos/table_requests.proto",
             "protos/wal_on_mq.proto",
+            "protos/cache.proto",
         ],
         &["protos"],
     )?;

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "protos/sys_catalog.proto",
             "protos/table_requests.proto",
             "protos/wal_on_mq.proto",
-            "protos/cache.proto",
+            "protos/oss_cache.proto",
         ],
         &["protos"],
     )?;

--- a/proto/protos/cache.proto
+++ b/proto/protos/cache.proto
@@ -1,12 +1,11 @@
-
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 syntax = "proto3";
 package cache;
 
 message Bytes {
-  // Cache key
-  string key = 1;
   // Cache value
-  bytes value = 2;
+  bytes value = 1;
+  // CRC of value bytes
+  uint32 crc = 2;
 }

--- a/proto/protos/cache.proto
+++ b/proto/protos/cache.proto
@@ -1,0 +1,12 @@
+
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+syntax = "proto3";
+package cache;
+
+message Bytes {
+  // Cache key
+  string key = 1;
+  // Cache value
+  bytes value = 2;
+}

--- a/proto/protos/oss_cache.proto
+++ b/proto/protos/oss_cache.proto
@@ -1,7 +1,7 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 syntax = "proto3";
-package cache;
+package oss_cache;
 
 message Bytes {
   // Cache value

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -5,9 +5,9 @@
 #![allow(clippy::all)]
 
 pub mod analytic_common;
-pub mod cache;
 pub mod common;
 pub mod meta_update;
+pub mod oss_cache;
 pub mod sst;
 pub mod sys_catalog;
 pub mod table_requests;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::all)]
 
 pub mod analytic_common;
+pub mod cache;
 pub mod common;
 pub mod meta_update;
 pub mod sst;


### PR DESCRIPTION
# Which issue does this PR close?

Close #391

# Rationale for this change

Final PR for  #391

# What changes are included in this PR?

- Add DiskCacheStore, ObjectStore wrapper which use disk as cache. Some features:
  - Cache key is used as filename, something like `2-2199023255565-1.sst-0-3297`
  - When startup, it will recover cache from given cache dir
  - Besides sst cache file, there is a `manifest.json` file contains following info:
```json
{
    "create_at": "2022-12-01T08:51:15.167795+00:00",
    "page_size": 1048576,
    "version": 1
}
```

- Setup DiskCacheStore

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No


# How does this change test

Unit test in disk_store.rs and test harness
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

