### PR TITLE
fix: bug in distributed wal(obkv, kafka)

### DIFF
--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -122,19 +122,19 @@ impl Instance {
         let payload = WritePayload::AlterSchema(&alter_schema_pb);
 
         // Encode payloads
-        let region_id = table_data.location();
+        let wal_location = table_data.wal_location();
         let log_batch_encoder =
             self.space_store
                 .wal_manager
-                .encoder(region_id)
+                .encoder(wal_location)
                 .context(GetLogBatchEncoder {
                     table: &table_data.name,
-                    table_location: table_data.location(),
+                    wal_location: table_data.wal_location(),
                 })?;
 
         let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
             table: &table_data.name,
-            table_location: table_data.location(),
+            wal_location: table_data.wal_location(),
         })?;
 
         // Write log batch
@@ -159,7 +159,7 @@ impl Instance {
         let update = MetaUpdate::AlterSchema(manifest_update);
         self.space_store
             .manifest
-            .store_update(MetaUpdateRequest::new(table_data.location(), update))
+            .store_update(MetaUpdateRequest::new(table_data.wal_location(), update))
             .await
             .context(WriteManifest {
                 space_id: table_data.space_id,
@@ -290,19 +290,19 @@ impl Instance {
         let payload = WritePayload::AlterOption(&alter_options_pb);
 
         // Encode payload
-        let region_id = table_data.location();
+        let region_id = table_data.wal_location();
         let log_batch_encoder =
             self.space_store
                 .wal_manager
                 .encoder(region_id)
                 .context(GetLogBatchEncoder {
                     table: &table_data.name,
-                    table_location: table_data.location(),
+                    wal_location: table_data.wal_location(),
                 })?;
 
         let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
             table: &table_data.name,
-            table_location: table_data.location(),
+            wal_location: table_data.wal_location(),
         })?;
 
         // Write log batch
@@ -322,7 +322,10 @@ impl Instance {
         let meta_update = MetaUpdate::AlterOptions(manifest_update);
         self.space_store
             .manifest
-            .store_update(MetaUpdateRequest::new(table_data.location(), meta_update))
+            .store_update(MetaUpdateRequest::new(
+                table_data.wal_location(),
+                meta_update,
+            ))
             .await
             .context(WriteManifest {
                 space_id: table_data.space_id,

--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -104,7 +104,7 @@ impl Instance {
         });
         self.space_store
             .manifest
-            .store_update(MetaUpdateRequest::new(table_data.location(), update))
+            .store_update(MetaUpdateRequest::new(table_data.wal_location(), update))
             .await
             .context(WriteManifest {
                 space_id: space.id,

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -111,7 +111,7 @@ impl Instance {
         });
         self.space_store
             .manifest
-            .store_update(MetaUpdateRequest::new(table_data.location(), update))
+            .store_update(MetaUpdateRequest::new(table_data.wal_location(), update))
             .await
             .context(WriteManifest {
                 space_id: space.id,

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -4,13 +4,14 @@
 
 use std::sync::Arc;
 
-use common_types::{schema::Version, table::Location};
+use common_types::schema::Version;
 use common_util::define_result;
 use snafu::{Backtrace, OptionExt, Snafu};
 use table_engine::{
     engine::{CloseTableRequest, CreateTableRequest, DropTableRequest, OpenTableRequest},
     table::TableId,
 };
+use wal::manager::WalLocation;
 
 use crate::{
     instance::{write_worker::WriteGroup, Instance},
@@ -191,26 +192,26 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to get to log batch encoder, table:{}, table_location:{:?}, err:{}",
+        "Failed to get to log batch encoder, table:{}, wal_location:{:?}, err:{}",
         table,
-        table_location,
+        wal_location,
         source
     ))]
     GetLogBatchEncoder {
         table: String,
-        table_location: Location,
+        wal_location: WalLocation,
         source: wal::manager::Error,
     },
 
     #[snafu(display(
-        "Failed to encode payloads, table:{},table_location:{:?}, err:{}",
+        "Failed to encode payloads, table:{}, wal_location:{:?}, err:{}",
         table,
-        table_location,
+        wal_location,
         source
     ))]
     EncodePayloads {
         table: String,
-        table_location: Location,
+        wal_location: WalLocation,
         source: wal::manager::Error,
     },
 }

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -205,7 +205,7 @@ impl Instance {
             .load_data(
                 WalLocation::new(
                     request.shard_id as RegionId,
-                    request.shard_version,
+                    request.cluster_version,
                     request.table_id.as_u64(),
                 ),
                 true,
@@ -252,7 +252,7 @@ impl Instance {
                 &self.file_purger,
                 space.mem_usage_collector.clone(),
                 request.shard_id,
-                request.shard_version,
+                request.cluster_version,
             )
             .context(RecoverTableData {
                 space_id: table_meta.space_id,
@@ -283,7 +283,7 @@ impl Instance {
         read_ctx: &ReadContext,
     ) -> Result<()> {
         debug!(
-            "Instance recover table from wal, replay batch size:{}, table id:{}, shard id:{}",
+            "Instance recover table from wal, replay batch size:{}, table id:{}, shard info:{:?}",
             replay_batch_size, table_data.id, table_data.shard_info
         );
 

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -284,7 +284,7 @@ impl Instance {
     ) -> Result<()> {
         debug!(
             "Instance recover table from wal, replay batch size:{}, table id:{}, shard id:{}",
-            replay_batch_size, table_data.id, table_data.shard_id
+            replay_batch_size, table_data.id, table_data.shard_info
         );
 
         let read_req = ReadRequest {

--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -13,7 +13,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use common_types::table::Location;
 use common_util::{config::ReadableDuration, define_result};
 use log::{debug, info};
 use serde_derive::Deserialize;
@@ -23,7 +22,7 @@ use wal::{
     log_batch::LogEntry,
     manager::{
         BatchLogIteratorAdapter, ReadBoundary, ReadContext, ReadRequest, RegionId, SequenceNumber,
-        WalManagerRef, WriteContext,
+        WalLocation, WalManagerRef, WriteContext,
     },
 };
 
@@ -39,22 +38,22 @@ use crate::meta::{
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(
-        "Failed to get to get log batch encoder, table_location:{:?}, err:{}",
-        table_location,
+        "Failed to get to get log batch encoder, wal_location:{:?}, err:{}",
+        wal_location,
         source
     ))]
     GetLogBatchEncoder {
-        table_location: Location,
+        wal_location: WalLocation,
         source: wal::manager::Error,
     },
 
     #[snafu(display(
-        "Failed to encode payloads, table_location:{:?}, err:{}",
-        table_location,
+        "Failed to encode payloads, wal_location:{:?}, err:{}",
+        wal_location,
         source
     ))]
     EncodePayloads {
-        table_location: Location,
+        wal_location: WalLocation,
         source: wal::manager::Error,
     },
     #[snafu(display("Failed to write update to wal, err:{}", source))]
@@ -233,10 +232,10 @@ impl ManifestImpl {
             self.wal_manager
                 .encoder(request.location)
                 .context(GetLogBatchEncoder {
-                    table_location: request.location,
+                    wal_location: request.location,
                 })?;
         let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
-            table_location: request.location,
+            wal_location: request.location,
         })?;
 
         let store_ctx = self.opts.store_context();
@@ -253,7 +252,7 @@ impl ManifestImpl {
     /// Do snapshot if no other snapshot is triggered.
     ///
     /// Returns the latest snapshot if snapshot is done.
-    async fn maybe_do_snapshot(&self, location: Location) -> Result<Option<Snapshot>> {
+    async fn maybe_do_snapshot(&self, location: WalLocation) -> Result<Option<Snapshot>> {
         if let Ok(_guard) = self.snapshot_write_guard.try_lock() {
             let snapshotter = Snapshotter {
                 location,
@@ -305,7 +304,7 @@ impl Manifest for ManifestImpl {
 
     async fn load_data(
         &self,
-        location: Location,
+        location: WalLocation,
         do_snapshot: bool,
     ) -> std::result::Result<Option<TableManifestData>, Box<dyn std::error::Error + Send + Sync>>
     {
@@ -342,12 +341,12 @@ trait MetaUpdateLogStore: std::fmt::Debug {
 
 #[derive(Debug, Clone)]
 struct RegionWal {
-    location: Location,
+    location: WalLocation,
     wal_manager: WalManagerRef,
 }
 
 impl RegionWal {
-    fn new(location: Location, wal_manager: WalManagerRef) -> Self {
+    fn new(location: WalLocation, wal_manager: WalManagerRef) -> Self {
         Self {
             location,
             wal_manager,
@@ -390,14 +389,14 @@ impl MetaUpdateLogStore for RegionWal {
     }
 
     async fn store(&self, ctx: &StoreContext, log_entries: &[MetaUpdateLogEntry]) -> Result<()> {
-        let table_location = self.location;
+        let wal_location = self.location;
         let log_batch_encoder = self
             .wal_manager
-            .encoder(table_location)
-            .context(GetLogBatchEncoder { table_location })?;
+            .encoder(wal_location)
+            .context(GetLogBatchEncoder { wal_location })?;
         let log_batch = log_batch_encoder
             .encode_batch::<MetaUpdatePayload, MetaUpdateLogEntry>(log_entries)
-            .context(EncodePayloads { table_location })?;
+            .context(EncodePayloads { wal_location })?;
 
         let write_ctx = WriteContext {
             timeout: ctx.timeout,
@@ -472,7 +471,7 @@ impl MetaUpdateLogStore for RegionWal {
 ///     just read all logs and convert them into snapshot.
 #[derive(Debug, Clone)]
 struct Snapshotter<S> {
-    location: Location,
+    location: WalLocation,
     log_store: S,
     options: Options,
 }
@@ -765,12 +764,12 @@ mod tests {
         datum::DatumKind,
         schema,
         schema::Schema,
-        table::{Location, DEFAULT_SHARD_ID},
+        table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
     };
     use common_util::{runtime, runtime::Runtime, tests::init_log_for_test};
     use futures::future::BoxFuture;
     use table_engine::table::{SchemaId, TableId, TableSeqGenerator};
-    use wal::rocks_impl::manager::Builder as WalBuilder;
+    use wal::{manager::VersionedRegionId, rocks_impl::manager::Builder as WalBuilder};
 
     use super::*;
     use crate::{
@@ -858,10 +857,15 @@ mod tests {
         }
 
         async fn open_manifest(&self) -> ManifestImpl {
+            let versioned_region_id = VersionedRegionId {
+                version: DEFAULT_SHARD_VERSION,
+                id: DEFAULT_SHARD_ID as RegionId,
+            };
+
             let manifest_wal = WalBuilder::with_default_rocksdb_config(
                 self.dir.clone(),
                 self.runtime.clone(),
-                DEFAULT_SHARD_ID as RegionId,
+                versioned_region_id,
             )
             .build()
             .unwrap();
@@ -873,7 +877,7 @@ mod tests {
 
         async fn check_table_manifest_data_with_manifest(
             &self,
-            location: Location,
+            location: WalLocation,
             expected: &Option<TableManifestData>,
             manifest: &ManifestImpl,
         ) {
@@ -883,7 +887,7 @@ mod tests {
 
         async fn check_table_manifest_data(
             &self,
-            location: Location,
+            location: WalLocation,
             expected: &Option<TableManifestData>,
         ) {
             let manifest = self.open_manifest().await;
@@ -951,7 +955,11 @@ mod tests {
             manifest_data_builder: &mut TableManifestDataBuilder,
             manifest: &ManifestImpl,
         ) {
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let add_table = self.meta_update_add_table(table_id);
             manifest
                 .store_update(MetaUpdateRequest::new(location, add_table.clone()))
@@ -966,7 +974,11 @@ mod tests {
             manifest_data_builder: &mut TableManifestDataBuilder,
             manifest: &ManifestImpl,
         ) {
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let drop_table = self.meta_update_drop_table(table_id);
             manifest
                 .store_update(MetaUpdateRequest::new(location, drop_table.clone()))
@@ -982,7 +994,11 @@ mod tests {
             manifest_data_builder: &mut TableManifestDataBuilder,
             manifest: &ManifestImpl,
         ) {
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let version_edit = self.meta_update_version_edit(table_id, flushed_seq);
             manifest
                 .store_update(MetaUpdateRequest::new(location, version_edit.clone()))
@@ -1029,7 +1045,11 @@ mod tests {
         ) {
             let manifest = self.open_manifest().await;
 
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let alter_options = self.meta_update_alter_table_options(table_id);
             manifest
                 .store_update(MetaUpdateRequest::new(location, alter_options.clone()))
@@ -1045,7 +1065,11 @@ mod tests {
         ) {
             let manifest = self.open_manifest().await;
 
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let alter_schema = self.meta_update_alter_table_schema(table_id);
             manifest
                 .store_update(MetaUpdateRequest::new(location, alter_schema.clone()))
@@ -1070,7 +1094,11 @@ mod tests {
 
             update_table_meta(&ctx, table_id, &mut manifest_data_builder).await;
 
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let expected_table_manifest_data = manifest_data_builder.build();
             ctx.check_table_manifest_data(location, &expected_table_manifest_data)
                 .await;
@@ -1140,7 +1168,11 @@ mod tests {
         let runtime = ctx.runtime.clone();
         runtime.block_on(async move {
             let table_id = ctx.alloc_table_id();
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let mut manifest_data_builder = TableManifestDataBuilder::default();
             let manifest = ctx.open_manifest().await;
             ctx.add_table_with_manifest(table_id, &mut manifest_data_builder, &manifest)
@@ -1170,7 +1202,11 @@ mod tests {
         let runtime = ctx.runtime.clone();
         runtime.block_on(async move {
             let table_id = ctx.alloc_table_id();
-            let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id.as_u64(),
+            );
             let mut manifest_data_builder = TableManifestDataBuilder::default();
             let manifest = ctx.open_manifest().await;
             ctx.add_table_with_manifest(table_id, &mut manifest_data_builder, &manifest)
@@ -1324,7 +1360,11 @@ mod tests {
             manifest_builder.build()
         };
 
-        let location = Location::new(DEFAULT_SHARD_ID, table_id.as_u64());
+        let location = WalLocation::new(
+            DEFAULT_SHARD_ID as RegionId,
+            DEFAULT_SHARD_VERSION,
+            table_id.as_u64(),
+        );
         let log_store = {
             let log_entries: Vec<_> = logs
                 .iter()

--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -764,7 +764,7 @@ mod tests {
         datum::DatumKind,
         schema,
         schema::Schema,
-        table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+        table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     };
     use common_util::{runtime, runtime::Runtime, tests::init_log_for_test};
     use futures::future::BoxFuture;
@@ -858,7 +858,7 @@ mod tests {
 
         async fn open_manifest(&self) -> ManifestImpl {
             let versioned_region_id = VersionedRegionId {
-                version: DEFAULT_SHARD_VERSION,
+                version: DEFAULT_CLUSTER_VERSION,
                 id: DEFAULT_SHARD_ID as RegionId,
             };
 
@@ -957,7 +957,7 @@ mod tests {
         ) {
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let add_table = self.meta_update_add_table(table_id);
@@ -976,7 +976,7 @@ mod tests {
         ) {
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let drop_table = self.meta_update_drop_table(table_id);
@@ -996,7 +996,7 @@ mod tests {
         ) {
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let version_edit = self.meta_update_version_edit(table_id, flushed_seq);
@@ -1047,7 +1047,7 @@ mod tests {
 
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let alter_options = self.meta_update_alter_table_options(table_id);
@@ -1067,7 +1067,7 @@ mod tests {
 
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let alter_schema = self.meta_update_alter_table_schema(table_id);
@@ -1096,7 +1096,7 @@ mod tests {
 
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let expected_table_manifest_data = manifest_data_builder.build();
@@ -1170,7 +1170,7 @@ mod tests {
             let table_id = ctx.alloc_table_id();
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let mut manifest_data_builder = TableManifestDataBuilder::default();
@@ -1204,7 +1204,7 @@ mod tests {
             let table_id = ctx.alloc_table_id();
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id.as_u64(),
             );
             let mut manifest_data_builder = TableManifestDataBuilder::default();
@@ -1362,7 +1362,7 @@ mod tests {
 
         let location = WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id.as_u64(),
         );
         let log_store = {

--- a/analytic_engine/src/meta/meta_update.rs
+++ b/analytic_engine/src/meta/meta_update.rs
@@ -7,7 +7,6 @@ use std::convert::TryFrom;
 use bytes::{Buf, BufMut};
 use common_types::{
     schema::{Schema, Version},
-    table::Location,
     SequenceNumber,
 };
 use common_util::define_result;
@@ -15,7 +14,10 @@ use prost::Message;
 use proto::{analytic_common, common as common_pb, meta_update as meta_pb};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::table::TableId;
-use wal::log_batch::{Payload, PayloadDecoder};
+use wal::{
+    log_batch::{Payload, PayloadDecoder},
+    manager::WalLocation,
+};
 
 use crate::{
     space::SpaceId,
@@ -447,12 +449,12 @@ impl PayloadDecoder for MetaUpdateDecoder {
 
 #[derive(Debug, Clone)]
 pub struct MetaUpdateRequest {
-    pub location: Location,
+    pub location: WalLocation,
     pub meta_update: MetaUpdate,
 }
 
 impl MetaUpdateRequest {
-    pub fn new(location: Location, meta_update: MetaUpdate) -> Self {
+    pub fn new(location: WalLocation, meta_update: MetaUpdate) -> Self {
         Self {
             location,
             meta_update,

--- a/analytic_engine/src/meta/mod.rs
+++ b/analytic_engine/src/meta/mod.rs
@@ -9,7 +9,7 @@ pub mod meta_update;
 use std::{fmt, sync::Arc};
 
 use async_trait::async_trait;
-use common_types::table::Location;
+use wal::manager::WalLocation;
 
 use crate::meta::{meta_data::TableManifestData, meta_update::MetaUpdateRequest};
 
@@ -28,7 +28,7 @@ pub trait Manifest: Send + Sync + fmt::Debug {
     /// the manifest data.
     async fn load_data(
         &self,
-        location: Location,
+        location: WalLocation,
         do_snapshot: bool,
     ) -> Result<Option<TableManifestData>, Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -5,7 +5,7 @@
 use std::{path::Path, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
-use common_types::table::DEFAULT_SHARD_ID;
+use common_types::table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION};
 use common_util::define_result;
 use futures::Future;
 use message_queue::kafka::kafka_impl::KafkaImpl;
@@ -17,7 +17,7 @@ use snafu::{Backtrace, ResultExt, Snafu};
 use table_engine::engine::{EngineRuntimes, TableEngineRef};
 use table_kv::{memory::MemoryImpl, obkv::ObkvImpl, TableKv};
 use wal::{
-    manager::{self, RegionId, WalManagerRef},
+    manager::{self, RegionId, VersionedRegionId, WalManagerRef},
     message_queue_impl::wal::MessageQueueImpl,
     rocks_impl::manager::Builder as WalBuilder,
     table_kv_impl::{wal::WalNamespaceImpl, WalRuntimes},
@@ -139,7 +139,10 @@ impl EngineBuilder for RocksDBWalEngineBuilder {
             }
         }
 
-        let default_region_id = DEFAULT_SHARD_ID as RegionId;
+        let default_versioned_region_id = VersionedRegionId {
+            version: DEFAULT_SHARD_VERSION,
+            id: DEFAULT_SHARD_ID as RegionId,
+        };
 
         let write_runtime = engine_runtimes.write_runtime.clone();
         let data_path = Path::new(&config.wal_path);
@@ -147,7 +150,7 @@ impl EngineBuilder for RocksDBWalEngineBuilder {
         let wal_manager = WalBuilder::with_default_rocksdb_config(
             wal_path,
             write_runtime.clone(),
-            default_region_id,
+            default_versioned_region_id,
         )
         .build()
         .context(OpenWal)?;
@@ -156,7 +159,7 @@ impl EngineBuilder for RocksDBWalEngineBuilder {
         let manifest_wal = WalBuilder::with_default_rocksdb_config(
             manifest_path,
             write_runtime,
-            default_region_id,
+            default_versioned_region_id,
         )
         .build()
         .context(OpenManifestWal)?;

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -5,7 +5,7 @@
 use std::{path::Path, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
-use common_types::table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION};
+use common_types::table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID};
 use common_util::define_result;
 use futures::Future;
 use message_queue::kafka::kafka_impl::KafkaImpl;
@@ -140,7 +140,7 @@ impl EngineBuilder for RocksDBWalEngineBuilder {
         }
 
         let default_versioned_region_id = VersionedRegionId {
-            version: DEFAULT_SHARD_VERSION,
+            version: DEFAULT_CLUSTER_VERSION,
             id: DEFAULT_SHARD_ID as RegionId,
         };
 

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -78,13 +78,13 @@ pub type MemTableId = u64;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct TableShardInfo {
-    pub id: ShardId,
+    pub shard_id: ShardId,
     pub version: ShardVersion,
 }
 
 impl TableShardInfo {
-    pub fn new(id: ShardId, version: ShardVersion) -> Self {
-        Self { id, version }
+    pub fn new(shard_id: ShardId, version: ShardVersion) -> Self {
+        Self { shard_id: id, version }
     }
 }
 
@@ -509,7 +509,7 @@ impl TableData {
     /// Now we just use table id as region id
     #[inline]
     pub fn wal_location(&self) -> WalLocation {
-        let region_id = self.shard_info.id as RegionId;
+        let region_id = self.shard_info.shard_id as RegionId;
         let region_version = self.shard_info.version;
         let table_id = self.id;
 

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -507,9 +507,7 @@ impl TableData {
         self.table_options().storage_format
     }
 
-    /// Get the wal's region info of this table
-    ///
-    /// Now we just use table id as region id
+    /// Get the table's wal location of this table.
     #[inline]
     pub fn wal_location(&self) -> WalLocation {
         let region_id = self.shard_info.shard_id as RegionId;

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -18,7 +18,7 @@ use arc_swap::ArcSwap;
 use arena::CollectorRef;
 use common_types::{
     schema::{Schema, Version},
-    table::{Location, ShardId},
+    table::{ShardId, ShardVersion},
     time::{TimeRange, Timestamp},
     SequenceNumber,
 };
@@ -27,6 +27,7 @@ use log::{debug, info};
 use object_store::Path;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::{engine::CreateTableRequest, table::TableId};
+use wal::manager::{RegionId, WalLocation};
 
 use crate::{
     instance::write_worker::{choose_worker, WorkerLocal, WriteHandle},
@@ -74,6 +75,18 @@ pub enum Error {
 define_result!(Error);
 
 pub type MemTableId = u64;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct TableShardInfo {
+    pub id: ShardId,
+    pub version: ShardVersion,
+}
+
+impl TableShardInfo {
+    pub fn new(id: ShardId, version: ShardVersion) -> Self {
+        Self { id, version }
+    }
+}
 
 /// Data of a table
 pub struct TableData {
@@ -136,7 +149,7 @@ pub struct TableData {
     pub metrics: Metrics,
 
     /// Shard id
-    pub shard_id: ShardId,
+    pub shard_info: TableShardInfo,
 }
 
 impl fmt::Debug for TableData {
@@ -152,7 +165,7 @@ impl fmt::Debug for TableData {
             .field("last_memtable_id", &self.last_memtable_id)
             .field("last_file_id", &self.last_file_id)
             .field("dropped", &self.dropped.load(Ordering::Relaxed))
-            .field("shard_id", &self.shard_id)
+            .field("shard_info", &self.shard_info)
             .finish()
     }
 }
@@ -208,7 +221,7 @@ impl TableData {
             last_flush_time_ms: AtomicU64::new(0),
             dropped: AtomicBool::new(false),
             metrics,
-            shard_id: request.shard_id,
+            shard_info: TableShardInfo::new(request.shard_id, request.shard_version),
         })
     }
 
@@ -221,6 +234,7 @@ impl TableData {
         purger: &FilePurger,
         mem_usage_collector: CollectorRef,
         shard_id: ShardId,
+        shard_version: ShardVersion,
     ) -> Result<Self> {
         let memtable_factory = Arc::new(SkiplistMemTableFactory);
         let purge_queue = purger.create_purge_queue(add_meta.space_id, add_meta.table_id);
@@ -246,7 +260,7 @@ impl TableData {
             last_flush_time_ms: AtomicU64::new(0),
             dropped: AtomicBool::new(false),
             metrics,
-            shard_id,
+            shard_info: TableShardInfo::new(shard_id, shard_version),
         })
     }
 
@@ -269,14 +283,6 @@ impl TableData {
     #[inline]
     pub fn current_version(&self) -> &TableVersion {
         &self.current_version
-    }
-
-    /// Get the wal region id of this table
-    ///
-    /// Now we just use table id as region id
-    #[inline]
-    pub fn shard_id(&self) -> ShardId {
-        self.shard_id
     }
 
     /// Get last sequence number
@@ -498,8 +504,16 @@ impl TableData {
         self.table_options().storage_format
     }
 
-    pub fn location(&self) -> Location {
-        Location::new(self.shard_id, self.id.as_u64())
+    /// Get the wal's region info of this table
+    ///
+    /// Now we just use table id as region id
+    #[inline]
+    pub fn wal_location(&self) -> WalLocation {
+        let region_id = self.shard_info.id as RegionId;
+        let region_version = self.shard_info.version;
+        let table_id = self.id;
+
+        WalLocation::new(region_id, region_version, table_id.as_u64())
     }
 }
 
@@ -592,7 +606,10 @@ pub mod tests {
     use std::sync::Arc;
 
     use arena::NoopCollector;
-    use common_types::{datum::DatumKind, table::DEFAULT_SHARD_ID};
+    use common_types::{
+        datum::DatumKind,
+        table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    };
     use common_util::config::ReadableDuration;
     use table_engine::{engine::TableState, table::SchemaId};
 
@@ -638,6 +655,7 @@ pub mod tests {
         table_id: TableId,
         table_name: String,
         shard_id: ShardId,
+        shard_version: ShardVersion,
         write_handle: Option<WriteHandle>,
     }
 
@@ -654,6 +672,11 @@ pub mod tests {
 
         pub fn shard_id(mut self, shard_id: ShardId) -> Self {
             self.shard_id = shard_id;
+            self
+        }
+
+        pub fn shard_version(mut self, shard_version: ShardVersion) -> Self {
+            self.shard_version = shard_version;
             self
         }
 
@@ -677,6 +700,7 @@ pub mod tests {
                 options: HashMap::new(),
                 state: TableState::Stable,
                 shard_id: self.shard_id,
+                shard_version: self.shard_version,
             };
 
             let write_handle = self.write_handle.unwrap_or_else(|| {
@@ -705,6 +729,7 @@ pub mod tests {
                 table_id: table::new_table_id(2, 1),
                 table_name: "mocked_table".to_string(),
                 shard_id: DEFAULT_SHARD_ID,
+                shard_version: DEFAULT_SHARD_VERSION,
                 write_handle: None,
             }
         }
@@ -715,15 +740,20 @@ pub mod tests {
         let table_id = table::new_table_id(100, 30);
         let table_name = "new_table".to_string();
         let shard_id = 42;
+        let shard_version = 1;
         let table_data = TableDataMocker::default()
             .table_id(table_id)
             .table_name(table_name.clone())
             .shard_id(shard_id)
+            .shard_version(shard_version)
             .build();
 
         assert_eq!(table_id, table_data.id);
         assert_eq!(table_name, table_data.name);
-        assert_eq!(shard_id, table_data.shard_id);
+        assert_eq!(
+            TableShardInfo::new(shard_id, shard_version),
+            table_data.shard_info
+        );
         assert_eq!(0, table_data.last_sequence());
         assert!(!table_data.is_dropped());
         assert_eq!(0, table_data.last_file_id());

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -12,7 +12,7 @@ use common_types::{
     request_id::RequestId,
     row::{Row, RowGroup, RowGroupBuilder},
     schema::{self, Schema},
-    table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     time::Timestamp,
 };
 use common_util::config::ReadableDuration;
@@ -308,7 +308,7 @@ impl Default for Builder {
                 options: HashMap::new(),
                 state: TableState::Stable,
                 shard_id: DEFAULT_SHARD_ID,
-                shard_version: DEFAULT_SHARD_VERSION,
+                cluster_version: DEFAULT_CLUSTER_VERSION,
             },
         }
     }

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -12,7 +12,7 @@ use common_types::{
     request_id::RequestId,
     row::{Row, RowGroup, RowGroupBuilder},
     schema::{self, Schema},
-    table::DEFAULT_SHARD_ID,
+    table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
     time::Timestamp,
 };
 use common_util::config::ReadableDuration;
@@ -308,6 +308,7 @@ impl Default for Builder {
                 options: HashMap::new(),
                 state: TableState::Stable,
                 shard_id: DEFAULT_SHARD_ID,
+                shard_version: DEFAULT_SHARD_VERSION,
             },
         }
     }

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -8,7 +8,7 @@ use common_types::{
     datum::Datum,
     record_batch::RecordBatch,
     row::{Row, RowGroup},
-    table::DEFAULT_SHARD_ID,
+    table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
     time::Timestamp,
 };
 use common_util::{
@@ -174,6 +174,7 @@ impl<T: EngineContext> TestContext<T> {
                 table_id,
                 engine: table_engine::ANALYTIC_ENGINE_TYPE.to_string(),
                 shard_id: DEFAULT_SHARD_ID,
+                shard_version: DEFAULT_SHARD_VERSION,
             })
             .await
             .unwrap()
@@ -197,6 +198,7 @@ impl<T: EngineContext> TestContext<T> {
                 table_id,
                 engine: table_engine::ANALYTIC_ENGINE_TYPE.to_string(),
                 shard_id: DEFAULT_SHARD_ID,
+                shard_version: DEFAULT_SHARD_VERSION,
             })
             .await?;
 

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -8,7 +8,7 @@ use common_types::{
     datum::Datum,
     record_batch::RecordBatch,
     row::{Row, RowGroup},
-    table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     time::Timestamp,
 };
 use common_util::{
@@ -174,7 +174,7 @@ impl<T: EngineContext> TestContext<T> {
                 table_id,
                 engine: table_engine::ANALYTIC_ENGINE_TYPE.to_string(),
                 shard_id: DEFAULT_SHARD_ID,
-                shard_version: DEFAULT_SHARD_VERSION,
+                cluster_version: DEFAULT_CLUSTER_VERSION,
             })
             .await
             .unwrap()
@@ -198,7 +198,7 @@ impl<T: EngineContext> TestContext<T> {
                 table_id,
                 engine: table_engine::ANALYTIC_ENGINE_TYPE.to_string(),
                 shard_id: DEFAULT_SHARD_ID,
-                shard_version: DEFAULT_SHARD_VERSION,
+                cluster_version: DEFAULT_CLUSTER_VERSION,
             })
             .await?;
 

--- a/benchmarks/src/wal_write_bench.rs
+++ b/benchmarks/src/wal_write_bench.rs
@@ -4,12 +4,11 @@
 
 use std::sync::Arc;
 
-use common_types::table::Location;
 use common_util::runtime::Runtime;
 use rand::prelude::*;
 use table_kv::memory::MemoryImpl;
 use wal::{
-    manager::{WalManager, WriteContext},
+    manager::{WalLocation, WalManager, WriteContext},
     table_kv_impl::{model::NamespaceConfig, wal::WalNamespaceImpl, WalRuntimes},
 };
 
@@ -76,7 +75,7 @@ impl WalWriteBench {
 
             let values = self.build_value_vec();
             let wal_encoder = wal
-                .encoder(Location::new(1, 1))
+                .encoder(WalLocation::new(1, 1, 1))
                 .expect("should succeed to create wal encoder");
             let log_batch = wal_encoder
                 .encode_batch::<WritePayload, Vec<u8>>(values.as_slice())

--- a/catalog/src/schema.rs
+++ b/catalog/src/schema.rs
@@ -5,7 +5,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use common_types::{column_schema::ColumnSchema, table::ShardId};
+use common_types::{
+    column_schema::ColumnSchema,
+    table::{ShardId, ShardVersion},
+};
 use snafu::{Backtrace, Snafu};
 use table_engine::{
     engine::{self, TableEngineRef, TableState},
@@ -214,6 +217,8 @@ pub struct CreateTableRequest {
     pub state: TableState,
     /// Shard id of the table
     pub shard_id: ShardId,
+    /// Shard version
+    pub shard_version: ShardVersion,
 }
 
 impl CreateTableRequest {
@@ -230,6 +235,7 @@ impl CreateTableRequest {
             options: self.options,
             state: self.state,
             shard_id: self.shard_id,
+            shard_version: self.shard_version,
         }
     }
 }

--- a/catalog/src/schema.rs
+++ b/catalog/src/schema.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use common_types::{
     column_schema::ColumnSchema,
-    table::{ShardId, ShardVersion},
+    table::{ClusterVersion, ShardId},
 };
 use snafu::{Backtrace, Snafu};
 use table_engine::{
@@ -217,8 +217,8 @@ pub struct CreateTableRequest {
     pub state: TableState,
     /// Shard id of the table
     pub shard_id: ShardId,
-    /// Shard version
-    pub shard_version: ShardVersion,
+    /// Cluster version of shard
+    pub cluster_version: ClusterVersion,
 }
 
 impl CreateTableRequest {
@@ -235,7 +235,7 @@ impl CreateTableRequest {
             options: self.options,
             state: self.state,
             shard_id: self.shard_id,
-            shard_version: self.shard_version,
+            cluster_version: self.cluster_version,
         }
     }
 }

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -879,7 +879,7 @@ mod tests {
         manager::Manager,
         schema::{CreateOptions, CreateTableRequest, DropOptions, DropTableRequest, SchemaRef},
     };
-    use common_types::table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION};
+    use common_types::table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID};
     use server::table_engine::{MemoryTableEngine, TableEngineProxy};
     use table_engine::{
         engine::{TableEngineRef, TableState},
@@ -930,7 +930,7 @@ mod tests {
             options: HashMap::new(),
             state: TableState::Stable,
             shard_id: DEFAULT_SHARD_ID,
-            shard_version: DEFAULT_SHARD_VERSION,
+            cluster_version: DEFAULT_CLUSTER_VERSION,
         }
     }
 

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -879,7 +879,7 @@ mod tests {
         manager::Manager,
         schema::{CreateOptions, CreateTableRequest, DropOptions, DropTableRequest, SchemaRef},
     };
-    use common_types::table::DEFAULT_SHARD_ID;
+    use common_types::table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION};
     use server::table_engine::{MemoryTableEngine, TableEngineProxy};
     use table_engine::{
         engine::{TableEngineRef, TableState},
@@ -930,6 +930,7 @@ mod tests {
             options: HashMap::new(),
             state: TableState::Stable,
             shard_id: DEFAULT_SHARD_ID,
+            shard_version: DEFAULT_SHARD_VERSION,
         }
     }
 

--- a/common_types/src/table.rs
+++ b/common_types/src/table.rs
@@ -4,5 +4,7 @@ pub type TableId = u64;
 pub type TableName = String;
 pub type ShardId = u32;
 pub type ShardVersion = u64;
+pub type ClusterVersion = u64;
 pub const DEFAULT_SHARD_ID: u32 = 0;
 pub const DEFAULT_SHARD_VERSION: u64 = 0;
+pub const DEFAULT_CLUSTER_VERSION: u64 = 0;

--- a/common_types/src/table.rs
+++ b/common_types/src/table.rs
@@ -3,16 +3,6 @@
 pub type TableId = u64;
 pub type TableName = String;
 pub type ShardId = u32;
+pub type ShardVersion = u64;
 pub const DEFAULT_SHARD_ID: u32 = 0;
-
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct Location {
-    pub shard_id: ShardId,
-    pub table_id: TableId,
-}
-
-impl Location {
-    pub fn new(shard_id: ShardId, table_id: TableId) -> Self {
-        Self { shard_id, table_id }
-    }
-}
+pub const DEFAULT_SHARD_VERSION: u64 = 0;

--- a/interpreters/src/table_manipulator/catalog_based.rs
+++ b/interpreters/src/table_manipulator/catalog_based.rs
@@ -5,7 +5,7 @@ use catalog::{
     manager::ManagerRef,
     schema::{CreateOptions, CreateTableRequest, DropOptions, DropTableRequest},
 };
-use common_types::table::DEFAULT_SHARD_ID;
+use common_types::table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION};
 use log::warn;
 use snafu::{OptionExt, ResultExt};
 use sql::plan::{CreateTablePlan, DropTablePlan};
@@ -77,6 +77,7 @@ impl TableManipulator for TableManipulatorImpl {
             options,
             state: TableState::Stable,
             shard_id: DEFAULT_SHARD_ID,
+            shard_version: DEFAULT_SHARD_VERSION,
         };
 
         let opts = CreateOptions {

--- a/interpreters/src/table_manipulator/catalog_based.rs
+++ b/interpreters/src/table_manipulator/catalog_based.rs
@@ -5,7 +5,7 @@ use catalog::{
     manager::ManagerRef,
     schema::{CreateOptions, CreateTableRequest, DropOptions, DropTableRequest},
 };
-use common_types::table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION};
+use common_types::table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID};
 use log::warn;
 use snafu::{OptionExt, ResultExt};
 use sql::plan::{CreateTablePlan, DropTablePlan};
@@ -77,7 +77,7 @@ impl TableManipulator for TableManipulatorImpl {
             options,
             state: TableState::Stable,
             shard_id: DEFAULT_SHARD_ID,
-            shard_version: DEFAULT_SHARD_VERSION,
+            cluster_version: DEFAULT_CLUSTER_VERSION,
         };
 
         let opts = CreateOptions {

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -3,6 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use ceresdbproto::{cluster as cluster_pb, meta_service as meta_service_pb};
+pub use common_types::table::{ShardId, ShardVersion};
 use common_types::{
     schema::{SchemaId, SchemaName},
     table::{TableId, TableName},
@@ -12,9 +13,6 @@ use serde_derive::Deserialize;
 use snafu::OptionExt;
 
 use crate::{Error, MissingShardInfo, MissingTableInfo, Result};
-
-pub type ShardId = u32;
-pub type ShardVersion = u64;
 pub type ClusterNodesRef = Arc<Vec<NodeShard>>;
 
 #[derive(Debug, Clone)]

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -179,6 +179,7 @@ async fn handle_open_shard(ctx: HandlerContext, request: OpenShardRequest) -> Re
             table_id: TableId::new(table.id),
             engine: table_engine::ANALYTIC_ENGINE_TYPE.to_string(),
             shard_id: shard_info.id,
+            shard_version: shard_info.version,
         };
         schema
             .open_table(open_request.clone(), opts.clone())
@@ -314,6 +315,7 @@ async fn handle_create_table_on_shard(
         options: request.options,
         state: TableState::Stable,
         shard_id: shard_info.id,
+        shard_version: shard_info.version,
     };
     let create_opts = CreateOptions {
         table_engine: ctx.table_engine,

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -15,7 +15,7 @@ use common_types::{
     request_id::RequestId,
     row::{Row, RowGroup, RowGroupBuilder},
     schema::{self, Schema},
-    table::DEFAULT_SHARD_ID,
+    table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
     time::Timestamp,
 };
 use common_util::{
@@ -270,6 +270,7 @@ impl SysCatalogTable {
             table_id: SYS_CATALOG_TABLE_ID,
             engine: table_engine.engine_type().to_string(),
             shard_id: DEFAULT_SHARD_ID,
+            shard_version: DEFAULT_SHARD_VERSION,
         };
 
         let table_opt = table_engine
@@ -310,6 +311,7 @@ impl SysCatalogTable {
             options,
             state: TableState::Stable,
             shard_id: DEFAULT_SHARD_ID,
+            shard_version: DEFAULT_SHARD_VERSION,
         };
 
         let table = table_engine

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -15,7 +15,7 @@ use common_types::{
     request_id::RequestId,
     row::{Row, RowGroup, RowGroupBuilder},
     schema::{self, Schema},
-    table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     time::Timestamp,
 };
 use common_util::{
@@ -270,7 +270,7 @@ impl SysCatalogTable {
             table_id: SYS_CATALOG_TABLE_ID,
             engine: table_engine.engine_type().to_string(),
             shard_id: DEFAULT_SHARD_ID,
-            shard_version: DEFAULT_SHARD_VERSION,
+            cluster_version: DEFAULT_CLUSTER_VERSION,
         };
 
         let table_opt = table_engine
@@ -311,7 +311,7 @@ impl SysCatalogTable {
             options,
             state: TableState::Stable,
             shard_id: DEFAULT_SHARD_ID,
-            shard_version: DEFAULT_SHARD_VERSION,
+            cluster_version: DEFAULT_CLUSTER_VERSION,
         };
 
         let table = table_engine

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use common_types::{
     schema::Schema,
-    table::{ShardId, DEFAULT_SHARD_ID},
+    table::{ShardId, ShardVersion, DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
 };
 use common_util::runtime::Runtime;
 use proto::sys_catalog as sys_catalog_pb;
@@ -162,6 +162,8 @@ pub struct CreateTableRequest {
     /// It will be assigned the default value in standalone mode,
     /// and just be useful in cluster mode
     pub shard_id: ShardId,
+    /// Shard version, it will change while cluster's topology changes.
+    pub shard_version: ShardVersion,
 }
 
 impl From<CreateTableRequest> for sys_catalog_pb::TableEntry {
@@ -225,6 +227,8 @@ pub struct OpenTableRequest {
     pub engine: String,
     /// Shard id, shard is the table set about scheduling from nodes
     pub shard_id: ShardId,
+    /// Shard version, same as the one in [CreateTableRequest]
+    pub shard_version: ShardVersion,
 }
 
 impl From<TableInfo> for OpenTableRequest {
@@ -240,6 +244,7 @@ impl From<TableInfo> for OpenTableRequest {
             table_id: table_info.table_id,
             engine: table_info.engine,
             shard_id: DEFAULT_SHARD_ID,
+            shard_version: DEFAULT_SHARD_VERSION,
         }
     }
 }

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_trait::async_trait;
 use common_types::{
     schema::Schema,
-    table::{ShardId, ShardVersion, DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    table::{ClusterVersion, ShardId, DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
 };
 use common_util::runtime::Runtime;
 use proto::sys_catalog as sys_catalog_pb;
@@ -162,8 +162,9 @@ pub struct CreateTableRequest {
     /// It will be assigned the default value in standalone mode,
     /// and just be useful in cluster mode
     pub shard_id: ShardId,
-    /// Shard version, it will change while cluster's topology changes.
-    pub shard_version: ShardVersion,
+    /// Cluster version of shard, it will change while cluster's topology
+    /// changes.
+    pub cluster_version: ClusterVersion,
 }
 
 impl From<CreateTableRequest> for sys_catalog_pb::TableEntry {
@@ -227,8 +228,8 @@ pub struct OpenTableRequest {
     pub engine: String,
     /// Shard id, shard is the table set about scheduling from nodes
     pub shard_id: ShardId,
-    /// Shard version, same as the one in [CreateTableRequest]
-    pub shard_version: ShardVersion,
+    /// Cluster version, same as the one in [CreateTableRequest]
+    pub cluster_version: ClusterVersion,
 }
 
 impl From<TableInfo> for OpenTableRequest {
@@ -244,7 +245,7 @@ impl From<TableInfo> for OpenTableRequest {
             table_id: table_info.table_id,
             engine: table_info.engine,
             shard_id: DEFAULT_SHARD_ID,
-            shard_version: DEFAULT_SHARD_VERSION,
+            cluster_version: DEFAULT_CLUSTER_VERSION,
         }
     }
 }

--- a/wal/src/kv_encoder.rs
+++ b/wal/src/kv_encoder.rs
@@ -4,7 +4,7 @@
 
 use common_types::{
     bytes::{self, Buf, BufMut, BytesMut, SafeBuf, SafeBufMut},
-    table::{Location, TableId},
+    table::TableId,
     SequenceNumber,
 };
 use common_util::{
@@ -15,7 +15,7 @@ use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
 use crate::{
     log_batch::{LogWriteBatch, LogWriteEntry, Payload},
-    manager::{self, Encoding, RegionId},
+    manager::{self, Encoding, RegionId, WalLocation},
 };
 
 pub const LOG_KEY_ENCODING_V0: u8 = 0;
@@ -535,13 +535,13 @@ impl LogEncoding {
 /// LogBatchEncoder which are used to encode specify payloads.
 #[derive(Debug)]
 pub struct LogBatchEncoder {
-    location: Location,
+    location: WalLocation,
     log_encoding: LogEncoding,
 }
 
 impl LogBatchEncoder {
     /// Create LogBatchEncoder with specific region_id.
-    pub fn create(location: Location) -> Self {
+    pub fn create(location: WalLocation) -> Self {
         Self {
             location,
             log_encoding: LogEncoding::newest(),

--- a/wal/src/log_batch.rs
+++ b/wal/src/log_batch.rs
@@ -6,9 +6,11 @@ use std::fmt::Debug;
 
 use common_types::{
     bytes::{Buf, BufMut},
-    table::{Location, TableId},
+    table::TableId,
     SequenceNumber,
 };
+
+use crate::manager::WalLocation;
 
 pub trait Payload: Send + Sync + Debug {
     type Error: std::error::Error + Send + Sync + 'static;
@@ -35,16 +37,16 @@ pub struct LogWriteEntry {
 /// A batch of `LogWriteEntry`s.
 #[derive(Debug)]
 pub struct LogWriteBatch {
-    pub(crate) location: Location,
+    pub(crate) location: WalLocation,
     pub(crate) entries: Vec<LogWriteEntry>,
 }
 
 impl LogWriteBatch {
-    pub fn new(location: Location) -> Self {
+    pub fn new(location: WalLocation) -> Self {
         Self::with_capacity(location, 0)
     }
 
-    pub fn with_capacity(location: Location, cap: usize) -> Self {
+    pub fn with_capacity(location: WalLocation, cap: usize) -> Self {
         Self {
             location,
             entries: Vec::with_capacity(cap),

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -7,7 +7,7 @@ use std::{collections::VecDeque, fmt, sync::Arc, time::Duration};
 use async_trait::async_trait;
 pub use common_types::SequenceNumber;
 use common_types::{
-    table::{Location, TableId, DEFAULT_SHARD_ID},
+    table::{Location, TableId},
     MAX_SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER,
 };
 use common_util::runtime::Runtime;
@@ -21,9 +21,10 @@ use crate::{
 };
 
 pub mod error {
-    use common_types::table::Location;
     use common_util::define_result;
     use snafu::{Backtrace, Snafu};
+
+    use crate::manager::WalLocation;
 
     // Now most error from manage implementation don't have backtrace, so we add
     // backtrace here.
@@ -49,12 +50,12 @@ pub mod error {
         },
 
         #[snafu(display(
-            "Region is not found, table_location:{:?}.\nBacktrace:\n{}",
+            "Region is not found, wal location:{:?}.\nBacktrace:\n{}",
             location,
             backtrace
         ))]
         RegionNotFound {
-            location: Location,
+            location: WalLocation,
             backtrace: Backtrace,
         },
 
@@ -123,8 +124,21 @@ pub mod error {
     define_result!(Error);
 }
 
+#[derive(Debug)]
+pub struct WalLocation {
+    pub versioned_region_id: VersionedRegionId,
+    pub table_id: TableId,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq)]
+pub struct VersionedRegionId {
+    pub version: RegionVersion,
+    pub id: RegionId,
+}
+
 pub type RegionId = u64;
 pub const MAX_REGION_ID: RegionId = u64::MAX;
+pub type RegionVersion = u64;
 
 #[derive(Debug, Clone)]
 pub struct WriteContext {
@@ -209,7 +223,7 @@ impl ReadBoundary {
 #[derive(Debug, Clone)]
 pub struct ReadRequest {
     /// Location of the wal to read
-    pub location: Location,
+    pub location: WalLocation,
     // TODO(yingwen): Or just rename to ReadBound?
     /// Start bound
     pub start: ReadBoundary,
@@ -230,7 +244,7 @@ impl Default for ReadRequest {
 #[derive(Debug, Clone, Default)]
 pub struct ScanRequest {
     /// Region id of the wals to be scanned
-    pub region_id: RegionId,
+    pub versioned_region_id: VersionedRegionId,
 }
 
 pub type ScanContext = ReadContext;
@@ -257,13 +271,13 @@ pub trait AsyncLogIterator: Send + fmt::Debug {
 #[async_trait]
 pub trait WalManager: Send + Sync + fmt::Debug + 'static {
     /// Get current sequence number.
-    async fn sequence_num(&self, location: Location) -> Result<SequenceNumber>;
+    async fn sequence_num(&self, location: WalLocation) -> Result<SequenceNumber>;
 
     /// Mark the entries whose sequence number is in [0, `sequence_number`] to
     /// be deleted in the future.
     async fn mark_delete_entries_up_to(
         &self,
-        location: Location,
+        location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()>;
 
@@ -278,7 +292,7 @@ pub trait WalManager: Send + Sync + fmt::Debug + 'static {
     ) -> Result<BatchLogIteratorAdapter>;
 
     /// Provide the encoder for encoding payloads.
-    fn encoder(&self, location: Location) -> Result<LogBatchEncoder> {
+    fn encoder(&self, location: WalLocation) -> Result<LogBatchEncoder> {
         Ok(LogBatchEncoder::create(location))
     }
 

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -124,6 +124,7 @@ pub mod error {
     define_result!(Error);
 }
 
+/// Decide where to write logs
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WalLocation {
     pub versioned_region_id: VersionedRegionId,
@@ -144,6 +145,11 @@ impl WalLocation {
     }
 }
 
+/// Region id with version
+///
+/// The `version` may be mapped to cluster version(while shard moved from nodes,
+/// it may changed to mark this moving) now.
+/// Introduce this field is for solving the following bug: https://github.com/CeresDB/ceresdb/issues/441
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VersionedRegionId {
     pub version: RegionVersion,

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -7,7 +7,7 @@ use std::{collections::VecDeque, fmt, sync::Arc, time::Duration};
 use async_trait::async_trait;
 pub use common_types::SequenceNumber;
 use common_types::{
-    table::{TableId, DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    table::{TableId, DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     MAX_SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER,
 };
 use common_util::runtime::Runtime;
@@ -250,7 +250,7 @@ impl Default for ReadRequest {
         Self {
             location: WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 TableId::MIN,
             ),
             start: ReadBoundary::Min,

--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -238,6 +238,7 @@ impl<M: MessageQueue> fmt::Debug for Namespace<M> {
 
 struct NamespaceInner<M: MessageQueue> {
     namespace: String,
+    // TODO: should use some strategies(such as lru) to clean the invalid region.
     regions: Arc<RwLock<HashMap<VersionedRegionId, RegionRef<M>>>>,
     message_queue: Arc<M>,
     meta_encoding: MetaEncoding,

--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
 
-use common_types::{table::Location, SequenceNumber};
+use common_types::SequenceNumber;
 use common_util::{define_result, runtime::Runtime};
 use log::{debug, error, info};
 use message_queue::{ConsumeIterator, MessageQueue};
@@ -14,7 +14,10 @@ use tokio::sync::RwLock;
 use crate::{
     kv_encoder::LogEncoding,
     log_batch::{LogEntry, LogWriteBatch},
-    manager::{ReadContext, ReadRequest, RegionId, ScanContext, ScanRequest, WriteContext},
+    manager::{
+        ReadContext, ReadRequest, ScanContext, ScanRequest, VersionedRegionId, WalLocation,
+        WriteContext,
+    },
     message_queue_impl::{
         config::Config,
         encoding::MetaEncoding,
@@ -33,7 +36,7 @@ pub enum Error {
     ))]
     GetSequence {
         namespace: String,
-        location: Location,
+        location: WalLocation,
         source: region::Error,
     },
 
@@ -98,7 +101,7 @@ pub enum Error {
     ))]
     Write {
         namespace: String,
-        location: Location,
+        location: WalLocation,
         batch_size: usize,
         source: region::Error,
     },
@@ -112,7 +115,7 @@ pub enum Error {
     ))]
     MarkDeleteTo {
         namespace: String,
-        location: Location,
+        location: WalLocation,
         sequence_num: SequenceNumber,
         source: region::Error,
     },
@@ -173,7 +176,7 @@ impl<M: MessageQueue> Namespace<M> {
     }
 
     /// Get table's sequence number.
-    pub async fn sequence_num(&self, location: Location) -> Result<SequenceNumber> {
+    pub async fn sequence_num(&self, location: WalLocation) -> Result<SequenceNumber> {
         self.inner.sequence_num(location).await
     }
 
@@ -212,7 +215,7 @@ impl<M: MessageQueue> Namespace<M> {
     /// `sequence_number`] to be deleted in the future.
     pub async fn mark_delete_to(
         &self,
-        location: Location,
+        location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         self.inner.mark_delete_to(location, sequence_num).await
@@ -235,7 +238,7 @@ impl<M: MessageQueue> fmt::Debug for Namespace<M> {
 
 struct NamespaceInner<M: MessageQueue> {
     namespace: String,
-    regions: Arc<RwLock<HashMap<RegionId, RegionRef<M>>>>,
+    regions: Arc<RwLock<HashMap<VersionedRegionId, RegionRef<M>>>>,
     message_queue: Arc<M>,
     meta_encoding: MetaEncoding,
     log_encoding: LogEncoding,
@@ -261,14 +264,14 @@ impl<M: MessageQueue> NamespaceInner<M> {
     /// about above operations on an empty region.
     async fn get_or_open_region(
         &self,
-        region_id: RegionId,
+        versioned_region_id: VersionedRegionId,
     ) -> std::result::Result<RegionRef<M>, region::Error> {
         {
             let regions = self.regions.read().await;
-            if let Some(region) = regions.get(&region_id) {
+            if let Some(region) = regions.get(&versioned_region_id) {
                 debug!(
-                    "Region exists and return it, namespace:{}, region id:{}",
-                    self.namespace, region_id
+                    "Region exists and return it, namespace:{}, versioned region id:{:?}",
+                    self.namespace, versioned_region_id
                 );
                 return Ok(region.clone());
             }
@@ -276,29 +279,35 @@ impl<M: MessageQueue> NamespaceInner<M> {
 
         let mut regions = self.regions.write().await;
         // Multiple tables share one region, so double check here is needed.
-        if let Some(region) = regions.get(&region_id) {
+        if let Some(region) = regions.get(&versioned_region_id) {
             debug!(
-                "Region exists and return it, namespace:{}, region id:{}",
-                self.namespace, region_id
+                "Region exists and return it, namespace:{}, versioned region id:{:?}",
+                self.namespace, versioned_region_id
             );
             return Ok(region.clone());
         }
 
-        let region =
-            Arc::new(Region::open(&self.namespace, region_id, self.message_queue.clone()).await?);
-        regions.insert(region_id, region.clone());
+        let region = Arc::new(
+            Region::open(
+                &self.namespace,
+                versioned_region_id.id,
+                self.message_queue.clone(),
+            )
+            .await?,
+        );
+        regions.insert(versioned_region_id, region.clone());
 
         info!(
-            "Region open successfully, namespace:{}, region id:{}",
-            self.namespace, region_id
+            "Region open successfully, namespace:{}, versioned region id:{:?}",
+            self.namespace, versioned_region_id
         );
 
         Ok(region)
     }
 
-    pub async fn sequence_num(&self, location: Location) -> Result<SequenceNumber> {
+    pub async fn sequence_num(&self, location: WalLocation) -> Result<SequenceNumber> {
         let region = self
-            .get_or_open_region(location.shard_id as u64)
+            .get_or_open_region(location.versioned_region_id)
             .await
             .context(GetSequence {
                 namespace: self.namespace.clone(),
@@ -330,7 +339,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
         );
 
         let region = self
-            .get_or_open_region(request.location.shard_id as u64)
+            .get_or_open_region(request.location.versioned_region_id)
             .await
             .context(ReadWithCause {
                 namespace: self.namespace.clone(),
@@ -365,7 +374,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
         );
 
         let region = self
-            .get_or_open_region(request.region_id)
+            .get_or_open_region(request.versioned_region_id)
             .await
             .context(ScanWithCause {
                 namespace: self.namespace.clone(),
@@ -404,7 +413,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
         );
 
         let region = self
-            .get_or_open_region(log_batch.location.shard_id as RegionId)
+            .get_or_open_region(log_batch.location.versioned_region_id)
             .await
             .context(Write {
                 namespace: self.namespace.clone(),
@@ -421,13 +430,13 @@ impl<M: MessageQueue> NamespaceInner<M> {
 
     pub async fn mark_delete_to(
         &self,
-        location: Location,
+        location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         debug!("Mark table logs delete in namespace, namespace:{}, location:{:?}, delete to sequence number:{}", self.namespace, location, sequence_num);
 
         let region = self
-            .get_or_open_region(location.shard_id as RegionId)
+            .get_or_open_region(location.versioned_region_id)
             .await
             .context(MarkDeleteTo {
                 namespace: self.namespace.clone(),

--- a/wal/src/message_queue_impl/region.rs
+++ b/wal/src/message_queue_impl/region.rs
@@ -946,12 +946,20 @@ mod tests {
         message_queue: Arc<M>,
     ) {
         let namespace = format!("test_{}", uuid::Uuid::new_v4());
-        let shard_id = 42;
         let region_id = 42;
+        let region_version = 4242;
+        let table_id = 424242;
 
         let table_num = test_datas.len();
-        let test_context =
-            TestContext::new(namespace, region_id, shard_id, test_datas, message_queue).await;
+        let test_context = TestContext::new(
+            namespace,
+            region_id,
+            region_version,
+            table_id,
+            test_datas,
+            message_queue,
+        )
+        .await;
 
         // Write.
         let mut mixed_test_payloads = Vec::new();
@@ -994,12 +1002,20 @@ mod tests {
         message_queue: Arc<M>,
     ) {
         let namespace = format!("test_{}", uuid::Uuid::new_v4());
-        let shard_id = 42;
         let region_id = 42;
+        let region_version = 4242;
+        let table_id = 424242;
 
         let table_num = test_datas.len();
-        let test_context =
-            TestContext::new(namespace, region_id, shard_id, test_datas, message_queue).await;
+        let test_context = TestContext::new(
+            namespace,
+            region_id,
+            region_version,
+            table_id,
+            test_datas,
+            message_queue,
+        )
+        .await;
 
         // Mark deleted and check
         for table_idx in 0..table_num {
@@ -1118,15 +1134,17 @@ mod tests {
         message_queue: Arc<M>,
     ) {
         let namespace = format!("test_{}", uuid::Uuid::new_v4());
-        let shard_id = 42;
         let region_id = 42;
+        let region_version = 4242;
+        let table_id = 424242;
 
         let mut snapshot_from_origin = {
             let table_num = test_datas.len();
             let test_context = TestContext::new(
                 namespace.clone(),
                 region_id,
-                shard_id,
+                region_version,
+                table_id,
                 test_datas.clone(),
                 message_queue.clone(),
             )
@@ -1151,8 +1169,15 @@ mod tests {
             test_context.region.make_meta_snapshot().await
         };
 
-        let test_context =
-            TestContext::new(namespace, region_id, shard_id, test_datas, message_queue).await;
+        let test_context = TestContext::new(
+            namespace,
+            region_id,
+            region_version,
+            table_id,
+            test_datas,
+            message_queue,
+        )
+        .await;
         let mut snapshot_from_recovered = test_context.region.make_meta_snapshot().await;
 
         snapshot_from_origin

--- a/wal/src/message_queue_impl/wal.rs
+++ b/wal/src/message_queue_impl/wal.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use common_types::{table::Location, SequenceNumber};
+use common_types::SequenceNumber;
 use common_util::runtime::Runtime;
 use message_queue::{ConsumeIterator, MessageQueue};
 use snafu::ResultExt;
@@ -14,7 +14,7 @@ use crate::{
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
         error::*, AsyncLogIterator, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext,
-        ScanRequest, WalManager, WriteContext,
+        ScanRequest, WalLocation, WalManager, WriteContext,
     },
     message_queue_impl::{
         config::Config,
@@ -43,7 +43,7 @@ impl<M: MessageQueue> MessageQueueImpl<M> {
 
 #[async_trait]
 impl<M: MessageQueue> WalManager for MessageQueueImpl<M> {
-    async fn sequence_num(&self, location: Location) -> Result<SequenceNumber> {
+    async fn sequence_num(&self, location: WalLocation) -> Result<SequenceNumber> {
         self.0
             .sequence_num(location)
             .await
@@ -53,7 +53,7 @@ impl<M: MessageQueue> WalManager for MessageQueueImpl<M> {
 
     async fn mark_delete_entries_up_to(
         &self,
-        location: Location,
+        location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         self.0

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1450,7 +1450,7 @@ mod tests {
 
     use common_types::{
         bytes::BytesMut,
-        table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+        table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     };
     use common_util::runtime::{Builder, Runtime};
     use table_kv::{memory::MemoryImpl, KeyBoundary, ScanContext, ScanRequest};
@@ -1756,7 +1756,7 @@ mod tests {
             let table_id = 123;
             let location = WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             );
             let seq1 = write_test_payloads(&namespace, location, 1000, 1004).await;

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -222,6 +222,7 @@ struct NamespaceInner<T> {
     table_kv: T,
     entry: NamespaceEntry,
     bucket_set: RwLock<BucketSet>,
+    // TODO: should use some strategies(such as lru) to clean the invalid table unit.
     table_units: RwLock<HashMap<WalLocation, TableUnitRef>>,
     meta_table_name: String,
     table_unit_meta_tables: Vec<String>,

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -9,10 +9,7 @@ use std::{
     time::Duration,
 };
 
-use common_types::{
-    table::{Location, TableId},
-    time::Timestamp,
-};
+use common_types::{table::TableId, time::Timestamp};
 use common_util::{config::ReadableDuration, define_result, runtime::Runtime};
 use log::{debug, error, info, warn};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
@@ -23,7 +20,10 @@ use table_kv::{
 use crate::{
     kv_encoder::CommonLogKey,
     log_batch::LogWriteBatch,
-    manager::{self, ReadContext, ReadRequest, RegionId, ScanContext, ScanRequest, SequenceNumber},
+    manager::{
+        self, ReadContext, ReadRequest, RegionId, ScanContext, ScanRequest, SequenceNumber,
+        WalLocation,
+    },
     table_kv_impl::{
         consts, encoding,
         model::{BucketEntry, NamespaceConfig, NamespaceEntry},
@@ -140,58 +140,50 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to create table unit, namespace:{}, region_id:{}, table_id:{}, err:{}",
+        "Failed to create table unit, namespace:{}, wal location:{:?}, err:{}",
         namespace,
-        region_id,
-        table_id,
+        location,
         source
     ))]
     CreateTableUnit {
         namespace: String,
-        region_id: RegionId,
-        table_id: TableId,
+        location: WalLocation,
         source: crate::table_kv_impl::table_unit::Error,
     },
 
     #[snafu(display(
-        "Failed to write table unit, namespace:{}, region_id:{}, table_id:{}, err:{}",
+        "Failed to write table unit, namespace:{}, wal location:{:?}, err:{}",
         namespace,
-        region_id,
-        table_id,
+        location,
         source
     ))]
     WriteTableUnit {
         namespace: String,
-        region_id: RegionId,
-        table_id: TableId,
+        location: WalLocation,
         source: crate::table_kv_impl::table_unit::Error,
     },
 
     #[snafu(display(
-        "Failed to read table unit, namespace:{}, region_id:{}, table_id:{}, err:{}",
+        "Failed to read table unit, namespace:{}, wal location:{:?}, err:{}",
         namespace,
-        region_id,
-        table_id,
+        location,
         source
     ))]
     ReadTableUnit {
         namespace: String,
-        region_id: RegionId,
-        table_id: TableId,
+        location: WalLocation,
         source: crate::table_kv_impl::table_unit::Error,
     },
 
     #[snafu(display(
-        "Failed to delete entries, namespace:{}, region_id:{}, table_id:{}, err:{}",
+        "Failed to delete entries, namespace:{}, wal location:{:?}, err:{}",
         namespace,
-        region_id,
-        table_id,
+        location,
         source
     ))]
     DeleteEntries {
         namespace: String,
-        region_id: RegionId,
-        table_id: TableId,
+        location: WalLocation,
         source: crate::table_kv_impl::table_unit::Error,
     },
 
@@ -230,7 +222,7 @@ struct NamespaceInner<T> {
     table_kv: T,
     entry: NamespaceEntry,
     bucket_set: RwLock<BucketSet>,
-    table_units: RwLock<HashMap<TableId, TableUnitRef>>,
+    table_units: RwLock<HashMap<WalLocation, TableUnitRef>>,
     meta_table_name: String,
     table_unit_meta_tables: Vec<String>,
     operator: Mutex<TableOperator>,
@@ -250,8 +242,8 @@ impl<T> NamespaceInner<T> {
         &self.table_unit_meta_tables
     }
 
-    fn table_unit_meta_table(&self, region_id: RegionId) -> &str {
-        let index = region_id as usize % self.table_unit_meta_tables.len();
+    fn table_unit_meta_table(&self, table_id: TableId) -> &str {
+        let index = table_id as usize % self.table_unit_meta_tables.len();
 
         &self.table_unit_meta_tables[index]
     }
@@ -478,21 +470,23 @@ impl<T: TableKv> NamespaceInner<T> {
         Ok(())
     }
 
-    fn get_table_unit_from_memory(&self, region_id: RegionId) -> Option<TableUnitRef> {
+    fn get_table_unit_from_memory(&self, location: &WalLocation) -> Option<TableUnitRef> {
         let table_units = self.table_units.read().unwrap();
-        table_units.get(&region_id).cloned()
+        table_units.get(location).cloned()
     }
 
-    fn insert_or_get_table_unit(&self, table_unit: TableUnitRef) -> TableUnitRef {
+    fn insert_or_get_table_unit(
+        &self,
+        location: WalLocation,
+        table_unit: TableUnitRef,
+    ) -> TableUnitRef {
         let mut table_units = self.table_units.write().unwrap();
         // Table unit already exists.
-        if let Some(v) = table_units.get(&table_unit.table_id()) &&
-            v.region_id() == table_unit.region_id()
-        {
+        if let Some(v) = table_units.get(&location) {
             return v.clone();
         }
 
-        table_units.insert(table_unit.table_id(), table_unit.clone());
+        table_units.insert(location, table_unit.clone());
 
         table_unit
     }
@@ -521,27 +515,20 @@ impl<T: TableKv> NamespaceInner<T> {
     // FIXME: a dangerous bug, when table are scheduled to another node and
     // scheduled back after, we should deprecate the `TableUnit` entry in memory
     // but now we will continue to use the outdated entry.
-    async fn get_or_open_table_unit(
-        &self,
-        region_id: RegionId,
-        table_id: TableId,
-    ) -> Result<Option<TableUnitRef>> {
-        if let Some(table_unit) = self.get_table_unit_from_memory(table_id) &&
-            table_unit.region_id() == region_id
-        {
+    async fn get_or_open_table_unit(&self, location: WalLocation) -> Result<Option<TableUnitRef>> {
+        if let Some(table_unit) = self.get_table_unit_from_memory(&location) {
             return Ok(Some(table_unit));
         }
 
-        self.open_table_unit(region_id, table_id).await
+        self.open_table_unit(location).await
     }
 
     // TODO(yingwen): Provide a close_table_unit() method.
-    async fn open_table_unit(
-        &self,
-        region_id: RegionId,
-        table_id: TableId,
-    ) -> Result<Option<TableUnitRef>> {
-        let table_unit_meta_table = self.table_unit_meta_table(region_id);
+    async fn open_table_unit(&self, location: WalLocation) -> Result<Option<TableUnitRef>> {
+        let region_id = location.versioned_region_id.id;
+        let table_id = location.table_id;
+
+        let table_unit_meta_table = self.table_unit_meta_table(table_id);
         let buckets = self.bucket_set.read().unwrap().buckets();
 
         let table_unit_opt = TableUnit::open(
@@ -570,7 +557,7 @@ impl<T: TableKv> NamespaceInner<T> {
             region_id
         );
 
-        let table_unit = self.insert_or_get_table_unit(table_unit);
+        let table_unit = self.insert_or_get_table_unit(location, table_unit);
 
         Ok(Some(table_unit))
     }
@@ -578,26 +565,16 @@ impl<T: TableKv> NamespaceInner<T> {
     // FIXME: a dangerous bug, when table are scheduled to another node and
     // scheduled back after, we should deprecate the `TableUnit` entry in memory
     // but now we will continue to use the outdated entry.
-    async fn get_or_create_table_unit(
-        &self,
-        region_id: RegionId,
-        table_id: TableId,
-    ) -> Result<TableUnitRef> {
-        if let Some(table_unit) = self.get_table_unit_from_memory(table_id) &&
-            table_unit.region_id() == region_id
-        {
+    async fn get_or_create_table_unit(&self, location: WalLocation) -> Result<TableUnitRef> {
+        if let Some(table_unit) = self.get_table_unit_from_memory(&location) {
             return Ok(table_unit);
         }
 
-        self.create_table_unit(region_id, table_id).await
+        self.create_table_unit(location).await
     }
 
-    async fn create_table_unit(
-        &self,
-        region_id: RegionId,
-        table_id: TableId,
-    ) -> Result<TableUnitRef> {
-        let table_unit_meta_table = self.table_unit_meta_table(region_id);
+    async fn create_table_unit(&self, location: WalLocation) -> Result<TableUnitRef> {
+        let table_unit_meta_table = self.table_unit_meta_table(location.table_id);
         let buckets = self.bucket_set.read().unwrap().buckets();
 
         let table_unit = TableUnit::open_or_create(
@@ -605,25 +582,23 @@ impl<T: TableKv> NamespaceInner<T> {
             &self.table_kv,
             self.config.new_init_scan_ctx(),
             table_unit_meta_table,
-            region_id,
-            table_id,
+            location.versioned_region_id.id,
+            location.table_id,
             buckets,
         )
         .await
         .context(CreateTableUnit {
             namespace: self.name(),
-            region_id,
-            table_id,
+            location,
         })?;
 
         debug!(
-            "Create wal table unit, namespace:{}, region_id:{}, table_id:{}",
+            "Create wal table unit, namespace:{}, wal location:{:?}",
             self.name(),
-            region_id,
-            table_id,
+            location
         );
 
-        let table_unit = self.insert_or_get_table_unit(Arc::new(table_unit));
+        let table_unit = self.insert_or_get_table_unit(location, Arc::new(table_unit));
 
         Ok(table_unit)
     }
@@ -634,32 +609,26 @@ impl<T: TableKv> NamespaceInner<T> {
         ctx: &manager::WriteContext,
         batch: &LogWriteBatch,
     ) -> Result<SequenceNumber> {
-        let region_id = batch.location.shard_id as RegionId;
-        let table_id = batch.location.table_id;
         let now = Timestamp::now();
         // Get current bucket to write.
         let bucket = self.get_or_create_bucket(now)?;
 
-        let table_unit = self.get_or_create_table_unit(region_id, table_id).await?;
+        let table_unit = self.get_or_create_table_unit(batch.location).await?;
 
         let sequence = table_unit
             .write_log(&self.table_kv, &bucket, ctx, batch)
             .await
             .context(WriteTableUnit {
                 namespace: self.name(),
-                region_id,
-                table_id,
+                location: batch.location,
             })?;
 
         Ok(sequence)
     }
 
     /// Get last sequence number of this region.
-    async fn last_sequence(&self, location: Location) -> Result<SequenceNumber> {
-        let region_id = location.shard_id as RegionId;
-        let table_id = location.table_id;
-
-        if let Some(table_unit) = self.get_or_open_table_unit(region_id, table_id).await? {
+    async fn last_sequence(&self, location: WalLocation) -> Result<SequenceNumber> {
+        if let Some(table_unit) = self.get_or_open_table_unit(location).await? {
             return Ok(table_unit.last_sequence());
         }
 
@@ -673,16 +642,13 @@ impl<T: TableKv> NamespaceInner<T> {
         // buckets.
         let buckets = self.list_buckets();
 
-        let region_id = req.location.shard_id as RegionId;
-        let table_id = req.location.table_id;
-        if let Some(table_unit) = self.get_or_open_table_unit(region_id, table_id).await? {
+        if let Some(table_unit) = self.get_or_open_table_unit(req.location).await? {
             table_unit
                 .read_log(&self.table_kv, buckets, ctx, req)
                 .await
                 .context(ReadTableUnit {
                     namespace: self.name(),
-                    region_id,
-                    table_id,
+                    location: req.location,
                 })
         } else {
             Ok(TableLogIterator::new_empty(self.table_kv.clone()))
@@ -691,19 +657,20 @@ impl<T: TableKv> NamespaceInner<T> {
 
     /// Delete entries up to `sequence_num` of table unit identified by
     /// `location`.
-    async fn delete_entries(&self, location: Location, sequence_num: SequenceNumber) -> Result<()> {
-        let region_id = location.shard_id as RegionId;
-        let table_id = location.table_id;
-        if let Some(table_unit) = self.get_or_open_table_unit(region_id, table_id).await? {
-            let table_unit_meta_table = self.table_unit_meta_table(table_id);
+    async fn delete_entries(
+        &self,
+        location: WalLocation,
+        sequence_num: SequenceNumber,
+    ) -> Result<()> {
+        if let Some(table_unit) = self.get_or_open_table_unit(location).await? {
+            let table_unit_meta_table = self.table_unit_meta_table(location.table_id);
 
             table_unit
                 .delete_entries_up_to(&self.table_kv, table_unit_meta_table, sequence_num)
                 .await
                 .context(DeleteEntries {
                     namespace: self.name(),
-                    region_id,
-                    table_id,
+                    location,
                 })?;
         }
 
@@ -720,7 +687,7 @@ impl<T: TableKv> NamespaceInner<T> {
         // during reading start/end sequence.
         let buckets = self.list_buckets();
 
-        let region_id = request.region_id;
+        let region_id = request.versioned_region_id.id;
         let min_log_key = CommonLogKey::new(region_id, TableId::MIN, SequenceNumber::MIN);
         let max_log_key = CommonLogKey::new(region_id, TableId::MAX, SequenceNumber::MAX);
 
@@ -1133,7 +1100,7 @@ impl<T: TableKv> Namespace<T> {
     }
 
     /// Get last sequence number of this table unit.
-    pub async fn last_sequence(&self, location: Location) -> Result<SequenceNumber> {
+    pub async fn last_sequence(&self, location: WalLocation) -> Result<SequenceNumber> {
         self.inner.last_sequence(location).await
     }
 
@@ -1151,7 +1118,7 @@ impl<T: TableKv> Namespace<T> {
     /// `region_id` and `table_id`.
     pub async fn delete_entries(
         &self,
-        location: Location,
+        location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         self.inner.delete_entries(location, sequence_num).await
@@ -1476,7 +1443,7 @@ mod tests {
 
     use common_types::{
         bytes::BytesMut,
-        table::{Location, DEFAULT_SHARD_ID},
+        table::{DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
     };
     use common_util::runtime::{Builder, Runtime};
     use table_kv::{memory::MemoryImpl, KeyBoundary, ScanContext, ScanRequest};
@@ -1780,8 +1747,11 @@ mod tests {
         runtime.block_on(async {
             let namespace = NamespaceMocker::new(table_kv.clone(), runtime.clone()).build();
             let table_id = 123;
-            let location = Location::new(DEFAULT_SHARD_ID, table_id);
-
+            let location = WalLocation::new(
+                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_VERSION,
+                table_id,
+            );
             let seq1 = write_test_payloads(&namespace, location, 1000, 1004).await;
             write_test_payloads(&namespace, location, 1005, 1009).await;
 
@@ -1858,7 +1828,7 @@ mod tests {
 
     async fn write_test_payloads<T: TableKv>(
         namespace: &Namespace<T>,
-        location: Location,
+        location: WalLocation,
         start_sequence: u32,
         end_sequence: u32,
     ) -> SequenceNumber {

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -11,7 +11,7 @@ use std::{
 
 use common_types::{table::TableId, time::Timestamp};
 use common_util::{config::ReadableDuration, define_result, runtime::Runtime};
-use log::{debug, error, info, warn};
+use log::{debug, error, info, trace, warn};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_kv::{
     ScanContext as KvScanContext, ScanIter, TableError, TableKv, WriteBatch, WriteContext,
@@ -609,6 +609,13 @@ impl<T: TableKv> NamespaceInner<T> {
         ctx: &manager::WriteContext,
         batch: &LogWriteBatch,
     ) -> Result<SequenceNumber> {
+        trace!(
+            "Write batch to namespace:{}, location:{:?}, entries num:{}",
+            self.name(),
+            batch.location,
+            batch.entries.len()
+        );
+
         let now = Timestamp::now();
         // Get current bucket to write.
         let bucket = self.get_or_create_bucket(now)?;

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -207,6 +207,10 @@ impl TableUnit {
                     Some(v) => v,
                     None => return Ok(None),
                 };
+            debug!(
+                "Open table unit, table unit entry:{:?}, region id:{}, table id:{}",
+                table_unit_entry, region_id, table_id
+            );
 
             // Load last sequence of this table unit.
             let last_sequence =
@@ -405,7 +409,13 @@ impl TableUnit {
         table_id: TableId,
         buckets: &[BucketRef],
     ) -> Result<SequenceNumber> {
-        // Starts from the latest bucket, find last sequence of given table.
+        debug!(
+            "Load last sequence, buckets{:?}, region id:{}, table id:{}",
+            buckets, region_id, table_id
+        );
+
+        // Starts from the latest bucket, find last sequence of given region id.
+        let mut last_sequence = common_types::MIN_SEQUENCE_NUMBER;
         for bucket in buckets.iter().rev() {
             let table_name = bucket.wal_shard_table(region_id);
 

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -415,7 +415,6 @@ impl TableUnit {
         );
 
         // Starts from the latest bucket, find last sequence of given region id.
-        let mut last_sequence = common_types::MIN_SEQUENCE_NUMBER;
         for bucket in buckets.iter().rev() {
             let table_name = bucket.wal_shard_table(region_id);
 

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -5,7 +5,7 @@
 use std::{fmt, str, sync::Arc};
 
 use async_trait::async_trait;
-use common_types::{table::Location, SequenceNumber};
+use common_types::SequenceNumber;
 use log::info;
 use snafu::ResultExt;
 use table_kv::TableKv;
@@ -14,7 +14,7 @@ use crate::{
     log_batch::LogWriteBatch,
     manager::{
         self, error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext,
-        ScanRequest, WalManager,
+        ScanRequest, WalLocation, WalManager,
     },
     table_kv_impl::{
         model::NamespaceConfig,
@@ -99,7 +99,7 @@ impl<T> fmt::Debug for WalNamespaceImpl<T> {
 
 #[async_trait]
 impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
-    async fn sequence_num(&self, location: Location) -> Result<SequenceNumber> {
+    async fn sequence_num(&self, location: WalLocation) -> Result<SequenceNumber> {
         self.namespace
             .last_sequence(location)
             .await
@@ -109,7 +109,7 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
 
     async fn mark_delete_entries_up_to(
         &self,
-        location: Location,
+        location: WalLocation,
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         self.namespace

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -36,6 +36,8 @@ impl<T: TableKv> WalNamespaceImpl<T> {
         namespace_name: &str,
         config: NamespaceConfig,
     ) -> Result<WalNamespaceImpl<T>> {
+        info!("Open table kv wal, namespace:{}", namespace_name);
+
         let namespace = Self::open_namespace(table_kv, runtimes, namespace_name, config).await?;
 
         let wal = WalNamespaceImpl { namespace };

--- a/wal/src/tests/read_write.rs
+++ b/wal/src/tests/read_write.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use common_types::{
-    table::{TableId, DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    table::{TableId, DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     SequenceNumber,
 };
 
@@ -92,7 +92,7 @@ fn test_simple_read_write_default_batch<B: WalBuilder>(builder: B) {
         &env,
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
     ));
@@ -109,7 +109,7 @@ fn test_simple_read_write_different_batch_size<B: WalBuilder>(builder: B) {
             &env,
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
         ));
@@ -318,7 +318,7 @@ async fn simple_read_write_with_range_and_wal_internal<B: WalBuilder>(
 async fn read_with_boundary<B: WalBuilder>(env: &TestEnv<B>) {
     let wal = env.build_wal().await;
     let versioned_region_id = VersionedRegionId {
-        version: DEFAULT_SHARD_VERSION,
+        version: DEFAULT_CLUSTER_VERSION,
         id: DEFAULT_SHARD_ID as u64,
     };
     let location = WalLocation {
@@ -417,12 +417,12 @@ async fn write_multiple_regions_parallelly<B: WalBuilder + 'static>(env: Arc<Tes
         let read_write_0 = env.runtime.spawn(simple_read_write_with_wal(
             env.clone(),
             wal.clone(),
-            WalLocation::new(DEFAULT_SHARD_ID as RegionId, DEFAULT_SHARD_VERSION, i),
+            WalLocation::new(DEFAULT_SHARD_ID as RegionId, DEFAULT_CLUSTER_VERSION, i),
         ));
         let read_write_1 = env.runtime.spawn(simple_read_write_with_wal(
             env.clone(),
             wal.clone(),
-            WalLocation::new(DEFAULT_SHARD_ID as RegionId, DEFAULT_SHARD_VERSION, i),
+            WalLocation::new(DEFAULT_SHARD_ID as RegionId, DEFAULT_CLUSTER_VERSION, i),
         ));
         handles.push(read_write_0);
         handles.push(read_write_1);
@@ -447,7 +447,7 @@ async fn reopen<B: WalBuilder>(env: &TestEnv<B>) {
                 wal.clone(),
                 WalLocation::new(
                     DEFAULT_SHARD_ID as RegionId,
-                    DEFAULT_SHARD_VERSION,
+                    DEFAULT_CLUSTER_VERSION,
                     table_id,
                 ),
                 0,
@@ -470,7 +470,7 @@ async fn reopen<B: WalBuilder>(env: &TestEnv<B>) {
     let last_seq = wal
         .sequence_num(WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ))
         .await
@@ -480,7 +480,7 @@ async fn reopen<B: WalBuilder>(env: &TestEnv<B>) {
     let read_req = ReadRequest {
         location: WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         start: ReadBoundary::Included(seq + 1 - write_batch.entries.len() as u64),
@@ -513,7 +513,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             start_val,
@@ -529,7 +529,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             mid_val,
@@ -547,7 +547,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
         wal.clone(),
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq_1,
@@ -560,7 +560,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
         wal.clone(),
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq_2,
@@ -575,7 +575,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
         wal.clone(),
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq_3,
@@ -595,7 +595,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
         wal.clone(),
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq_4,
@@ -615,7 +615,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -631,7 +631,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
         wal.clone(),
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq,
@@ -642,7 +642,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
     let last_seq = wal
         .sequence_num(WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ))
         .await
@@ -653,7 +653,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
     wal.mark_delete_entries_up_to(
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq,
@@ -663,7 +663,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
     let read_req = ReadRequest {
         location: WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         start: ReadBoundary::Min,
@@ -681,7 +681,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
     let last_seq = wal
         .sequence_num(WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ))
         .await
@@ -700,7 +700,7 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -716,7 +716,7 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
         wal.clone(),
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq,
@@ -728,7 +728,7 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
     wal.mark_delete_entries_up_to(
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq / 2,
@@ -738,7 +738,7 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
     let read_req = ReadRequest {
         location: WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         start: ReadBoundary::Min,
@@ -757,7 +757,7 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
     let last_seq = wal
         .sequence_num(WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ))
         .await
@@ -776,7 +776,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id_1,
             ),
             0,
@@ -793,7 +793,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id_2,
             ),
             10,
@@ -809,7 +809,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
     wal.mark_delete_entries_up_to(
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id_1,
         ),
         seq_1,
@@ -819,7 +819,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
     let read_req = ReadRequest {
         location: WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id_1,
         ),
         start: ReadBoundary::Min,
@@ -837,7 +837,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
         wal.clone(),
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id_2,
         ),
         seq_2,
@@ -857,7 +857,7 @@ async fn sequence_increase_monotonically_multiple_writes<B: WalBuilder>(env: &Te
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -873,7 +873,7 @@ async fn sequence_increase_monotonically_multiple_writes<B: WalBuilder>(env: &Te
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -889,7 +889,7 @@ async fn sequence_increase_monotonically_multiple_writes<B: WalBuilder>(env: &Te
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -918,7 +918,7 @@ async fn sequence_increase_monotonically_delete_write<B: WalBuilder>(env: &TestE
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -934,7 +934,7 @@ async fn sequence_increase_monotonically_delete_write<B: WalBuilder>(env: &TestE
     wal.mark_delete_entries_up_to(
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq_1,
@@ -946,7 +946,7 @@ async fn sequence_increase_monotonically_delete_write<B: WalBuilder>(env: &TestE
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -962,7 +962,7 @@ async fn sequence_increase_monotonically_delete_write<B: WalBuilder>(env: &TestE
     let last_seq = wal
         .sequence_num(WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ))
         .await
@@ -984,7 +984,7 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -1000,7 +1000,7 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
     wal.mark_delete_entries_up_to(
         WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ),
         seq_1,
@@ -1019,7 +1019,7 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id,
             ),
             0,
@@ -1034,7 +1034,7 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
     let last_seq = wal
         .sequence_num(WalLocation::new(
             DEFAULT_SHARD_ID as RegionId,
-            DEFAULT_SHARD_VERSION,
+            DEFAULT_CLUSTER_VERSION,
             table_id,
         ))
         .await
@@ -1057,7 +1057,7 @@ async fn write_scan<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id_1,
             ),
             0,
@@ -1076,7 +1076,7 @@ async fn write_scan<B: WalBuilder>(env: &TestEnv<B>) {
             wal.clone(),
             WalLocation::new(
                 DEFAULT_SHARD_ID as RegionId,
-                DEFAULT_SHARD_VERSION,
+                DEFAULT_CLUSTER_VERSION,
                 table_id_2,
             ),
             0,

--- a/wal/src/tests/read_write.rs
+++ b/wal/src/tests/read_write.rs
@@ -180,11 +180,11 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
     let region_id = 1;
     let table_id = 0;
 
-    // Use two wal managers to represent datanode 1 and datanode 2.
-    // At first, write some things in node 1.
-    let wal_1 = env.runtime.block_on(async { env.build_wal().await });
-    let region_version_1 = 0;
     env.runtime.block_on(async {
+        // Use two wal managers to represent datanode 1 and datanode 2.
+        // At first, write some things in node 1.
+        let wal_1 = env.build_wal().await;
+        let region_version_1 = 0;
         simple_read_write_with_range_and_wal(
             &env,
             wal_1.clone(),
@@ -193,13 +193,11 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
             10,
         )
         .await;
-    });
 
-    // The table are move to node 2 but in the same shard, so its region id is still
-    // 0, but region version changed to 1 for distinguishing this moving.
-    let wal_2 = env.runtime.block_on(async { env.build_wal().await });
-    let region_version_2 = 1;
-    env.runtime.block_on(async {
+        // The table are move to node 2 but in the same shard, so its region id is still
+        // 0, but region version changed to 1 for distinguishing this moving.
+        let wal_2 = env.build_wal().await;
+        let region_version_2 = 1;
         simple_read_write_with_range_and_wal(
             &env,
             wal_2,
@@ -208,13 +206,11 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
             20,
         )
         .await;
-    });
 
-    // Finally, the table with the same shard is moved to node 1 again.
-    // If version changed, wal manager can distinguish that
-    // the region info in it is outdated, it should reopen the region.
-    let region_version_3 = 2;
-    env.runtime.block_on(async {
+        // Finally, the table with the same shard is moved to node 1 again.
+        // If version changed, wal manager can distinguish that
+        // the region info in it is outdated, it should reopen the region.
+        let region_version_3 = 2;
         simple_read_write_with_range_and_wal(
             &env,
             wal_1,

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -12,7 +12,7 @@ use std::{
 use async_trait::async_trait;
 use common_types::{
     bytes::{BufMut, SafeBuf, SafeBufMut},
-    table::{Location, TableId, DEFAULT_SHARD_ID},
+    table::{TableId, DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
     SequenceNumber,
 };
 use common_util::{
@@ -27,7 +27,8 @@ use tempfile::TempDir;
 use crate::{
     log_batch::{LogWriteBatch, Payload, PayloadDecoder},
     manager::{
-        BatchLogIteratorAdapter, ReadContext, RegionId, WalManager, WalManagerRef, WriteContext,
+        BatchLogIteratorAdapter, ReadContext, RegionId, VersionedRegionId, WalLocation, WalManager,
+        WalManagerRef, WriteContext,
     },
     message_queue_impl::{config::Config, wal::MessageQueueImpl},
     rocks_impl::{self, manager::RocksImpl},
@@ -52,10 +53,14 @@ impl WalBuilder for RocksWalBuilder {
     type Wal = RocksImpl;
 
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
+        let versioned_region_id = VersionedRegionId {
+            version: DEFAULT_SHARD_VERSION,
+            id: DEFAULT_SHARD_ID as RegionId,
+        };
         let wal_builder = rocks_impl::manager::Builder::with_default_rocksdb_config(
             data_path,
             runtime,
-            DEFAULT_SHARD_ID as RegionId,
+            versioned_region_id,
         );
 
         Arc::new(
@@ -208,7 +213,7 @@ impl<B: WalBuilder> TestEnv<B> {
     pub async fn build_log_batch(
         &self,
         wal: WalManagerRef,
-        location: Location,
+        location: WalLocation,
         start: u32,
         end: u32,
     ) -> (Vec<TestPayload>, LogWriteBatch) {

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -12,7 +12,7 @@ use std::{
 use async_trait::async_trait;
 use common_types::{
     bytes::{BufMut, SafeBuf, SafeBufMut},
-    table::{TableId, DEFAULT_SHARD_ID, DEFAULT_SHARD_VERSION},
+    table::{TableId, DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
     SequenceNumber,
 };
 use common_util::{
@@ -54,7 +54,7 @@ impl WalBuilder for RocksWalBuilder {
 
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
         let versioned_region_id = VersionedRegionId {
-            version: DEFAULT_SHARD_VERSION,
+            version: DEFAULT_CLUSTER_VERSION,
             id: DEFAULT_SHARD_ID as RegionId,
         };
         let wal_builder = rocks_impl::manager::Builder::with_default_rocksdb_config(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #441 

# Rationale for this change
If a shard (which is mapped to region in wal) is move between nodes like this:
```
A --> B --> ... --> A
```
Then wal module in mode A can't distinguish if the shard has been moved.
This may cause a serious bug: 
+ the shard's wal meta information may be modify in other nodes.
+ when it is moved to A(original node), A doesn't know it and think it is same as before it was moved.
+ A persists the old meta information to storage and overwritten the new one which are persisted in other nodes. 

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
#### 1. For rocksdb and obkv impls
before:
```                                                
+----------+         +----------+                     
| table id |-------->|table unit|                     
+----------+         +----------+                     
 ```
 now:                           
 ```                                              
+----------+----------+----------+        +----------+
| region   | region   |  table   | ------>|  table   |
| version  |   id     |   id     |        |   unit   |
+----------+----------+----------+        +----------+
 ```                                                
Before,`Table unit` in `wal manager` is only indexed by `table id`, so `wal manager` know nothing about `shard id` and `shard version` (shard are mapped to region). So where `shard id` and `shard version` of `table` changed, `wal manager` can't perceive. 
Now, `Table unit` is indexed by `region version` + `region id` + `table id`, it can perceive any changes.                                             

#### 2. For kafka impl
before:
```                                                
+----------+         +----------+                     
|region id |-------> |  region  |                     
+----------+         +----------+                     
 ```
 now:                           
 ```                                              
+----------+----------+          +----------+
| region   | region   |--------->|  region  |
| version  |   id     |          |          |
+----------+----------+          +----------+
 ``` 
Similar as above, `region` in kafka impl can perceive `shard version` now.

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
