### PR TITLE
fix: hybrid storage encode bug in multi record batch

### DIFF
--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -16,11 +16,14 @@ use log::debug;
 use object_store::{ObjectStoreRef, Path};
 use snafu::ResultExt;
 
-use crate::sst::{
-    builder::{RecordBatchStream, SstBuilder, *},
-    factory::SstBuilderOptions,
-    file::{BloomFilter, SstMetaData},
-    parquet::encoding::ParquetEncoder,
+use crate::{
+    sst::{
+        builder::{RecordBatchStream, SstBuilder, *},
+        factory::SstBuilderOptions,
+        file::{BloomFilter, SstMetaData},
+        parquet::encoding::ParquetEncoder,
+    },
+    table_options::StorageFormat,
 };
 
 /// The implementation of sst based on parquet and object storage.
@@ -133,6 +136,10 @@ impl RecordBytesReader {
     }
 
     fn build_bloom_filter(&self) -> BloomFilter {
+        // TODO: support bloom filter in hybrid storage format [#435](https://github.com/CeresDB/ceresdb/issues/435)
+        if self.meta_data.storage_format_opts.format == StorageFormat::Hybrid {
+            return BloomFilter::default();
+        }
         let filters = self
             .partitioned_record_batch
             .iter()

--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -950,10 +950,7 @@ mod tests {
         let input_record_batch2 =
             ArrowRecordBatch::try_new(schema.to_arrow_schema_ref(), columns2).unwrap();
         let row_nums = encoder
-            .encode(vec![
-                input_record_batch.clone(),
-                input_record_batch2.clone(),
-            ])
+            .encode(vec![input_record_batch, input_record_batch2])
             .unwrap();
         assert_eq!(2, row_nums);
 

--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -143,8 +143,8 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Sst meta data collapsible_cols_idx is empty, fail to decode hybrid record batch.\nBacktrace:\n{}",
-        backtrace
+    "Sst meta data collapsible_cols_idx is empty, fail to decode hybrid record batch.\nBacktrace:\n{}",
+    backtrace
     ))]
     CollapsibleColsIdxEmpty { backtrace: Backtrace },
 
@@ -909,18 +909,31 @@ mod tests {
             HybridRecordEncoder::try_new(100, Compression::ZSTD, meta_data.clone()).unwrap();
 
         let columns = vec![
-            Arc::new(UInt64Array::from(vec![1, 1, 2, 2])) as ArrayRef,
+            Arc::new(UInt64Array::from(vec![1, 1, 2])) as ArrayRef,
+            timestamp_array(vec![100, 101, 100]),
+            string_array(vec![Some("host1"), Some("host1"), Some("host2")]),
+            string_array(vec![Some("region1"), Some("region1"), Some("region2")]),
+            int32_array(vec![Some(1), Some(2), Some(11)]),
+            string_array(vec![
+                Some("string_value1"),
+                Some("string_value2"),
+                Some("string_value3"),
+            ]),
+        ];
+
+        let columns2 = vec![
+            Arc::new(UInt64Array::from(vec![1, 2, 1, 2])) as ArrayRef,
             timestamp_array(vec![100, 101, 100, 101]),
             string_array(vec![
                 Some("host1"),
-                Some("host1"),
                 Some("host2"),
+                Some("host1"),
                 Some("host2"),
             ]),
             string_array(vec![
                 Some("region1"),
-                Some("region1"),
                 Some("region2"),
+                Some("region1"),
                 Some("region2"),
             ]),
             int32_array(vec![Some(1), Some(2), Some(11), Some(12)]),
@@ -934,7 +947,14 @@ mod tests {
 
         let input_record_batch =
             ArrowRecordBatch::try_new(schema.to_arrow_schema_ref(), columns).unwrap();
-        let row_nums = encoder.encode(vec![input_record_batch.clone()]).unwrap();
+        let input_record_batch2 =
+            ArrowRecordBatch::try_new(schema.to_arrow_schema_ref(), columns2).unwrap();
+        let row_nums = encoder
+            .encode(vec![
+                input_record_batch.clone(),
+                input_record_batch2.clone(),
+            ])
+            .unwrap();
         assert_eq!(2, row_nums);
 
         // read encoded records back, and then compare with input records
@@ -957,6 +977,53 @@ mod tests {
         // Note: decode record batch's schema doesn't have metadata
         // It's encoded in metadata of every fields
         // assert_eq!(decoded_record_batch.schema(), input_record_batch.schema());
-        assert_eq!(decoded_record_batch.columns(), input_record_batch.columns());
+
+        let expected_columns = vec![
+            Arc::new(UInt64Array::from(vec![1, 1, 1, 1, 2, 2, 2])) as ArrayRef,
+            timestamp_array(vec![100, 101, 100, 100, 100, 101, 101]),
+            string_array(vec![
+                Some("host1"),
+                Some("host1"),
+                Some("host1"),
+                Some("host1"),
+                Some("host2"),
+                Some("host2"),
+                Some("host2"),
+            ]),
+            string_array(vec![
+                Some("region1"),
+                Some("region1"),
+                Some("region1"),
+                Some("region1"),
+                Some("region2"),
+                Some("region2"),
+                Some("region2"),
+            ]),
+            int32_array(vec![
+                Some(1),
+                Some(2),
+                Some(1),
+                Some(11),
+                Some(11),
+                Some(2),
+                Some(12),
+            ]),
+            string_array(vec![
+                Some("string_value1"),
+                Some("string_value2"),
+                Some("string_value1"),
+                Some("string_value3"),
+                Some("string_value3"),
+                Some("string_value2"),
+                Some("string_value4"),
+            ]),
+        ];
+
+        let expect_record_batch =
+            ArrowRecordBatch::try_new(schema.to_arrow_schema_ref(), expected_columns).unwrap();
+        assert_eq!(
+            decoded_record_batch.columns(),
+            expect_record_batch.columns()
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #403 

# Rationale for this change
 Fix bugs described in #403 .
Hybrid storage compresses multi-record batches into one record batch.
There is a bug where `collapsible_col_arrays` in `TsidBatch` only stores the first record batch data, other record batch data are lost.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Modify some tests to cover this bug.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
