### PR TITLE
docs: fix broken conventional commit document link(#429)

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -139,7 +139,7 @@ curl --location --request POST 'http://127.0.0.1:5440/sql' \
 ## 如何贡献
 [如何参与 CeresDB 代码贡献](CONTRIBUTING.md)
 
-[约定式提交](docs/dev/conventional-commit.md)
+[约定式提交](docs/guides/src/dev/conventional_commit.md)
 
 ## 架构及技术文档
 相关技术文档在[docs](docs)目录中，补充完善中~


### PR DESCRIPTION
# Which issue does this PR close?

Closes #429

# Rationale for this change
 
Fix the broken link of  the conventional commit guide in the Chinese version of README-CN.md

# What changes are included in this PR?

- Update link target in README-CN.md

# Are there any user-facing changes?

no

# How does this change test

doesn't need
