### PR TITLE
fix: drop bug of wal on mq, can't not drop runtime

### DIFF
--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -138,12 +138,6 @@ pub struct Namespace<M: MessageQueue> {
 
     /// Handle for cleaner routine
     cleaner_handle: TaskHandle,
-
-    /// Background runtime for cleaner routine
-    ///
-    /// Keep it here to ensure it won't be drop during the lifetime of
-    /// [Namespace].
-    _bg_runtime: Arc<Runtime>,
 }
 
 impl<M: MessageQueue> Namespace<M> {
@@ -163,7 +157,6 @@ impl<M: MessageQueue> Namespace<M> {
         Self {
             inner,
             cleaner_handle,
-            _bg_runtime: bg_runtime,
         }
     }
 

--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -143,7 +143,7 @@ pub struct Namespace<M: MessageQueue> {
     ///
     /// Keep it here to ensure it won't be drop during the lifetime of
     /// [Namespace].
-    bg_runtime: Arc<Runtime>,
+    _bg_runtime: Arc<Runtime>,
 }
 
 impl<M: MessageQueue> Namespace<M> {
@@ -163,7 +163,7 @@ impl<M: MessageQueue> Namespace<M> {
         Self {
             inner,
             cleaner_handle,
-            bg_runtime,
+            _bg_runtime: bg_runtime,
         }
     }
 
@@ -237,19 +237,6 @@ impl<M: MessageQueue> fmt::Debug for Namespace<M> {
             .field("meta_encoding", &self.inner.meta_encoding)
             .field("log_encoding", &self.inner.log_encoding)
             .finish()
-    }
-}
-
-impl<M: MessageQueue> Drop for Namespace<M> {
-    fn drop(&mut self) {
-        self.bg_runtime.block_on(async {
-            if let Err(e) = self.close().await {
-                error!(
-                    "Close namespace failed, namespace:{}, err:{}",
-                    self.inner.namespace, e
-                );
-            }
-        })
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Now, I found drop wal on mq may need to panic because dropping runtime in `drop()`. 
You can reproduce it using following cmd(need a kafka cluster):
```
RUST_BACKTRACE=1 cargo test --workspace --package wal --lib -- read_write::test_kafka_wal --ignored
```
The error message:
```
---- tests::read_write::test_kafka_wal stdout ----
thread 'tests::read_write::test_kafka_wal' panicked at 'Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.', /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/thread_pool/mod.rs:89:25
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/std/src/panicking.rs:616:12
   1: tokio::runtime::enter::enter
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/enter.rs:40:9
   2: tokio::runtime::thread_pool::ThreadPool::block_on
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/thread_pool/mod.rs:89:25
   3: tokio::runtime::Runtime::block_on
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/mod.rs:484:43
   4: common_util::runtime::Runtime::block_on
             at /Users/kamiu/Desktop/github/ceresdb/common_util/src/runtime/mod.rs:82:9
   5: <wal::message_queue_impl::namespace::Namespace<M> as core::ops::drop::Drop>::drop
             at ./src/message_queue_impl/namespace.rs:245:9
   6: core::ptr::drop_in_place<wal::message_queue_impl::namespace::Namespace<message_queue::kafka::kafka_impl::KafkaImpl>>
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/ptr/mod.rs:487:1
   7: core::ptr::drop_in_place<wal::message_queue_impl::wal::MessageQueueImpl<message_queue::kafka::kafka_impl::KafkaImpl>>
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/ptr/mod.rs:487:1
   8: core::ptr::drop_in_place<dyn wal::manager::WalManager>
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/ptr/mod.rs:487:1
   9: alloc::sync::Arc<T>::drop_slow
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/alloc/src/sync.rs:1105:18
  10: <alloc::sync::Arc<T> as core::ops::drop::Drop>::drop
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/alloc/src/sync.rs:1702:13
  11: core::ptr::drop_in_place<alloc::sync::Arc<dyn wal::manager::WalManager>>
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/ptr/mod.rs:487:1
  12: wal::tests::read_write::simple_read_write::{{closure}}
             at ./src/tests/read_write.rs:216:1
  13: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/future/mod.rs:91:19
  14: tokio::park::thread::CachedParkThread::block_on::{{closure}}
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/park/thread.rs:263:54
  15: tokio::coop::with_budget::{{closure}}
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/coop.rs:102:9
  16: std::thread::local::LocalKey<T>::try_with
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/std/src/thread/local.rs:445:16
  17: std::thread::local::LocalKey<T>::with
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/std/src/thread/local.rs:421:9
  18: tokio::coop::with_budget
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/coop.rs:95:5
  19: tokio::coop::budget
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/coop.rs:72:5
  20: tokio::park::thread::CachedParkThread::block_on
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/park/thread.rs:263:31
  21: tokio::runtime::enter::Enter::block_on
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/enter.rs:152:13
  22: tokio::runtime::thread_pool::ThreadPool::block_on
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/thread_pool/mod.rs:90:9
  23: tokio::runtime::Runtime::block_on
             at /Users/kamiu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.20.1/src/runtime/mod.rs:484:43
  24: common_util::runtime::Runtime::block_on
             at /Users/kamiu/Desktop/github/ceresdb/common_util/src/runtime/mod.rs:82:9
  25: wal::tests::read_write::test_simple_read_write_default_batch
             at ./src/tests/read_write.rs:79:5
  26: wal::tests::read_write::test_all
             at ./src/tests/read_write.rs:49:5
  27: wal::tests::read_write::test_kafka_wal
             at ./src/tests/read_write.rs:45:5
  28: wal::tests::read_write::test_kafka_wal::{{closure}}
             at ./src/tests/read_write.rs:42:1
  29: core::ops::function::FnOnce::call_once
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/ops/function.rs:248:5
  30: core::ops::function::FnOnce::call_once
             at /rustc/d394408fb38c4de61f765a3ed5189d2731a1da91/library/core/src/ops/function.rs:248:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Fix above bug.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
User should manually call `close_gracefully` now.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
