### PR TITLE
fix: load last sequence in obkv wal

### DIFF
--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -395,8 +395,7 @@ impl TableUnit {
         table_id: TableId,
         buckets: &[BucketRef],
     ) -> Result<SequenceNumber> {
-        // Starts from the latest bucket, find last sequence of given region id.
-        let mut last_sequence = common_types::MIN_SEQUENCE_NUMBER;
+        // Starts from the latest bucket, find last sequence of given table.
         for bucket in buckets.iter().rev() {
             let table_name = bucket.wal_shard_table(region_id);
 
@@ -407,11 +406,11 @@ impl TableUnit {
                 region_id,
                 table_id,
             )? {
-                last_sequence = seq;
+                return Ok(seq);
             }
         }
 
-        Ok(last_sequence)
+        Ok(common_types::MIN_SEQUENCE_NUMBER)
     }
 
     fn load_last_sequence_from_table<T: TableKv>(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Now, load last sequence step in obkv wal has a logic error, which leads to a serious bug about load a mistaken last sequence.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Fix above bug.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
