### PR TITLE
refactor: manifest wal config

### DIFF
--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -131,12 +131,18 @@ pub struct ObkvWalConfig {
     pub manifest: ManifestNamespaceConfig,
 }
 
-pub type WalNamespaceConfig = NamespaceConfig;
-
+/// Config of obkv wal based manifest
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ManifestNamespaceConfig {
+    /// Decide how many wal data shards will be created
+    ///
+    /// NOTICE: it can just be set once, the later setting makes no effect.
     pub shard_num: usize,
+
+    /// Decide how many wal meta shards will be created
+    ///
+    /// NOTICE: it can just be set once, the later setting makes no effect.
     pub meta_shard_num: usize,
 
     pub init_scan_timeout: ReadableDuration,
@@ -147,13 +153,15 @@ pub struct ManifestNamespaceConfig {
 
 impl Default for ManifestNamespaceConfig {
     fn default() -> Self {
+        let namespace_config = NamespaceConfig::default();
+
         Self {
-            shard_num: 512,
-            meta_shard_num: 128,
-            init_scan_timeout: ReadableDuration::secs(10),
-            init_scan_batch_size: 100,
-            clean_scan_timeout: ReadableDuration::secs(10),
-            clean_scan_batch_size: 100,
+            shard_num: namespace_config.wal_shard_num,
+            meta_shard_num: namespace_config.table_unit_meta_shard_num,
+            init_scan_timeout: namespace_config.init_scan_timeout,
+            init_scan_batch_size: namespace_config.init_scan_batch_size,
+            clean_scan_timeout: namespace_config.clean_scan_timeout,
+            clean_scan_batch_size: namespace_config.clean_scan_batch_size,
         }
     }
 }
@@ -168,6 +176,52 @@ impl From<ManifestNamespaceConfig> for NamespaceConfig {
             init_scan_batch_size: manifest_config.init_scan_batch_size,
             clean_scan_timeout: manifest_config.clean_scan_timeout,
             clean_scan_batch_size: manifest_config.clean_scan_batch_size,
+        }
+    }
+}
+
+/// Config of obkv wal based wal module
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct WalNamespaceConfig {
+    /// Decide how many wal data shards will be created
+    ///
+    /// NOTICE: it can just be set once, the later setting makes no effect.
+    pub shard_num: usize,
+
+    /// Decide how many wal meta shards will be created
+    ///
+    /// NOTICE: it can just be set once, the later setting makes no effect.
+    pub meta_shard_num: usize,
+
+    pub ttl: ReadableDuration,
+    pub init_scan_timeout: ReadableDuration,
+    pub init_scan_batch_size: i32,
+}
+
+impl Default for WalNamespaceConfig {
+    fn default() -> Self {
+        let namespace_config = NamespaceConfig::default();
+
+        Self {
+            shard_num: namespace_config.wal_shard_num,
+            meta_shard_num: namespace_config.table_unit_meta_shard_num,
+            ttl: namespace_config.ttl.unwrap(),
+            init_scan_timeout: namespace_config.init_scan_timeout,
+            init_scan_batch_size: namespace_config.init_scan_batch_size,
+        }
+    }
+}
+
+impl From<WalNamespaceConfig> for NamespaceConfig {
+    fn from(wal_config: WalNamespaceConfig) -> Self {
+        Self {
+            wal_shard_num: wal_config.shard_num,
+            table_unit_meta_shard_num: wal_config.meta_shard_num,
+            ttl: Some(wal_config.ttl),
+            init_scan_timeout: wal_config.init_scan_timeout,
+            init_scan_batch_size: wal_config.init_scan_batch_size,
+            ..Default::default()
         }
     }
 }

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -319,7 +319,7 @@ async fn open_wal_and_manifest_with_table_kv<T: TableKv>(
         table_kv.clone(),
         runtimes.clone(),
         WAL_DIR_NAME,
-        config.wal.clone(),
+        config.wal.clone().into(),
     )
     .await
     .context(OpenWal)?;

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -328,7 +328,7 @@ async fn open_wal_and_manifest_with_table_kv<T: TableKv>(
         table_kv,
         runtimes,
         MANIFEST_DIR_NAME,
-        config.manifest.clone(),
+        config.manifest.clone().into(),
     )
     .await
     .context(OpenManifestWal)?;

--- a/wal/src/table_kv_impl/model.rs
+++ b/wal/src/table_kv_impl/model.rs
@@ -253,6 +253,11 @@ impl Default for NamespaceEntry {
 pub struct NamespaceConfig {
     pub wal_shard_num: usize,
     pub table_unit_meta_shard_num: usize,
+
+    /// Outdated log cleaning strategy
+    ///  
+    /// Notice: you can just set once, if change after setting, it will lead to
+    /// error. Recommend to use default setting.
     pub ttl: Option<ReadableDuration>,
 
     pub init_scan_timeout: ReadableDuration,

--- a/wal/src/table_kv_impl/model.rs
+++ b/wal/src/table_kv_impl/model.rs
@@ -256,7 +256,7 @@ pub struct NamespaceConfig {
 
     /// Outdated log cleaning strategy
     ///  
-    /// Notice: you can just set once, if change after setting, it will lead to
+    /// NOTICE: you can just set once, if change after setting, it will lead to
     /// error. Recommend to use default setting.
     pub ttl: Option<ReadableDuration>,
 

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -15,7 +15,7 @@ use common_types::{
 };
 use common_util::{config::ReadableDuration, define_result, runtime::Runtime};
 use log::{debug, error, info, warn};
-use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use table_kv::{
     ScanContext as KvScanContext, ScanIter, TableError, TableKv, WriteBatch, WriteContext,
 };
@@ -214,6 +214,18 @@ pub enum Error {
         table_id: TableId,
         source: crate::table_kv_impl::table_unit::Error,
     },
+
+    #[snafu(display(
+        "Failed to check the clean strategy, namespace:{}, origin ttl:{:?}, current ttl:{:?}",
+        namespace,
+        origin_ttl,
+        current_ttl,
+    ))]
+    CleanStrategyChanged {
+        namespace: String,
+        origin_ttl: Option<ReadableDuration>,
+        current_ttl: Option<ReadableDuration>,
+    },
 }
 
 define_result!(Error);
@@ -250,8 +262,8 @@ impl<T> NamespaceInner<T> {
         &self.table_unit_meta_tables
     }
 
-    fn table_unit_meta_table(&self, region_id: RegionId) -> &str {
-        let index = region_id as usize % self.table_unit_meta_tables.len();
+    fn table_unit_meta_table(&self, table_id: TableId) -> &str {
+        let index = table_id as usize % self.table_unit_meta_tables.len();
 
         &self.table_unit_meta_tables[index]
     }
@@ -541,7 +553,7 @@ impl<T: TableKv> NamespaceInner<T> {
         region_id: RegionId,
         table_id: TableId,
     ) -> Result<Option<TableUnitRef>> {
-        let table_unit_meta_table = self.table_unit_meta_table(region_id);
+        let table_unit_meta_table = self.table_unit_meta_table(table_id);
         let buckets = self.bucket_set.read().unwrap().buckets();
 
         let table_unit_opt = TableUnit::open(
@@ -597,7 +609,7 @@ impl<T: TableKv> NamespaceInner<T> {
         region_id: RegionId,
         table_id: TableId,
     ) -> Result<TableUnitRef> {
-        let table_unit_meta_table = self.table_unit_meta_table(region_id);
+        let table_unit_meta_table = self.table_unit_meta_table(table_id);
         let buckets = self.bucket_set.read().unwrap().buckets();
 
         let table_unit = TableUnit::open_or_create(
@@ -936,13 +948,28 @@ impl<T: TableKv> Namespace<T> {
 
         let namespace =
             match Self::load_namespace_from_meta(table_kv, consts::META_TABLE_NAME, name)? {
-                Some(namespace_entry) => Namespace::new(
-                    runtimes,
-                    table_kv.clone(),
-                    consts::META_TABLE_NAME,
-                    namespace_entry,
-                    config,
-                )?,
+                Some(namespace_entry) => {
+                    // Clean strategy can't changed after namespace has created.
+                    let is_clean_strategy_same =
+                        namespace_entry.wal.enable_ttl == config.ttl.is_some();
+                    ensure!(
+                        is_clean_strategy_same,
+                        CleanStrategyChanged {
+                            namespace: name,
+                            origin_ttl: namespace_entry.wal.ttl,
+                            current_ttl: config.ttl,
+                        }
+                    );
+
+                    Namespace::new(
+                        runtimes,
+                        table_kv.clone(),
+                        consts::META_TABLE_NAME,
+                        namespace_entry,
+                        config,
+                    )?
+                }
+
                 None => Namespace::try_persist_namespace(
                     runtimes,
                     table_kv,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Background of this pr:
+ now, our `manifest` is `wal` based, and in `wal` on obkv, there is a `ttl` based logs clean strategy.
But data in `manifest` should be permanent and shouldn't be cleaned due to `ttl`. So we should hide the `ttl` of `wal` on obkv, while it is set for `manifest`.

+ the `ttl` and `permanent` strategies are incompatible, so we should check it while opening `wal` (on obkv).

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
See above background.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Obkv users should switch to new config.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
