### PR TITLE
chore: return schema not found when schmea not exists

### DIFF
--- a/sql/src/provider.rs
+++ b/sql/src/provider.rs
@@ -34,6 +34,9 @@ pub enum Error {
         source: catalog::Error,
     },
 
+    #[snafu(display("Failed to find schema, name:{}", name))]
+    SchemaNotFound { name: String },
+
     #[snafu(display("Failed to find table, name:{}, err:{}", name, source))]
     FindTable {
         name: String,
@@ -111,7 +114,12 @@ impl<'a> MetaProvider for CatalogMetaProvider<'a> {
                 name: resolved.schema,
             })? {
             Some(s) => s,
-            None => return Ok(None),
+            None => {
+                return SchemaNotFound {
+                    name: resolved.schema,
+                }
+                .fail()
+            }
         };
 
         schema.table_by_name(resolved.table).context(FindTable {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 When query a not existed schema, the server will return `table not found` response which is confusing.
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Return schema not found when schmea not exists.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
