### PR TITLE
fix: object_store config

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/docker-build-image.yml'
       - 'Dockerfile'
       - 'docker/**'
+      - 'docs/minimal.toml'
   push:
     branches:
       - main
@@ -14,6 +15,7 @@ on:
       - '.github/workflows/docker-build-image.yml'
       - 'Dockerfile'
       - 'docker/**'
+      - 'docs/minimal.toml'
 
 env:
   CERESDB_ADDR: 127.0.0.1

--- a/docs/example-cluster-0.toml
+++ b/docs/example-cluster-0.toml
@@ -7,10 +7,12 @@ deploy_mode = "Cluster"
 
 [analytic]
 wal_path = "/tmp/ceresdb"
-sst_data_cache_cap = 10000
-sst_meta_cache_cap = 10000
 
 [analytic.storage]
+mem_cache_capacity = '1G'
+mem_cache_partition_bits = 0
+
+[analytic.storage.object_store]
 type = "Local"
 data_path = "/tmp/ceresdb"
 

--- a/docs/example-cluster-1.toml
+++ b/docs/example-cluster-1.toml
@@ -7,10 +7,12 @@ deploy_mode = "Cluster"
 
 [analytic]
 wal_path = "/tmp/ceresdb2"
-sst_data_cache_cap = 10000
-sst_meta_cache_cap = 10000
 
 [analytic.storage]
+mem_cache_capacity = '1G'
+mem_cache_partition_bits = 0
+
+[analytic.storage.object_store]
 type = "Local"
 data_path = "/tmp/ceresdb2"
 

--- a/docs/minimal.toml
+++ b/docs/minimal.toml
@@ -3,14 +3,16 @@ http_port = 5440
 grpc_port = 8831
 log_level = "info"
 
-[analytic.storage]
-type = "Local"
-data_path = "/tmp/ceresdb"
-
 [analytic]
 wal_path = "/tmp/ceresdb"
-sst_data_cache_cap = 10000
-sst_meta_cache_cap = 10000
+
+[analytic.storage]
+mem_cache_capacity = '1G'
+mem_cache_partition_bits = 0
+
+[analytic.storage.object_store]
+type = "Local"
+data_path = "/tmp/ceresdb"
 
 [[static_route.topology.schema_shards]]
 schema = 'public'


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
After #421, config of object store is changed, but minimal config is still using old format, and it will cause error below
```
thread 'main' panicked at 'Failed to parse config.: ParseToml { path: "/etc/ceresdb/ceresdb.toml", source: Error { inner: ErrorInner { kind: Custom, l
ine: Some(21), col: 0, at: Some(381), message: "missing field `mem_cache_capacity`", key: ["analytic", "storage"] } }, backtrace: Backtrace(   0: <sna
```
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

No 
# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

CI 

