### PR TITLE
feat: add dynamic setting log level

### DIFF
--- a/src/bin/ceresdb-server.rs
+++ b/src/bin/ceresdb-server.rs
@@ -64,7 +64,7 @@ fn main() {
     }
 
     // Setup log.
-    let _runtime_level = setup::setup_log(&config);
+    let runtime_level = setup::setup_log(&config);
     // Setup tracing.
     let _writer_guard = setup::setup_tracing(&config);
 
@@ -73,5 +73,5 @@ fn main() {
     // Log version.
     info!("version:{}", version);
 
-    setup::run_server(config);
+    setup::run_server(config, runtime_level);
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes # https://github.com/CeresDB/ceresdb/issues/436

# Rationale for this change
Support dynamic setting of log level to avoid server restart.

# What changes are included in this PR?
Add API `logLevel`, log level could be updated like this:

```curl --location --request PUT 'http://localhost:5440/log_level?level=debug'```

# Are there any user-facing changes?
None.

# How does this change test
Manual test in local environment.
