### PR TITLE
feat: impl parallel get_byte_ranges for ObjectStoreReader

### DIFF
--- a/analytic_engine/src/sst/metrics.rs
+++ b/analytic_engine/src/sst/metrics.rs
@@ -1,13 +1,14 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use lazy_static::lazy_static;
-use prometheus::{register_histogram, Histogram};
+use prometheus::{exponential_buckets, register_histogram, Histogram};
+
 lazy_static! {
     // Histogram:
-    // Buckets: 100B,500B,1KB,100KB,500KB,1M,5M
+    // Buckets: 100B,200B,400B,...,2KB
     pub static ref SST_GET_RANGE_HISTOGRAM: Histogram = register_histogram!(
         "sst_get_range_length",
         "Histogram for sst get range length",
-        vec!(100.0, 500.0, 1024.0, 1024.0 * 5.0, 1024.0 * 100.0, 1024.0 * 1000.0 * 5.0, 1024.0 * 1000.0 * 1000.0, 1024.0 * 1000.0 * 1000.0 * 5.0)
+        exponential_buckets(100.0, 2.0, 5).unwrap()
     ).unwrap();
 }

--- a/analytic_engine/src/sst/metrics.rs
+++ b/analytic_engine/src/sst/metrics.rs
@@ -1,0 +1,11 @@
+use lazy_static::lazy_static;
+use prometheus::{register_histogram, Histogram};
+lazy_static! {
+    // Histograms:
+    // Buckets: 100B,500B,1KB,100KB,500KB,1M,5M
+    pub static ref SST_GET_RANGE_HISTOGRAM: Histogram = register_histogram!(
+        "sst_get_range_length",
+        "Histogram for sst get range length",
+        vec!(100.0, 500.0, 1024.0, 1024.0 * 5.0, 1024.0 * 100.0, 1024.0 * 1000.0 * 5.0, 1024.0 * 1000.0 * 1000.0, 1024.0 * 1000.0 * 1000.0 * 5.0)
+    ).unwrap();
+}

--- a/analytic_engine/src/sst/metrics.rs
+++ b/analytic_engine/src/sst/metrics.rs
@@ -1,7 +1,9 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
 use lazy_static::lazy_static;
 use prometheus::{register_histogram, Histogram};
 lazy_static! {
-    // Histograms:
+    // Histogram:
     // Buckets: 100B,500B,1KB,100KB,500KB,1M,5M
     pub static ref SST_GET_RANGE_HISTOGRAM: Histogram = register_histogram!(
         "sst_get_range_length",

--- a/analytic_engine/src/sst/mod.rs
+++ b/analytic_engine/src/sst/mod.rs
@@ -7,5 +7,6 @@ pub mod factory;
 pub mod file;
 pub mod manager;
 pub mod meta_cache;
+pub mod metrics;
 pub mod parquet;
 pub mod reader;

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -239,6 +239,24 @@ impl AsyncFileReader for ObjectStoreReader {
             .boxed()
     }
 
+    fn get_byte_ranges(
+        &mut self,
+        ranges: Vec<Range<usize>>,
+    ) -> BoxFuture<'_, parquet::errors::Result<Vec<Bytes>>> {
+        async move {
+            self.storage
+                .get_ranges(&self.path, &ranges)
+                .map_err(|e| {
+                    parquet::errors::ParquetError::General(format!(
+                        "ObjectStoreReader::get_byte_ranges error: {}",
+                        e
+                    ))
+                })
+                .await
+        }
+        .boxed()
+    }
+
     fn get_metadata(
         &mut self,
     ) -> BoxFuture<'_, parquet::errors::Result<Arc<parquet::file::metadata::ParquetMetaData>>> {

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -241,7 +241,7 @@ impl AsyncFileReader for ObjectStoreReader {
             .get_range(&self.path, range)
             .map_err(|e| {
                 parquet::errors::ParquetError::General(format!(
-                    "Failed to fetch ranges from object store, err:{}",
+                    "Failed to fetch range from object store, err:{}",
                     e
                 ))
             })
@@ -262,7 +262,7 @@ impl AsyncFileReader for ObjectStoreReader {
                 .get_ranges(&self.path, &ranges)
                 .map_err(|e| {
                     parquet::errors::ParquetError::General(format!(
-                        "ObjectStoreReader::get_byte_ranges error: {}",
+                        "Failed to fetch ranges from object store, err:{}",
                         e
                     ))
                 })


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 The default implementation of `get_byte_ranges` in `AsyncFileReader` is sequentially.
Refer to: https://github.com/apache/arrow-rs/blob/99ced481308e870f69792e49cd23a529fa3ccc70/parquet/src/arrow/async_reader.rs#L124-L140

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
* Implement parallel `get_byte_ranges` using `get_ranges` in `ObjectStore`.
* Add a histogram to record the length of `get_range`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Manual testing.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
