### PR TITLE
fix: wrong primary key when define tsid and timestamp key as primary key

### DIFF
--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -346,8 +346,8 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
     fn create_table_schema(
         columns: &[Ident],
         primary_key_columns: &[Ident],
-        mut columns_by_name: BTreeMap<&str, ColumnSchema>,
-        column_idxs_by_name: BTreeMap<&str, usize>,
+        mut columns_by_name: HashMap<&str, ColumnSchema>,
+        column_idxs_by_name: HashMap<&str, usize>,
         enable_tsid_primary_key: bool,
     ) -> Result<Schema> {
         assert_eq!(columns_by_name.len(), column_idxs_by_name.len());
@@ -411,7 +411,7 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
 
     // Find the timestamp column and ensure its valid existence (only one).
     fn find_and_ensure_timestamp_column(
-        columns_by_name: &BTreeMap<&str, ColumnSchema>,
+        columns_by_name: &HashMap<&str, ColumnSchema>,
         constraints: &[TableConstraint],
     ) -> Result<Ident> {
         let mut timestamp_column_name = None;
@@ -461,14 +461,14 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
             .columns
             .iter()
             .map(|col| Ok((col.name.value.as_str(), parse_column(col)?)))
-            .collect::<Result<BTreeMap<_, _>>>()?;
+            .collect::<Result<HashMap<_, _>>>()?;
 
-        let mut column_idxs_by_name = stmt
+        let mut column_idxs_by_name: HashMap<_, _> = stmt
             .columns
             .iter()
             .enumerate()
             .map(|(idx, col)| (col.name.value.as_str(), idx))
-            .collect::<BTreeMap<_, _>>();
+            .collect();
 
         // Tsid column is a reserved column.
         ensure!(

--- a/tests/cases/local/03_dml/case_insensitive.result
+++ b/tests/cases/local/03_dml/case_insensitive.result
@@ -22,10 +22,10 @@ SELECT
 FROM
     case_insensitive_table1;
 
-ts,value1,tsid,
-Timestamp(Timestamp(1)),Double(10.0),Int64(0),
-Timestamp(Timestamp(2)),Double(20.0),Int64(0),
-Timestamp(Timestamp(3)),Double(30.0),Int64(0),
+tsid,ts,value1,
+Int64(0),Timestamp(Timestamp(1)),Double(10.0),
+Int64(0),Timestamp(Timestamp(2)),Double(20.0),
+Int64(0),Timestamp(Timestamp(3)),Double(30.0),
 
 
 SELECT
@@ -33,37 +33,37 @@ SELECT
 FROM
     CASE_INSENSITIVE_TABLE1;
 
-ts,value1,tsid,
-Timestamp(Timestamp(1)),Double(10.0),Int64(0),
-Timestamp(Timestamp(2)),Double(20.0),Int64(0),
-Timestamp(Timestamp(3)),Double(30.0),Int64(0),
+tsid,ts,value1,
+Int64(0),Timestamp(Timestamp(1)),Double(10.0),
+Int64(0),Timestamp(Timestamp(2)),Double(20.0),
+Int64(0),Timestamp(Timestamp(3)),Double(30.0),
 
 
 SHOW CREATE TABLE case_insensitive_table1;
 
 Table,Create Table,
-String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`ts` timestamp NOT NULL, `value1` double, `tsid` uint64 NOT NULL, PRIMARY KEY(ts,tsid), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`tsid` uint64 NOT NULL, `ts` timestamp NOT NULL, `value1` double, PRIMARY KEY(tsid,ts), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 SHOW CREATE TABLE CASE_INSENSITIVE_TABLE1;
 
 Table,Create Table,
-String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`ts` timestamp NOT NULL, `value1` double, `tsid` uint64 NOT NULL, PRIMARY KEY(ts,tsid), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`tsid` uint64 NOT NULL, `ts` timestamp NOT NULL, `value1` double, PRIMARY KEY(tsid,ts), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 DESC case_insensitive_table1;
 
 name,type,is_primary,is_nullable,is_tag,
+String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"ts")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"value1")),String(StringBytes(b"double")),Boolean(false),Boolean(true),Boolean(false),
-String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 
 
 DESC CASE_INSENSITIVE_TABLE1;
 
 name,type,is_primary,is_nullable,is_tag,
+String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"ts")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"value1")),String(StringBytes(b"double")),Boolean(false),Boolean(true),Boolean(false),
-String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 
 

--- a/tests/cases/local/03_dml/case_insensitive.result
+++ b/tests/cases/local/03_dml/case_insensitive.result
@@ -22,10 +22,10 @@ SELECT
 FROM
     case_insensitive_table1;
 
-ts,tsid,value1,
-Timestamp(Timestamp(1)),Int64(0),Double(10.0),
-Timestamp(Timestamp(2)),Int64(0),Double(20.0),
-Timestamp(Timestamp(3)),Int64(0),Double(30.0),
+ts,value1,tsid,
+Timestamp(Timestamp(1)),Double(10.0),Int64(0),
+Timestamp(Timestamp(2)),Double(20.0),Int64(0),
+Timestamp(Timestamp(3)),Double(30.0),Int64(0),
 
 
 SELECT
@@ -33,37 +33,37 @@ SELECT
 FROM
     CASE_INSENSITIVE_TABLE1;
 
-ts,tsid,value1,
-Timestamp(Timestamp(1)),Int64(0),Double(10.0),
-Timestamp(Timestamp(2)),Int64(0),Double(20.0),
-Timestamp(Timestamp(3)),Int64(0),Double(30.0),
+ts,value1,tsid,
+Timestamp(Timestamp(1)),Double(10.0),Int64(0),
+Timestamp(Timestamp(2)),Double(20.0),Int64(0),
+Timestamp(Timestamp(3)),Double(30.0),Int64(0),
 
 
 SHOW CREATE TABLE case_insensitive_table1;
 
 Table,Create Table,
-String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`ts` timestamp NOT NULL, `tsid` uint64 NOT NULL, `value1` double, PRIMARY KEY(ts,tsid), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`ts` timestamp NOT NULL, `value1` double, `tsid` uint64 NOT NULL, PRIMARY KEY(ts,tsid), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 SHOW CREATE TABLE CASE_INSENSITIVE_TABLE1;
 
 Table,Create Table,
-String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`ts` timestamp NOT NULL, `tsid` uint64 NOT NULL, `value1` double, PRIMARY KEY(ts,tsid), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`ts` timestamp NOT NULL, `value1` double, `tsid` uint64 NOT NULL, PRIMARY KEY(ts,tsid), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 DESC case_insensitive_table1;
 
 name,type,is_primary,is_nullable,is_tag,
 String(StringBytes(b"ts")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
-String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"value1")),String(StringBytes(b"double")),Boolean(false),Boolean(true),Boolean(false),
+String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 
 
 DESC CASE_INSENSITIVE_TABLE1;
 
 name,type,is_primary,is_nullable,is_tag,
 String(StringBytes(b"ts")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
-String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"value1")),String(StringBytes(b"double")),Boolean(false),Boolean(true),Boolean(false),
+String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 
 

--- a/tests/cases/local/03_dml/insert_mode.result
+++ b/tests/cases/local/03_dml/insert_mode.result
@@ -25,10 +25,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,value,tsid,
-Timestamp(Timestamp(3)),Double(-30.0),Int64(0),
-Timestamp(Timestamp(2)),Double(0.0),Int64(0),
-Timestamp(Timestamp(1)),Double(10.0),Int64(0),
+tsid,timestamp,value,
+Int64(0),Timestamp(Timestamp(3)),Double(-30.0),
+Int64(0),Timestamp(Timestamp(2)),Double(0.0),
+Int64(0),Timestamp(Timestamp(1)),Double(10.0),
 
 
 INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)
@@ -43,10 +43,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,value,tsid,
-Timestamp(Timestamp(1)),Double(100.0),Int64(0),
-Timestamp(Timestamp(2)),Double(200.0),Int64(0),
-Timestamp(Timestamp(3)),Double(300.0),Int64(0),
+tsid,timestamp,value,
+Int64(0),Timestamp(Timestamp(1)),Double(100.0),
+Int64(0),Timestamp(Timestamp(2)),Double(200.0),
+Int64(0),Timestamp(Timestamp(3)),Double(300.0),
 
 
 DROP TABLE `03_dml_insert_mode_table1`;
@@ -80,10 +80,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,value,tsid,
-Timestamp(Timestamp(1)),Double(10.0),Int64(0),
-Timestamp(Timestamp(2)),Double(20.0),Int64(0),
-Timestamp(Timestamp(3)),Double(30.0),Int64(0),
+tsid,timestamp,value,
+Int64(0),Timestamp(Timestamp(1)),Double(10.0),
+Int64(0),Timestamp(Timestamp(2)),Double(20.0),
+Int64(0),Timestamp(Timestamp(3)),Double(30.0),
 
 
 INSERT INTO `03_dml_insert_mode_table2` (`timestamp`, `value`)
@@ -98,13 +98,13 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,value,tsid,
-Timestamp(Timestamp(1)),Double(10.0),Int64(0),
-Timestamp(Timestamp(2)),Double(20.0),Int64(0),
-Timestamp(Timestamp(3)),Double(30.0),Int64(0),
-Timestamp(Timestamp(1)),Double(100.0),Int64(0),
-Timestamp(Timestamp(2)),Double(200.0),Int64(0),
-Timestamp(Timestamp(3)),Double(300.0),Int64(0),
+tsid,timestamp,value,
+Int64(0),Timestamp(Timestamp(1)),Double(10.0),
+Int64(0),Timestamp(Timestamp(2)),Double(20.0),
+Int64(0),Timestamp(Timestamp(3)),Double(30.0),
+Int64(0),Timestamp(Timestamp(1)),Double(100.0),
+Int64(0),Timestamp(Timestamp(2)),Double(200.0),
+Int64(0),Timestamp(Timestamp(3)),Double(300.0),
 
 
 DROP TABLE `03_dml_insert_mode_table2`;
@@ -137,10 +137,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,value,tsid,
-Timestamp(Timestamp(1)),Double(10.0),Int64(0),
-Timestamp(Timestamp(2)),Double(20.0),Int64(0),
-Timestamp(Timestamp(3)),Double(30.0),Int64(0),
+tsid,timestamp,value,
+Int64(0),Timestamp(Timestamp(1)),Double(10.0),
+Int64(0),Timestamp(Timestamp(2)),Double(20.0),
+Int64(0),Timestamp(Timestamp(3)),Double(30.0),
 
 
 INSERT INTO `03_dml_insert_mode_table3` (`timestamp`, `value`)
@@ -155,10 +155,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,value,tsid,
-Timestamp(Timestamp(1)),Double(100.0),Int64(0),
-Timestamp(Timestamp(2)),Double(200.0),Int64(0),
-Timestamp(Timestamp(3)),Double(300.0),Int64(0),
+tsid,timestamp,value,
+Int64(0),Timestamp(Timestamp(1)),Double(100.0),
+Int64(0),Timestamp(Timestamp(2)),Double(200.0),
+Int64(0),Timestamp(Timestamp(3)),Double(300.0),
 
 
 DROP TABLE `03_dml_insert_mode_table3`;
@@ -195,9 +195,9 @@ FROM
 ORDER BY
     `c1` ASC;
 
-timestamp,c1,c2,c3,c4,c5,tsid,
-Timestamp(Timestamp(1)),Int64(10),String(StringBytes(b"123")),Int64(11),Int64(12),Int64(3),Int64(0),
-Timestamp(Timestamp(2)),Int64(20),String(StringBytes(b"123")),Int64(21),Int64(22),Int64(4),Int64(0),
-Timestamp(Timestamp(3)),Int64(30),String(StringBytes(b"123")),Int64(31),Int64(32),Int64(5),Int64(0),
+tsid,timestamp,c1,c2,c3,c4,c5,
+Int64(0),Timestamp(Timestamp(1)),Int64(10),String(StringBytes(b"123")),Int64(11),Int64(12),Int64(3),
+Int64(0),Timestamp(Timestamp(2)),Int64(20),String(StringBytes(b"123")),Int64(21),Int64(22),Int64(4),
+Int64(0),Timestamp(Timestamp(3)),Int64(30),String(StringBytes(b"123")),Int64(31),Int64(32),Int64(5),
 
 

--- a/tests/cases/local/03_dml/insert_mode.result
+++ b/tests/cases/local/03_dml/insert_mode.result
@@ -25,10 +25,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,tsid,value,
-Timestamp(Timestamp(3)),Int64(0),Double(-30.0),
-Timestamp(Timestamp(2)),Int64(0),Double(0.0),
-Timestamp(Timestamp(1)),Int64(0),Double(10.0),
+timestamp,value,tsid,
+Timestamp(Timestamp(3)),Double(-30.0),Int64(0),
+Timestamp(Timestamp(2)),Double(0.0),Int64(0),
+Timestamp(Timestamp(1)),Double(10.0),Int64(0),
 
 
 INSERT INTO `03_dml_insert_mode_table1` (`timestamp`, `value`)
@@ -43,10 +43,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,tsid,value,
-Timestamp(Timestamp(1)),Int64(0),Double(100.0),
-Timestamp(Timestamp(2)),Int64(0),Double(200.0),
-Timestamp(Timestamp(3)),Int64(0),Double(300.0),
+timestamp,value,tsid,
+Timestamp(Timestamp(1)),Double(100.0),Int64(0),
+Timestamp(Timestamp(2)),Double(200.0),Int64(0),
+Timestamp(Timestamp(3)),Double(300.0),Int64(0),
 
 
 DROP TABLE `03_dml_insert_mode_table1`;
@@ -80,10 +80,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,tsid,value,
-Timestamp(Timestamp(1)),Int64(0),Double(10.0),
-Timestamp(Timestamp(2)),Int64(0),Double(20.0),
-Timestamp(Timestamp(3)),Int64(0),Double(30.0),
+timestamp,value,tsid,
+Timestamp(Timestamp(1)),Double(10.0),Int64(0),
+Timestamp(Timestamp(2)),Double(20.0),Int64(0),
+Timestamp(Timestamp(3)),Double(30.0),Int64(0),
 
 
 INSERT INTO `03_dml_insert_mode_table2` (`timestamp`, `value`)
@@ -98,13 +98,13 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,tsid,value,
-Timestamp(Timestamp(1)),Int64(0),Double(10.0),
-Timestamp(Timestamp(2)),Int64(0),Double(20.0),
-Timestamp(Timestamp(3)),Int64(0),Double(30.0),
-Timestamp(Timestamp(1)),Int64(0),Double(100.0),
-Timestamp(Timestamp(2)),Int64(0),Double(200.0),
-Timestamp(Timestamp(3)),Int64(0),Double(300.0),
+timestamp,value,tsid,
+Timestamp(Timestamp(1)),Double(10.0),Int64(0),
+Timestamp(Timestamp(2)),Double(20.0),Int64(0),
+Timestamp(Timestamp(3)),Double(30.0),Int64(0),
+Timestamp(Timestamp(1)),Double(100.0),Int64(0),
+Timestamp(Timestamp(2)),Double(200.0),Int64(0),
+Timestamp(Timestamp(3)),Double(300.0),Int64(0),
 
 
 DROP TABLE `03_dml_insert_mode_table2`;
@@ -137,10 +137,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,tsid,value,
-Timestamp(Timestamp(1)),Int64(0),Double(10.0),
-Timestamp(Timestamp(2)),Int64(0),Double(20.0),
-Timestamp(Timestamp(3)),Int64(0),Double(30.0),
+timestamp,value,tsid,
+Timestamp(Timestamp(1)),Double(10.0),Int64(0),
+Timestamp(Timestamp(2)),Double(20.0),Int64(0),
+Timestamp(Timestamp(3)),Double(30.0),Int64(0),
 
 
 INSERT INTO `03_dml_insert_mode_table3` (`timestamp`, `value`)
@@ -155,10 +155,10 @@ FROM
 ORDER BY
     `value` ASC;
 
-timestamp,tsid,value,
-Timestamp(Timestamp(1)),Int64(0),Double(100.0),
-Timestamp(Timestamp(2)),Int64(0),Double(200.0),
-Timestamp(Timestamp(3)),Int64(0),Double(300.0),
+timestamp,value,tsid,
+Timestamp(Timestamp(1)),Double(100.0),Int64(0),
+Timestamp(Timestamp(2)),Double(200.0),Int64(0),
+Timestamp(Timestamp(3)),Double(300.0),Int64(0),
 
 
 DROP TABLE `03_dml_insert_mode_table3`;
@@ -195,9 +195,9 @@ FROM
 ORDER BY
     `c1` ASC;
 
-timestamp,tsid,c1,c2,c3,c4,c5,
-Timestamp(Timestamp(1)),Int64(0),Int64(10),String(StringBytes(b"123")),Int64(11),Int64(12),Int64(3),
-Timestamp(Timestamp(2)),Int64(0),Int64(20),String(StringBytes(b"123")),Int64(21),Int64(22),Int64(4),
-Timestamp(Timestamp(3)),Int64(0),Int64(30),String(StringBytes(b"123")),Int64(31),Int64(32),Int64(5),
+timestamp,c1,c2,c3,c4,c5,tsid,
+Timestamp(Timestamp(1)),Int64(10),String(StringBytes(b"123")),Int64(11),Int64(12),Int64(3),Int64(0),
+Timestamp(Timestamp(2)),Int64(20),String(StringBytes(b"123")),Int64(21),Int64(22),Int64(4),Int64(0),
+Timestamp(Timestamp(3)),Int64(30),String(StringBytes(b"123")),Int64(31),Int64(32),Int64(5),Int64(0),
 
 

--- a/tests/cases/local/05_ddl/alter_table.result
+++ b/tests/cases/local/05_ddl/alter_table.result
@@ -12,8 +12,8 @@ affected_rows: 1
 
 SELECT * FROM `05_alter_table_t0`;
 
-a,t,tsid,
-Int32(1),Timestamp(Timestamp(1)),Int64(0),
+tsid,t,a,
+Int64(0),Timestamp(Timestamp(1)),Int32(1),
 
 
 ALTER TABLE `05_alter_table_t0` RENAME TO `t1`;
@@ -27,9 +27,9 @@ affected_rows: 0
 DESCRIBE TABLE `05_alter_table_t0`;
 
 name,type,is_primary,is_nullable,is_tag,
-String(StringBytes(b"a")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
-String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"a")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
 String(StringBytes(b"b")),String(StringBytes(b"string")),Boolean(false),Boolean(true),Boolean(false),
 
 
@@ -39,9 +39,9 @@ affected_rows: 1
 
 SELECT * FROM `05_alter_table_t0`;
 
-a,t,tsid,b,
-Int32(1),Timestamp(Timestamp(1)),Int64(0),Null,
-Int32(2),Timestamp(Timestamp(2)),Int64(0),String(StringBytes(b"2")),
+tsid,t,a,b,
+Int64(0),Timestamp(Timestamp(1)),Int32(1),Null,
+Int64(0),Timestamp(Timestamp(2)),Int32(2),String(StringBytes(b"2")),
 
 
 ALTER TABLE `05_alter_table_t0` DROP COLUMN b;
@@ -51,17 +51,17 @@ Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to cr
 DESCRIBE TABLE `05_alter_table_t0`;
 
 name,type,is_primary,is_nullable,is_tag,
-String(StringBytes(b"a")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
-String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"a")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
 String(StringBytes(b"b")),String(StringBytes(b"string")),Boolean(false),Boolean(true),Boolean(false),
 
 
 SELECT * FROM `05_alter_table_t0`;
 
-a,t,tsid,b,
-Int32(1),Timestamp(Timestamp(1)),Int64(0),Null,
-Int32(2),Timestamp(Timestamp(2)),Int64(0),String(StringBytes(b"2")),
+tsid,t,a,b,
+Int64(0),Timestamp(Timestamp(1)),Int32(1),Null,
+Int64(0),Timestamp(Timestamp(2)),Int32(2),String(StringBytes(b"2")),
 
 
 DROP TABLE `05_alter_table_t0`;

--- a/tests/cases/local/05_ddl/create_tables.result
+++ b/tests/cases/local/05_ddl/create_tables.result
@@ -84,15 +84,15 @@ affected_rows: 0
 describe table `05_create_tables_t4`;
 
 name,type,is_primary,is_nullable,is_tag,
-String(StringBytes(b"a")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
-String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"a")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
 
 
 show create table `05_create_tables_t4`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t4")),String(StringBytes(b"CREATE TABLE `05_create_tables_t4` (`a` int, `t` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t,tsid), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t4")),String(StringBytes(b"CREATE TABLE `05_create_tables_t4` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `05_create_tables_t5`(c1 int, t timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
@@ -102,15 +102,15 @@ affected_rows: 0
 describe table `05_create_tables_t5`;
 
 name,type,is_primary,is_nullable,is_tag,
-String(StringBytes(b"c1")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
-String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"c1")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
 
 
 show create table `05_create_tables_t5`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t5")),String(StringBytes(b"CREATE TABLE `05_create_tables_t5` (`c1` int, `t` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t,tsid), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t5")),String(StringBytes(b"CREATE TABLE `05_create_tables_t5` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `05_create_tables_t6`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, t2 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
@@ -124,15 +124,15 @@ affected_rows: 0
 describe table `05_create_tables_t7`;
 
 name,type,is_primary,is_nullable,is_tag,
-String(StringBytes(b"c1")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
-String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"t")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
+String(StringBytes(b"c1")),String(StringBytes(b"int")),Boolean(false),Boolean(true),Boolean(false),
 
 
 show create table `05_create_tables_t7`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t7")),String(StringBytes(b"CREATE TABLE `05_create_tables_t7` (`c1` int COMMENT 'id', `t` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t,tsid), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t7")),String(StringBytes(b"CREATE TABLE `05_create_tables_t7` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `c1` int COMMENT 'id', PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `05_create_tables_t8`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
@@ -142,7 +142,7 @@ affected_rows: 0
 show create table `05_create_tables_t8`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`c1` int, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t8`;
@@ -156,7 +156,7 @@ affected_rows: 0
 show create table `05_create_tables_t8`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`c1` int, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t8`;
@@ -170,7 +170,7 @@ affected_rows: 0
 show create table `05_create_tables_t8`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`c1` int, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='HYBRID', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='HYBRID', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t8`;
@@ -184,7 +184,7 @@ affected_rows: 0
 show create table `05_create_tables_t9`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t9")),String(StringBytes(b"CREATE TABLE `05_create_tables_t9` (`c1` int, `c2` bigint DEFAULT 0, `c3` uint32 DEFAULT 1 + 1, `c4` string DEFAULT 'xxx', `c5` uint32 DEFAULT c3 * 2 + 1, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t9")),String(StringBytes(b"CREATE TABLE `05_create_tables_t9` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, `c2` bigint DEFAULT 0, `c3` uint32 DEFAULT 1 + 1, `c4` string DEFAULT 'xxx', `c5` uint32 DEFAULT c3 * 2 + 1, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t9`;
@@ -198,7 +198,7 @@ affected_rows: 0
 show create table `05_create_tables_t10`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t10")),String(StringBytes(b"CREATE TABLE `05_create_tables_t10` (`c1` int, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t10")),String(StringBytes(b"CREATE TABLE `05_create_tables_t10` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t10`;
@@ -212,7 +212,7 @@ affected_rows: 0
 show create table `05_create_tables_t11`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t11")),String(StringBytes(b"CREATE TABLE `05_create_tables_t11` (`c1` int, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t11")),String(StringBytes(b"CREATE TABLE `05_create_tables_t11` (`t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, `c1` int, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t11`;

--- a/tests/cases/local/05_ddl/create_tables.result
+++ b/tests/cases/local/05_ddl/create_tables.result
@@ -191,6 +191,34 @@ drop table `05_create_tables_t9`;
 
 affected_rows: 0
 
+CREATE TABLE `05_create_tables_t10`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(tsid, t1)) ENGINE = Analytic;
+
+affected_rows: 0
+
+show create table `05_create_tables_t10`;
+
+Table,Create Table,
+String(StringBytes(b"05_create_tables_t10")),String(StringBytes(b"CREATE TABLE `05_create_tables_t10` (`c1` int, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+
+
+drop table `05_create_tables_t10`;
+
+affected_rows: 0
+
+CREATE TABLE `05_create_tables_t11`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(t1, tsid)) ENGINE = Analytic;
+
+affected_rows: 0
+
+show create table `05_create_tables_t11`;
+
+Table,Create Table,
+String(StringBytes(b"05_create_tables_t11")),String(StringBytes(b"CREATE TABLE `05_create_tables_t11` (`c1` int, `t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+
+
+drop table `05_create_tables_t11`;
+
+affected_rows: 0
+
 DROP TABLE IF EXISTS `05_create_tables_t`;
 
 affected_rows: 0
@@ -220,6 +248,18 @@ DROP TABLE IF EXISTS `05_create_tables_t7`;
 affected_rows: 0
 
 DROP TABLE IF EXISTS `05_create_tables_t8`;
+
+affected_rows: 0
+
+DROP TABLE IF EXISTS `05_create_tables_t9`;
+
+affected_rows: 0
+
+DROP TABLE IF EXISTS `05_create_tables_t10`;
+
+affected_rows: 0
+
+DROP TABLE IF EXISTS `05_create_tables_t11`;
 
 affected_rows: 0
 

--- a/tests/cases/local/05_ddl/create_tables.sql
+++ b/tests/cases/local/05_ddl/create_tables.sql
@@ -69,6 +69,16 @@ CREATE TABLE `05_create_tables_t9`(c1 int, c2 bigint default 0, c3 uint32 defaul
 show create table `05_create_tables_t9`;
 drop table `05_create_tables_t9`;
 
+-- Explicit primary key with tsid
+CREATE TABLE `05_create_tables_t10`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(tsid, t1)) ENGINE = Analytic;
+show create table `05_create_tables_t10`;
+drop table `05_create_tables_t10`;
+
+-- Explicit primary key with tsid
+CREATE TABLE `05_create_tables_t11`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(t1, tsid, c1)) ENGINE = Analytic;
+show create table `05_create_tables_t11`;
+drop table `05_create_tables_t11`;
+
 DROP TABLE IF EXISTS `05_create_tables_t`;
 DROP TABLE IF EXISTS `05_create_tables_t2`;
 DROP TABLE IF EXISTS `05_create_tables_t3`;
@@ -77,3 +87,6 @@ DROP TABLE IF EXISTS `05_create_tables_t5`;
 DROP TABLE IF EXISTS `05_create_tables_t6`;
 DROP TABLE IF EXISTS `05_create_tables_t7`;
 DROP TABLE IF EXISTS `05_create_tables_t8`;
+DROP TABLE IF EXISTS `05_create_tables_t9`;
+DROP TABLE IF EXISTS `05_create_tables_t10`;
+DROP TABLE IF EXISTS `05_create_tables_t11`;

--- a/tests/cases/local/05_ddl/create_tables.sql
+++ b/tests/cases/local/05_ddl/create_tables.sql
@@ -75,7 +75,7 @@ show create table `05_create_tables_t10`;
 drop table `05_create_tables_t10`;
 
 -- Explicit primary key with tsid
-CREATE TABLE `05_create_tables_t11`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(t1, tsid, c1)) ENGINE = Analytic;
+CREATE TABLE `05_create_tables_t11`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(t1, tsid)) ENGINE = Analytic;
 show create table `05_create_tables_t11`;
 drop table `05_create_tables_t11`;
 

--- a/tests/cases/local/06_show/show_create_table.result
+++ b/tests/cases/local/06_show/show_create_table.result
@@ -17,7 +17,7 @@ affected_rows: 0
 SHOW CREATE TABLE `06_show_a`;
 
 Table,Create Table,
-String(StringBytes(b"06_show_a")),String(StringBytes(b"CREATE TABLE `06_show_a` (`a` bigint, `b` int DEFAULT 3, `c` string DEFAULT 'x', `d` smallint, `t` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t,tsid), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"06_show_a")),String(StringBytes(b"CREATE TABLE `06_show_a` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` bigint, `b` int DEFAULT 3, `c` string DEFAULT 'x', `d` smallint, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `06_show_b` (a bigint, b int null default null, c string, d smallint null, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE = Analytic;
@@ -27,7 +27,7 @@ affected_rows: 0
 SHOW CREATE TABLE `06_show_b`;
 
 Table,Create Table,
-String(StringBytes(b"06_show_b")),String(StringBytes(b"CREATE TABLE `06_show_b` (`a` bigint, `b` int DEFAULT NULL, `c` string, `d` smallint, `t` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t,tsid), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"06_show_b")),String(StringBytes(b"CREATE TABLE `06_show_b` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` bigint, `b` int DEFAULT NULL, `c` string, `d` smallint, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `06_show_c` (a int, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE = Analytic;
@@ -37,7 +37,7 @@ affected_rows: 0
 SHOW CREATE TABLE `06_show_c`;
 
 Table,Create Table,
-String(StringBytes(b"06_show_c")),String(StringBytes(b"CREATE TABLE `06_show_c` (`a` int, `t` timestamp NOT NULL, `tsid` uint64 NOT NULL, PRIMARY KEY(t,tsid), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"06_show_c")),String(StringBytes(b"CREATE TABLE `06_show_c` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 DROP TABLE `06_show_a`;

--- a/tests/cases/local/basic.result
+++ b/tests/cases/local/basic.result
@@ -19,8 +19,8 @@ affected_rows: 1
 
 SELECT * FROM demo;
 
-name,value,t,tsid,
-String(StringBytes(b"ceresdb")),Double(100.0),Timestamp(Timestamp(1651737067000)),Int64(102432447525557625),
+tsid,t,name,value,
+Int64(-6317898613073581291),Timestamp(Timestamp(1651737067000)),String(StringBytes(b"ceresdb")),Double(100.0),
 
 
 INSERT INTO demo (t, name, value)
@@ -30,9 +30,9 @@ affected_rows: 1
 
 SELECT * FROM demo;
 
-name,value,t,tsid,
-String(StringBytes(b"ceresdb")),Double(100.0),Timestamp(Timestamp(1651737067000)),Int64(102432447525557625),
-String(StringBytes(b"ceresdb")),Double(100.0),Timestamp(Timestamp(1651737067001)),Int64(102432447525557625),
+tsid,t,name,value,
+Int64(-6317898613073581291),Timestamp(Timestamp(1651737067000)),String(StringBytes(b"ceresdb")),Double(100.0),
+Int64(-6317898613073581291),Timestamp(Timestamp(1651737067001)),String(StringBytes(b"ceresdb")),Double(100.0),
 
 
 DROP TABLE IF EXISTS `demo`;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 After #340 merged, it can't define (tsid, timestamp_key_name) as primary key. And this pr will fix this problem.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Refactor the generation of create table plan;
- We can define a primary key with tsid;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
The tsid column will be the last column in the schema after this pr, compared with that tsid column just follows the timestamp key column.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
New sql test in the harness.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
