### PR TITLE
feat: convert table name to quoted style

### DIFF
--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -214,6 +214,7 @@ impl<'a> SstBuilder for ParquetSstBuilder<'a> {
             request_id, meta, self.num_rows_per_row_group
         );
 
+        //
         let total_row_num = Arc::new(AtomicUsize::new(0));
         let reader = RecordBytesReader {
             request_id,
@@ -225,6 +226,8 @@ impl<'a> SstBuilder for ParquetSstBuilder<'a> {
             meta_data: meta.to_owned(),
             partitioned_record_batch: Default::default(),
         };
+
+        //
         let bytes = reader.read_all().await?;
         self.storage
             .put(self.path, bytes.into())

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -214,7 +214,6 @@ impl<'a> SstBuilder for ParquetSstBuilder<'a> {
             request_id, meta, self.num_rows_per_row_group
         );
 
-        //
         let total_row_num = Arc::new(AtomicUsize::new(0));
         let reader = RecordBytesReader {
             request_id,
@@ -226,8 +225,6 @@ impl<'a> SstBuilder for ParquetSstBuilder<'a> {
             meta_data: meta.to_owned(),
             partitioned_record_batch: Default::default(),
         };
-
-        //
         let bytes = reader.read_all().await?;
         self.storage
             .put(self.path, bytes.into())

--- a/sql/src/ast.rs
+++ b/sql/src/ast.rs
@@ -3,7 +3,7 @@
 //! SQL statement
 
 use sqlparser::ast::{
-    ColumnDef, Ident, ObjectName, SqlOption, Statement as SqlStatement, TableConstraint,
+    ColumnDef, ObjectName, SqlOption, Statement as SqlStatement, TableConstraint,
 };
 
 /// Statement representations
@@ -33,14 +33,6 @@ impl TableName {
     pub fn is_empty(&self) -> bool {
         self.0 .0.is_empty()
     }
-
-    // Normalize an identifer to a lowercase string unless the identifier is quoted.
-    fn normalize_ident(id: &Ident) -> String {
-        match id.quote_style {
-            Some(_) => id.value.clone(),
-            None => id.value.to_ascii_lowercase(),
-        }
-    }
 }
 
 impl ToString for TableName {
@@ -48,7 +40,7 @@ impl ToString for TableName {
         self.0
              .0
             .iter()
-            .map(Self::normalize_ident)
+            .map(|ident| ident.value.as_str())
             .collect::<Vec<_>>()
             .join(".")
     }

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -180,7 +180,6 @@ impl<'a> Parser<'a> {
                         self.parser.next_token();
                         self.parse_exists()
                     }
-                    // Keyword::Q
                     _ => {
                         // use the native parser
                         Ok(Statement::Standard(Box::new(maybe_normalize_table_name(
@@ -653,7 +652,6 @@ fn convert_relation(relation: TableFactor) -> TableFactor {
 }
 
 fn maybe_convert_table_name(object_name: ObjectName) -> ObjectName {
-    // let mut quoted_idents = Vec::with_capacity(object_name.0.len());
     let quoteds: Vec<_> = object_name
         .0
         .into_iter()

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -544,14 +544,13 @@ fn build_timestamp_key_constraint(col_defs: &[ColumnDef], constraints: &mut Vec<
     }
 }
 
-/// Add quotes in table name, for example:
-///     
-///     table --> `table`
+/// Add quotes in table name (for example: convert table to `table`).
 ///
 /// It is used to process table name in `SELECT`, for preventing `datafusion`
 /// converting the table name to lowercase, because `CeresDB` only support
 /// case-sensitive in sql.
-// TODO: other items(such as: alias, column name) are not normalized now.
+// TODO: maybe other items(such as: alias, column name) need to be normalized,
+// too.
 pub fn maybe_normalize_table_name(statement: SqlStatement) -> SqlStatement {
     let original_statement = statement.clone();
     if let SqlStatement::Query(query) = statement {

--- a/tests/cases/local/03_dml/case_insensitive.result
+++ b/tests/cases/local/03_dml/case_insensitive.result
@@ -33,11 +33,25 @@ SELECT
 FROM
     CASE_INSENSITIVE_TABLE1;
 
-tsid,ts,value1,
-Int64(0),Timestamp(Timestamp(1)),Double(10.0),
-Int64(0),Timestamp(Timestamp(2)),Double(20.0),
-Int64(0),Timestamp(Timestamp(3)),Double(30.0),
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: SELECT \n     * \n FROM \n     CASE_INSENSITIVE_TABLE1;. Caused by: Failed to create plan, err:Failed to generate datafusion plan, err:Execution error: Table is not found, \"table:CASE_INSENSITIVE_TABLE1\"" })
 
+SELECT
+    *
+FROM
+    `case_insensitive_table1`;
+
+ts,tsid,value1,
+Timestamp(Timestamp(1)),Int64(0),Double(10.0),
+Timestamp(Timestamp(2)),Int64(0),Double(20.0),
+Timestamp(Timestamp(3)),Int64(0),Double(30.0),
+
+
+SELECT
+    *
+FROM
+    `CASE_INSENSITIVE_TABLE1`;
+
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: SELECT \n     * \n FROM \n     `CASE_INSENSITIVE_TABLE1`;. Caused by: Failed to create plan, err:Failed to generate datafusion plan, err:Execution error: Table is not found, \"table:CASE_INSENSITIVE_TABLE1\"" })
 
 SHOW CREATE TABLE case_insensitive_table1;
 
@@ -47,9 +61,17 @@ String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABL
 
 SHOW CREATE TABLE CASE_INSENSITIVE_TABLE1;
 
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: SHOW CREATE TABLE CASE_INSENSITIVE_TABLE1;. Caused by: Failed to create plan, err:Table not found, table:CASE_INSENSITIVE_TABLE1" })
+
+SHOW CREATE TABLE `case_insensitive_table1`;
+
 Table,Create Table,
 String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`tsid` uint64 NOT NULL, `ts` timestamp NOT NULL, `value1` double, PRIMARY KEY(tsid,ts), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
+
+SHOW CREATE TABLE `CASE_INSENSITIVE_TABLE1`;
+
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: SHOW CREATE TABLE `CASE_INSENSITIVE_TABLE1`;. Caused by: Failed to create plan, err:Table not found, table:CASE_INSENSITIVE_TABLE1" })
 
 DESC case_insensitive_table1;
 
@@ -61,9 +83,17 @@ String(StringBytes(b"value1")),String(StringBytes(b"double")),Boolean(false),Boo
 
 DESC CASE_INSENSITIVE_TABLE1;
 
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: DESC CASE_INSENSITIVE_TABLE1;. Caused by: Failed to create plan, err:Table not found, table:CASE_INSENSITIVE_TABLE1" })
+
+DESC `case_insensitive_table1`;
+
 name,type,is_primary,is_nullable,is_tag,
 String(StringBytes(b"tsid")),String(StringBytes(b"uint64")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"ts")),String(StringBytes(b"timestamp")),Boolean(true),Boolean(false),Boolean(false),
 String(StringBytes(b"value1")),String(StringBytes(b"double")),Boolean(false),Boolean(true),Boolean(false),
 
+
+DESC `CASE_INSENSITIVE_TABLE1`;
+
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: DESC `CASE_INSENSITIVE_TABLE1`;. Caused by: Failed to create plan, err:Table not found, table:CASE_INSENSITIVE_TABLE1" })
 

--- a/tests/cases/local/03_dml/case_insensitive.result
+++ b/tests/cases/local/03_dml/case_insensitive.result
@@ -40,10 +40,10 @@ SELECT
 FROM
     `case_insensitive_table1`;
 
-ts,tsid,value1,
-Timestamp(Timestamp(1)),Int64(0),Double(10.0),
-Timestamp(Timestamp(2)),Int64(0),Double(20.0),
-Timestamp(Timestamp(3)),Int64(0),Double(30.0),
+tsid,ts,value1,
+Int64(0),Timestamp(Timestamp(1)),Double(10.0),
+Int64(0),Timestamp(Timestamp(2)),Double(20.0),
+Int64(0),Timestamp(Timestamp(3)),Double(30.0),
 
 
 SELECT

--- a/tests/cases/local/03_dml/case_insensitive.sql
+++ b/tests/cases/local/03_dml/case_insensitive.sql
@@ -24,11 +24,28 @@ SELECT
 FROM
     CASE_INSENSITIVE_TABLE1;
 
+SELECT
+    *
+FROM
+    `case_insensitive_table1`;
+
+SELECT
+    *
+FROM
+    `CASE_INSENSITIVE_TABLE1`;
 
 SHOW CREATE TABLE case_insensitive_table1;
 
 SHOW CREATE TABLE CASE_INSENSITIVE_TABLE1;
 
+SHOW CREATE TABLE `case_insensitive_table1`;
+
+SHOW CREATE TABLE `CASE_INSENSITIVE_TABLE1`;
+
 DESC case_insensitive_table1;
 
 DESC CASE_INSENSITIVE_TABLE1;
+
+DESC `case_insensitive_table1`;
+
+DESC `CASE_INSENSITIVE_TABLE1`;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
For #442 .
Now we convert table name to quoted style to prevent `datafusion` from converting it to lowercase. 

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
All changes are in `sql/src/parser.rs`.
Main steps:
+ extract the table name from `select ast`.
+ convert it to quoted style.
+ rebuild the `select ast`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Table name in ceresdb will be case-sensitive.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut and integrated test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
