### PR TITLE
chore: use default value for StorageOptions

### DIFF
--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -23,12 +23,12 @@ mod wal_synchronizer;
 #[cfg(any(test, feature = "test"))]
 pub mod tests;
 
-use common_util::config::{ReadableDuration, ReadableSize};
+use common_util::config::ReadableDuration;
 use message_queue::kafka::config::Config as KafkaConfig;
 use meta::details::Options as ManifestOptions;
 use serde::Serialize;
 use serde_derive::Deserialize;
-use storage_options::{LocalOptions, ObjectStoreOptions, StorageOptions};
+use storage_options::StorageOptions;
 use table_kv::config::ObkvConfig;
 use wal::{
     message_queue_impl::config::Config as MessageQueueWalConfig,
@@ -89,20 +89,9 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        let root_path = "/tmp/ceresdb".to_string();
-
         Self {
-            storage: StorageOptions {
-                mem_cache_capacity: ReadableSize::mb(512),
-                mem_cache_partition_bits: 1,
-                disk_cache_path: root_path.clone(),
-                disk_cache_capacity: ReadableSize::gb(5),
-                disk_cache_page_size: ReadableSize::mb(2),
-                object_store: ObjectStoreOptions::Local(LocalOptions {
-                    data_path: root_path.clone(),
-                }),
-            },
-            wal_path: root_path,
+            storage: Default::default(),
+            wal_path: "/tmp/ceresdb".to_string(),
             replay_batch_size: 500,
             max_replay_tables_per_batch: 64,
             write_group_worker_num: 8,

--- a/analytic_engine/src/storage_options.rs
+++ b/analytic_engine/src/storage_options.rs
@@ -5,6 +5,7 @@ use object_store::cache::CachedStoreConfig;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
 /// Options for storage backend
 pub struct StorageOptions {
     // 0 means disable mem cache
@@ -16,6 +17,23 @@ pub struct StorageOptions {
     pub disk_cache_page_size: ReadableSize,
     pub disk_cache_path: String,
     pub object_store: ObjectStoreOptions,
+}
+
+impl Default for StorageOptions {
+    fn default() -> Self {
+        let root_path = "/tmp/ceresdb".to_string();
+
+        StorageOptions {
+            mem_cache_capacity: ReadableSize::mb(512),
+            mem_cache_partition_bits: 1,
+            disk_cache_path: root_path.clone(),
+            disk_cache_capacity: ReadableSize::gb(5),
+            disk_cache_page_size: ReadableSize::mb(2),
+            object_store: ObjectStoreOptions::Local(LocalOptions {
+                data_path: root_path,
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
Use default value for StorageOptions, otherwise server will throw following errors when those options are not configured
```
thread 'main' panicked at 'Failed to parse config.: ParseToml { path: "/tmp/db.toml", source: Error { inner: ErrorInner { kind: Custom, line: Some(33), col: 0, at: Some(674), message: "missing field `disk_cache_capacity`", key: ["analytic", "storage"] } }, backtrace: Backtrace(   0: backtrace::backtrace::libunwind::trace
```
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->
No
# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Start server locally

