### PR TITLE
refactor: remove `enable_tsid_primary_key`

### DIFF
--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -749,7 +749,6 @@ mod tests {
     fn build_schema() -> Schema {
         Builder::new()
             .auto_increment_column_id(true)
-            .enable_tsid_primary_key(true)
             .add_key_column(
                 column_schema::Builder::new(TSID_COLUMN.to_string(), DatumKind::UInt64)
                     .build()

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -121,6 +121,12 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Primary key with tsid should only contains tsid and timestamp key.\nBacktrace:\n{}",
+        backtrace
+    ))]
+    InvalidPrimaryKeyWithTsid { backtrace: Backtrace },
+
+    #[snafu(display(
         "Invalid arrow schema key, key:{:?}, raw_value:{}, err:{:?}.\nBacktrace:\n{}",
         key,
         raw_value,
@@ -1129,6 +1135,12 @@ impl Builder {
         assert!(!self.primary_key_indexes.is_empty());
 
         let tsid_index = Self::find_tsid_index(&self.columns);
+        if tsid_index.is_some() {
+            ensure!(
+                self.primary_key_indexes.len() == 2,
+                InvalidPrimaryKeyWithTsid
+            );
+        }
 
         let fields = self.columns.iter().map(|c| c.to_arrow_field()).collect();
         let meta = self.build_arrow_schema_meta();

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -121,12 +121,6 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Invalid schema to generate tsid primary key.\nBacktrace:\n{}",
-        backtrace
-    ))]
-    InvalidTsidSchema { backtrace: Backtrace },
-
-    #[snafu(display(
         "Invalid arrow schema key, key:{:?}, raw_value:{}, err:{:?}.\nBacktrace:\n{}",
         key,
         raw_value,

--- a/interpreters/src/alter_table.rs
+++ b/interpreters/src/alter_table.rs
@@ -98,8 +98,7 @@ fn build_new_schema(current_schema: &Schema, column_schemas: Vec<ColumnSchema>) 
 
     builder = builder
         // Enable column id generation of the schema builder.
-        .auto_increment_column_id(true)
-        .enable_tsid_primary_key(current_schema.index_of_tsid().is_some());
+        .auto_increment_column_id(true);
 
     // Add new columns
     for mut column_schema in column_schemas {

--- a/proto/protos/common.proto
+++ b/proto/protos/common.proto
@@ -50,10 +50,8 @@ message TableSchema {
     uint32 version = 2;
     // Timestamp index in columns
     uint32 timestamp_index = 3;
-    // Enable auto generated tsid as primary key
-    bool enable_tsid_primary_key = 4;
     // Primary key index
-    repeated uint64 primary_key_indexes = 5;
+    repeated uint64 primary_key_indexes = 4;
 }
 
 // Time range of [start, end)

--- a/server/src/grpc/storage_service/mod.rs
+++ b/server/src/grpc/storage_service/mod.rs
@@ -627,7 +627,6 @@ fn build_schema_from_metric(schema_config: &SchemaConfig, metric: &WriteMetric) 
             })?;
 
     schema_builder = schema_builder
-        .enable_tsid_primary_key(true)
         .add_key_column(timestamp_column_schema)
         .map_err(|e| Box::new(e) as _)
         .context(ErrWithCause {

--- a/server/src/grpc/storage_service/prom_query.rs
+++ b/server/src/grpc/storage_service/prom_query.rs
@@ -339,7 +339,6 @@ mod tests {
     fn build_schema() -> schema::Schema {
         schema::Builder::new()
             .auto_increment_column_id(true)
-            .enable_tsid_primary_key(true)
             .add_key_column(
                 column_schema::Builder::new("timestamp".to_string(), DatumKind::Timestamp)
                     .build()

--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -348,13 +348,11 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
         primary_key_columns: &[Ident],
         mut columns_by_name: HashMap<&str, ColumnSchema>,
         column_idxs_by_name: HashMap<&str, usize>,
-        enable_tsid_primary_key: bool,
     ) -> Result<Schema> {
         assert_eq!(columns_by_name.len(), column_idxs_by_name.len());
 
-        let mut schema_builder = schema::Builder::with_capacity(columns_by_name.len())
-            .auto_increment_column_id(true)
-            .enable_tsid_primary_key(enable_tsid_primary_key);
+        let mut schema_builder =
+            schema::Builder::with_capacity(columns_by_name.len()).auto_increment_column_id(true);
 
         // Collect the key columns.
         for key_col in primary_key_columns {
@@ -482,13 +480,11 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
             Self::find_and_ensure_timestamp_column(&columns_by_name, &stmt.constraints)?;
         let tsid_column = Ident::with_quote(DEFAULT_QUOTE_CHAR, TSID_COLUMN);
         let mut columns: Vec<_> = stmt.columns.iter().map(|col| col.name.clone()).collect();
-        let mut enable_tsid_primary_key = false;
 
         let mut add_tsid_column = || {
             columns_by_name.insert(TSID_COLUMN, Self::tsid_column_schema()?);
             column_idxs_by_name.insert(TSID_COLUMN, columns.len());
             columns.push(tsid_column.clone());
-            enable_tsid_primary_key = true;
             Ok(())
         };
         let primary_key_columns =
@@ -519,7 +515,6 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
             &primary_key_columns,
             columns_by_name,
             column_idxs_by_name,
-            enable_tsid_primary_key,
         )?;
 
         let options = parse_options(stmt.options)?;
@@ -1089,7 +1084,6 @@ mod tests {
         table_schema: Schema {
             timestamp_index: 1,
             tsid_index: None,
-            enable_tsid_primary_key: false,
             column_schemas: ColumnSchemas {
                 columns: [
                     ColumnSchema {
@@ -1257,7 +1251,6 @@ mod tests {
             schema: Schema {
                 timestamp_index: 1,
                 tsid_index: None,
-                enable_tsid_primary_key: false,
                 column_schemas: ColumnSchemas {
                     columns: [
                         ColumnSchema {
@@ -1313,7 +1306,6 @@ mod tests {
             schema: Schema {
                 timestamp_index: 1,
                 tsid_index: None,
-                enable_tsid_primary_key: false,
                 column_schemas: ColumnSchemas {
                     columns: [
                         ColumnSchema {
@@ -1450,7 +1442,6 @@ mod tests {
             schema: Schema {
                 timestamp_index: 1,
                 tsid_index: None,
-                enable_tsid_primary_key: false,
                 column_schemas: ColumnSchemas {
                     columns: [
                         ColumnSchema {
@@ -1526,7 +1517,6 @@ mod tests {
             schema: Schema {
                 timestamp_index: 1,
                 tsid_index: None,
-                enable_tsid_primary_key: false,
                 column_schemas: ColumnSchemas {
                     columns: [
                         ColumnSchema {
@@ -1616,7 +1606,6 @@ mod tests {
             schema: Schema {
                 timestamp_index: 1,
                 tsid_index: None,
-                enable_tsid_primary_key: false,
                 column_schemas: ColumnSchemas {
                     columns: [
                         ColumnSchema {
@@ -1698,7 +1687,6 @@ mod tests {
                 schema: Schema {
                     timestamp_index: 1,
                     tsid_index: None,
-                    enable_tsid_primary_key: false,
                     column_schemas: ColumnSchemas {
                         columns: [
                             ColumnSchema {

--- a/tests/cases/local/05_ddl/create_tables.result
+++ b/tests/cases/local/05_ddl/create_tables.result
@@ -221,17 +221,15 @@ affected_rows: 0
 
 CREATE TABLE `05_create_tables_t12`(c1 int not null, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(tsid, t1, c1)) ENGINE = Analytic;
 
-affected_rows: 0
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: CREATE TABLE `05_create_tables_t12`(c1 int not null, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(tsid, t1, c1)) ENGINE = Analytic;. Caused by: Failed to create plan, err:Failed to build schema, err:Primary key with tsid should only contains tsid and timestamp key." })
 
 show create table `05_create_tables_t12`;
 
-Table,Create Table,
-String(StringBytes(b"05_create_tables_t12")),String(StringBytes(b"CREATE TABLE `05_create_tables_t12` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int NOT NULL, PRIMARY KEY(tsid,t1,c1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
-
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: show create table `05_create_tables_t12`;. Caused by: Failed to create plan, err:Table not found, table:05_create_tables_t12" })
 
 drop table `05_create_tables_t12`;
 
-affected_rows: 0
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: drop table `05_create_tables_t12`;. Caused by: Failed to create plan, err:Table not found, table:05_create_tables_t12" })
 
 DROP TABLE IF EXISTS `05_create_tables_t`;
 

--- a/tests/cases/local/05_ddl/create_tables.result
+++ b/tests/cases/local/05_ddl/create_tables.result
@@ -219,6 +219,20 @@ drop table `05_create_tables_t11`;
 
 affected_rows: 0
 
+CREATE TABLE `05_create_tables_t12`(c1 int not null, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(tsid, t1, c1)) ENGINE = Analytic;
+
+affected_rows: 0
+
+show create table `05_create_tables_t12`;
+
+Table,Create Table,
+String(StringBytes(b"05_create_tables_t12")),String(StringBytes(b"CREATE TABLE `05_create_tables_t12` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int NOT NULL, PRIMARY KEY(tsid,t1,c1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+
+
+drop table `05_create_tables_t12`;
+
+affected_rows: 0
+
 DROP TABLE IF EXISTS `05_create_tables_t`;
 
 affected_rows: 0
@@ -260,6 +274,10 @@ DROP TABLE IF EXISTS `05_create_tables_t10`;
 affected_rows: 0
 
 DROP TABLE IF EXISTS `05_create_tables_t11`;
+
+affected_rows: 0
+
+DROP TABLE IF EXISTS `05_create_tables_t12`;
 
 affected_rows: 0
 

--- a/tests/cases/local/05_ddl/create_tables.sql
+++ b/tests/cases/local/05_ddl/create_tables.sql
@@ -79,6 +79,10 @@ CREATE TABLE `05_create_tables_t11`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY,
 show create table `05_create_tables_t11`;
 drop table `05_create_tables_t11`;
 
+CREATE TABLE `05_create_tables_t12`(c1 int not null, t1 timestamp NOT NULL TIMESTAMP KEY, PRIMARY KEY(tsid, t1, c1)) ENGINE = Analytic;
+show create table `05_create_tables_t12`;
+drop table `05_create_tables_t12`;
+
 DROP TABLE IF EXISTS `05_create_tables_t`;
 DROP TABLE IF EXISTS `05_create_tables_t2`;
 DROP TABLE IF EXISTS `05_create_tables_t3`;
@@ -90,3 +94,4 @@ DROP TABLE IF EXISTS `05_create_tables_t8`;
 DROP TABLE IF EXISTS `05_create_tables_t9`;
 DROP TABLE IF EXISTS `05_create_tables_t10`;
 DROP TABLE IF EXISTS `05_create_tables_t11`;
+DROP TABLE IF EXISTS `05_create_tables_t12`;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Currently, the field in the schema `enable_tsid_primary_key` is useless. Let's remove it.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Remove `enable_tsid_primary_key` field in the schema.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
This will lead to breaking change for that the field `enable_tsid_primary_key` is part of the format of stored schema.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
