### PR TITLE
feat: make rocksdb wal compatible with other distributed implementation

### DIFF
--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -769,7 +769,7 @@ mod tests {
     use common_util::{runtime, runtime::Runtime, tests::init_log_for_test};
     use futures::future::BoxFuture;
     use table_engine::table::{SchemaId, TableId, TableSeqGenerator};
-    use wal::{manager::VersionedRegionId, rocks_impl::manager::Builder as WalBuilder};
+    use wal::rocks_impl::manager::Builder as WalBuilder;
 
     use super::*;
     use crate::{
@@ -857,18 +857,10 @@ mod tests {
         }
 
         async fn open_manifest(&self) -> ManifestImpl {
-            let versioned_region_id = VersionedRegionId {
-                version: DEFAULT_CLUSTER_VERSION,
-                id: DEFAULT_SHARD_ID as RegionId,
-            };
-
-            let manifest_wal = WalBuilder::with_default_rocksdb_config(
-                self.dir.clone(),
-                self.runtime.clone(),
-                versioned_region_id,
-            )
-            .build()
-            .unwrap();
+            let manifest_wal =
+                WalBuilder::with_default_rocksdb_config(self.dir.clone(), self.runtime.clone())
+                    .build()
+                    .unwrap();
 
             ManifestImpl::open(Arc::new(manifest_wal), self.options.clone())
                 .await

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -119,6 +119,9 @@ pub mod error {
 
         #[snafu(display("Failed to execute in runtime, err:{}", source))]
         RuntimeExec { source: common_util::runtime::Error },
+
+        #[snafu(display("Encountered Unknown error, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
+        Unknown { msg: String, backtrace: Backtrace },
     }
 
     define_result!(Error);

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -120,7 +120,7 @@ pub mod error {
         #[snafu(display("Failed to execute in runtime, err:{}", source))]
         RuntimeExec { source: common_util::runtime::Error },
 
-        #[snafu(display("Encountered Unknown error, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
+        #[snafu(display("Encountered unknown error, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
         Unknown { msg: String, backtrace: Backtrace },
     }
 

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -280,13 +280,6 @@ impl RocksImpl {
         &self,
         table_max_seqs: &mut HashMap<TableId, SequenceNumber>,
     ) -> Result<()> {
-        self.find_table_seqs_from_table_log_by_region_id(table_max_seqs)
-    }
-
-    fn find_table_seqs_from_table_log_by_region_id(
-        &self,
-        table_max_seqs: &mut HashMap<TableId, SequenceNumber>,
-    ) -> Result<()> {
         let mut current_region_id = RegionId::MAX;
         let mut end_boundary_key_buf = BytesMut::new();
         loop {
@@ -333,7 +326,7 @@ impl RocksImpl {
                 .map_err(|e| Box::new(e) as _)
                 .context(Decoding)?;
 
-            // Found a valid log key by `current_region_id`, search table sequences by table
+            // The max valid log key in a region is found, search table sequences by table
             // id.
             debug!(
                 "RocksImpl has found log key by region id, log key:{:?}",
@@ -407,10 +400,12 @@ impl RocksImpl {
             );
 
             if log_key.region_id != region_id {
-                debug!("RocksImpl find table unit pairs stop scanning by table id, because has encountered next region id,
-                    searching table id:{}
-                    current region id:{},
-                    next region id:{}", current_table_id, region_id, log_key.region_id);
+                debug!(
+                    "RocksImpl find table unit pairs stop scanning by table id,
+                    because has encountered next region id,
+                    searching table id:{}, current region id:{}, next region id:{}",
+                    current_table_id, region_id, log_key.region_id
+                );
                 break;
             }
 

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -12,7 +12,7 @@ use std::{
 use async_trait::async_trait;
 use common_types::{
     bytes::{BufMut, SafeBuf, SafeBufMut},
-    table::{TableId, DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
+    table::TableId,
     SequenceNumber,
 };
 use common_util::{
@@ -27,8 +27,7 @@ use tempfile::TempDir;
 use crate::{
     log_batch::{LogWriteBatch, Payload, PayloadDecoder},
     manager::{
-        BatchLogIteratorAdapter, ReadContext, RegionId, VersionedRegionId, WalLocation, WalManager,
-        WalManagerRef, WriteContext,
+        BatchLogIteratorAdapter, ReadContext, WalLocation, WalManager, WalManagerRef, WriteContext,
     },
     message_queue_impl::{config::Config, wal::MessageQueueImpl},
     rocks_impl::{self, manager::RocksImpl},
@@ -53,15 +52,8 @@ impl WalBuilder for RocksWalBuilder {
     type Wal = RocksImpl;
 
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
-        let versioned_region_id = VersionedRegionId {
-            version: DEFAULT_CLUSTER_VERSION,
-            id: DEFAULT_SHARD_ID as RegionId,
-        };
-        let wal_builder = rocks_impl::manager::Builder::with_default_rocksdb_config(
-            data_path,
-            runtime,
-            versioned_region_id,
-        );
+        let wal_builder =
+            rocks_impl::manager::Builder::with_default_rocksdb_config(data_path, runtime);
 
         Arc::new(
             wal_builder


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Now, If you write log with a not default region id in key, you will be unable to recover it when you restart the database(use a rocksdb based wal). It make no sense, so we should adjust the recover process in rocksdb based wal.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Adjust the recover process in rocksdb based wal.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
