### PR TITLE
fix: kill ceresdb-server if run harness failed

### DIFF
--- a/tests/harness/src/main.rs
+++ b/tests/harness/src/main.rs
@@ -2,6 +2,8 @@
 
 #![feature(try_blocks)]
 
+use std::ops::Deref;
+
 use anyhow::Result;
 use runner::Runner;
 use setup::Environment;
@@ -10,14 +12,31 @@ mod case;
 mod runner;
 mod setup;
 
+/// A guard used for auto server stopping for environment.
+struct EnvGuard(Environment);
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        self.0.stop_server()
+    }
+}
+
+impl Deref for EnvGuard {
+    type Target = Environment;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    let env = Environment::start_server();
+    let env = EnvGuard(Environment::start_server());
     let client = env.build_client();
     let cases = env.get_case_path();
     let runner = Runner::new(cases, client);
+
     runner.run().await?;
-    env.stop_server();
 
     Ok(())
 }

--- a/tests/harness/src/setup.rs
+++ b/tests/harness/src/setup.rs
@@ -63,7 +63,7 @@ impl Environment {
         })
     }
 
-    pub fn stop_server(mut self) {
+    pub fn stop_server(&mut self) {
         self.server_process.kill().unwrap();
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Currently, the `ceresdb-server` won't exit if the harness test fails.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Kill the `ceresdb-server` whether the harness test succeeds or not.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No confusion when running harness test locally.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
