### PR TITLE
feat: make pulling single sst file concurrent

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -898,6 +898,7 @@ impl SpaceStore {
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: self.meta_cache.clone(),
                 runtime: runtime.clone(),
+                row_group_num_per_reader: usize::MAX,
             };
             let mut builder = MergeBuilder::new(MergeConfig {
                 request_id,

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -160,6 +160,7 @@ impl Instance {
             predicate: request.predicate.clone(),
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
+            row_group_num_per_reader: request.opts.row_group_num_per_sst_reader,
         };
 
         let time_range = request.predicate.time_range();
@@ -220,6 +221,7 @@ impl Instance {
             predicate: request.predicate.clone(),
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
+            row_group_num_per_reader: request.opts.row_group_num_per_sst_reader,
         };
 
         let time_range = request.predicate.time_range();

--- a/analytic_engine/src/row_iter/chain.rs
+++ b/analytic_engine/src/row_iter/chain.rs
@@ -138,7 +138,7 @@ impl<'a> Builder<'a> {
 
         for leveled_ssts in &self.ssts {
             for sst in leveled_ssts {
-                let stream = record_batch_stream::filtered_stream_from_sst_file(
+                let sst_streams = record_batch_stream::filtered_stream_from_sst_file(
                     self.config.space_id,
                     self.config.table_id,
                     sst,
@@ -148,7 +148,7 @@ impl<'a> Builder<'a> {
                 )
                 .await
                 .context(BuildStreamFromSst)?;
-                streams.push(stream);
+                streams.extend(sst_streams);
             }
         }
 

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -202,7 +202,7 @@ impl<'a> MergeBuilder<'a> {
         let mut sst_ids = Vec::with_capacity(self.ssts.len());
         for leveled_ssts in &self.ssts {
             for f in leveled_ssts {
-                let stream = record_batch_stream::filtered_stream_from_sst_file(
+                let sst_streams = record_batch_stream::filtered_stream_from_sst_file(
                     self.config.space_id,
                     self.config.table_id,
                     f,
@@ -212,7 +212,7 @@ impl<'a> MergeBuilder<'a> {
                 )
                 .await
                 .context(BuildStreamFromSst)?;
-                streams.push(stream);
+                streams.extend(sst_streams);
                 sst_ids.push(f.id());
             }
         }

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -52,6 +52,7 @@ pub struct SstReaderOptions {
     pub predicate: PredicateRef,
     pub meta_cache: Option<MetaCacheRef>,
     pub runtime: Arc<Runtime>,
+    pub row_group_num_per_reader: usize,
 }
 
 #[derive(Debug, Clone)]

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -372,6 +372,7 @@ mod tests {
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: None,
                 runtime: runtime.clone(),
+                row_group_num_per_reader: usize::MAX,
             };
 
             let mut reader: Box<dyn SstReader + Send> = if async_reader {
@@ -423,14 +424,14 @@ mod tests {
                 Box::new(reader)
             };
 
-            let mut stream = reader.read().await.unwrap();
+            let mut streams = reader.read().await.unwrap();
             let mut expect_rows = vec![];
             for counter in &[4, 3, 2, 1, 0] {
                 expect_rows.push(build_row(b"a", 100 + counter, 10.0, "v4"));
                 expect_rows.push(build_row(b"b", 100 + counter, 10.0, "v4"));
                 expect_rows.push(build_row(b"c", 100 + counter, 10.0, "v4"));
             }
-            check_stream(&mut stream, expect_rows).await;
+            check_stream(streams.get_mut(0).unwrap(), expect_rows).await;
         });
     }
 

--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -385,7 +385,7 @@ impl<'a> SstReader for ParquetSstReader<'a> {
     // TODO(yingwen): Project the schema in parquet
     async fn read(
         &mut self,
-    ) -> Result<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>> {
+    ) -> Result<Vec<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>>> {
         debug!(
             "read sst:{}, projected_schema:{:?}, predicate:{:?}",
             self.path.to_string(),
@@ -397,6 +397,6 @@ impl<'a> SstReader for ParquetSstReader<'a> {
         let (tx, rx) = mpsc::channel::<Result<RecordBatchWithKey>>(self.channel_cap);
         self.read_record_batches(tx)?;
 
-        Ok(Box::new(RecordBatchReceiver { rx }))
+        Ok(vec![Box::new(RecordBatchReceiver { rx }) as _])
     }
 }

--- a/analytic_engine/src/sst/reader.rs
+++ b/analytic_engine/src/sst/reader.rs
@@ -86,7 +86,7 @@ pub trait SstReader {
 
     async fn read(
         &mut self,
-    ) -> Result<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>>;
+    ) -> Result<Vec<Box<dyn Stream<Item = Result<RecordBatchWithKey>> + Send + Unpin>>>;
 }
 
 #[cfg(test)]

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -154,18 +154,22 @@ pub fn read_opts_list() -> Vec<ReadOptions> {
         ReadOptions {
             batch_size: 1,
             read_parallelism: 1,
+            row_group_num_per_sst_reader: usize::MAX,
         },
         ReadOptions {
             batch_size: 1,
             read_parallelism: 4,
+            row_group_num_per_sst_reader: usize::MAX,
         },
         ReadOptions {
             batch_size: 100,
             read_parallelism: 1,
+            row_group_num_per_sst_reader: usize::MAX,
         },
         ReadOptions {
             batch_size: 100,
             read_parallelism: 4,
+            row_group_num_per_sst_reader: usize::MAX,
         },
     ]
 }

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -197,5 +197,6 @@ fn mock_sst_reader_options(
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
+        row_group_num_per_reader: usize::MAX,
     }
 }

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -66,6 +66,7 @@ impl MergeSstBench {
             predicate,
             meta_cache: meta_cache.clone(),
             runtime: runtime.clone(),
+            row_group_num_per_reader: usize::MAX,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -45,6 +45,7 @@ impl SstBench {
             predicate,
             meta_cache,
             runtime: runtime.clone(),
+            row_group_num_per_reader: usize::MAX,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 
@@ -80,7 +81,7 @@ impl SstBench {
 
         self.runtime.block_on(async {
             let begin_instant = Instant::now();
-            let mut sst_stream = sst_reader.read().await.unwrap();
+            let mut sst_stream = sst_reader.read().await.unwrap().pop().unwrap();
 
             let mut total_rows = 0;
             let mut batch_num = 0;

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -99,6 +99,7 @@ pub async fn rebuild_sst(config: RebuildSstConfig, runtime: Arc<Runtime>) {
         predicate: config.predicate.into_predicate(),
         meta_cache: None,
         runtime,
+        row_group_num_per_reader: usize::MAX,
     };
 
     let record_batch_stream =
@@ -127,7 +128,7 @@ async fn sst_to_record_batch_stream(
         .new_sst_reader(sst_reader_options, input_path, store)
         .unwrap();
 
-    let sst_stream = sst_reader.read().await.unwrap();
+    let sst_stream = sst_reader.read().await.unwrap().pop().unwrap();
 
     Box::new(sst_stream.map_err(|e| Box::new(e) as _))
 }
@@ -198,6 +199,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
             predicate: config.predicate.into_predicate(),
             meta_cache: None,
             runtime: runtime.clone(),
+            row_group_num_per_reader: usize::MAX,
         };
 
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -103,13 +103,14 @@ pub async fn load_sst_to_memtable(
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
+        row_group_num_per_reader: usize::MAX,
     };
     let sst_factory = FactoryImpl;
     let mut sst_reader = sst_factory
         .new_sst_reader(&sst_reader_options, sst_path, store)
         .unwrap();
 
-    let mut sst_stream = sst_reader.read().await.unwrap();
+    let mut sst_stream = sst_reader.read().await.unwrap().pop().unwrap();
     let index_in_writer = IndexInWriterSchema::for_same_schema(schema.num_columns());
     let mut ctx = PutContext::new(index_in_writer);
 

--- a/common_types/src/projected_schema.rs
+++ b/common_types/src/projected_schema.rs
@@ -40,7 +40,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RowProjector {
     schema_with_key: RecordSchemaWithKey,
     source_schema: Schema,

--- a/common_types/src/record_batch.rs
+++ b/common_types/src/record_batch.rs
@@ -544,7 +544,7 @@ impl RecordBatchWithKeyBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ArrowRecordBatchProjector {
     row_projector: RowProjector,
 }

--- a/table_engine/src/provider.rs
+++ b/table_engine/src/provider.rs
@@ -217,6 +217,7 @@ impl ScanTable {
             opts: ReadOptions {
                 batch_size: state.config.config_options.get_u64(OPT_BATCH_SIZE) as usize,
                 read_parallelism: self.read_parallelism,
+                row_group_num_per_sst_reader: usize::MAX,
             },
             projected_schema: self.projected_schema.clone(),
             predicate: self.predicate.clone(),

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -279,6 +279,7 @@ pub struct ReadOptions {
     /// Suggested read parallelism, the actual returned stream should equal to
     /// `read_parallelism`.
     pub read_parallelism: usize,
+    pub row_group_num_per_sst_reader: usize,
 }
 
 impl Default for ReadOptions {
@@ -286,6 +287,7 @@ impl Default for ReadOptions {
         Self {
             batch_size: 10000,
             read_parallelism: DEFAULT_READ_PARALLELISM,
+            row_group_num_per_sst_reader: usize::MAX,
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Now, the concurrent level while pulling sst data is on `file` level, we can enhance it to `row group` level. 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
+ Prefetch, see http://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
