### PR TITLE
feat: scan row groups in one sst file parallelly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "prometheus 0.12.0",
  "prost",
  "proto 1.0.0-alpha01",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "skiplist",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
  "prometheus 0.12.0",
  "prost",
  "proto 1.0.0-alpha01",
- "rand 0.8.5",
+ "rand 0.7.3",
  "serde",
  "serde_derive",
  "skiplist",
@@ -834,6 +834,7 @@ dependencies = [
  "query_engine",
  "server",
  "signal-hook",
+ "sort",
  "table_engine",
  "tracing_util",
  "vergen",
@@ -5464,6 +5465,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "sort"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b736394cbcbad245669dc12a0caff9b2570e9ad81ce9906f5d7831551cb0c5"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ meta_client = { workspace = true }
 query_engine = { workspace = true }
 server = { workspace = true }
 signal-hook = "0.3"
+sort = "0.8.5"
 table_engine = { workspace = true }
 tracing_util = { workspace = true }
 

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -51,5 +51,5 @@ wal = { workspace = true }
 common_types = { workspace = true, features = ["test"] }
 common_util = { workspace = true, features = ["test"] }
 env_logger = { workspace = true }
+rand = { workspace = true }
 wal = { workspace = true, features = ["test"] }
-rand = "0.8.5"

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -52,3 +52,4 @@ common_types = { workspace = true, features = ["test"] }
 common_util = { workspace = true, features = ["test"] }
 env_logger = { workspace = true }
 wal = { workspace = true, features = ["test"] }
+rand = "0.8.5"

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -918,6 +918,7 @@ impl SpaceStore {
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: self.meta_cache.clone(),
                 runtime: runtime.clone(),
+                read_parallelism: 1,
             };
             let mut builder = MergeBuilder::new(MergeConfig {
                 request_id,

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -918,7 +918,7 @@ impl SpaceStore {
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: self.meta_cache.clone(),
                 runtime: runtime.clone(),
-                read_parallelism: 1,
+                background_read_parallelism: 1,
             };
             let mut builder = MergeBuilder::new(MergeConfig {
                 request_id,

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -919,6 +919,7 @@ impl SpaceStore {
                 meta_cache: self.meta_cache.clone(),
                 runtime: runtime.clone(),
                 background_read_parallelism: 1,
+                num_rows_per_row_group: table_options.num_rows_per_row_group,
             };
             let mut builder = MergeBuilder::new(MergeConfig {
                 request_id,

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -33,6 +33,7 @@ use wal::manager::WalManagerRef;
 use crate::{
     compaction::scheduler::CompactionSchedulerRef,
     meta::ManifestRef,
+    row_iter::IterOptions,
     space::{SpaceId, SpaceRef},
     sst::{factory::FactoryRef as SstFactoryRef, file::FilePurger, meta_cache::MetaCacheRef},
     table::data::TableDataRef,
@@ -170,10 +171,10 @@ pub struct Instance {
     pub(crate) db_write_buffer_size: usize,
     /// Space write buffer size
     pub(crate) space_write_buffer_size: usize,
-    /// replay wal batch size
+    /// Replay wal batch size
     pub(crate) replay_batch_size: usize,
-    /// batch size for scan sst
-    pub(crate) scan_batch_size: usize,
+    /// Options for scanning sst
+    pub(crate) iter_options: IterOptions,
 }
 
 impl Instance {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -34,6 +34,7 @@ use crate::{
     },
     meta::{meta_data::TableManifestData, ManifestRef},
     payload::{ReadPayload, WalDecoder},
+    row_iter::IterOptions,
     space::{Space, SpaceId, SpaceRef},
     sst::{factory::FactoryRef as SstFactoryRef, file::FilePurger},
     table::data::{TableData, TableDataRef},
@@ -72,6 +73,11 @@ impl Instance {
             WalSynchronizer::new(WalSynchronizerConfig::default(), wal_manager);
         wal_synchronizer.start(&bg_runtime).await;
 
+        let iter_options = IterOptions {
+            batch_size: ctx.config.scan_batch_size,
+            sst_background_read_parallelism: ctx.config.sst_background_read_parallelism,
+        };
+
         let instance = Arc::new(Instance {
             space_store,
             runtimes: ctx.runtimes.clone(),
@@ -86,7 +92,7 @@ impl Instance {
             db_write_buffer_size: ctx.config.db_write_buffer_size,
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
-            scan_batch_size: ctx.config.scan_batch_size,
+            iter_options,
         });
 
         Ok(instance)

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -160,7 +160,7 @@ impl Instance {
             predicate: request.predicate.clone(),
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
-            read_parallelism: iter_options.sst_background_read_parallelism,
+            background_read_parallelism: iter_options.sst_background_read_parallelism,
         };
 
         let time_range = request.predicate.time_range();
@@ -222,7 +222,7 @@ impl Instance {
             predicate: request.predicate.clone(),
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
-            read_parallelism: iter_options.sst_background_read_parallelism,
+            background_read_parallelism: iter_options.sst_background_read_parallelism,
         };
 
         let time_range = request.predicate.time_range();

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -161,6 +161,7 @@ impl Instance {
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
             background_read_parallelism: iter_options.sst_background_read_parallelism,
+            num_rows_per_row_group: table_options.num_rows_per_row_group,
         };
 
         let time_range = request.predicate.time_range();
@@ -223,6 +224,7 @@ impl Instance {
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
             background_read_parallelism: iter_options.sst_background_read_parallelism,
+            num_rows_per_row_group: table_options.num_rows_per_row_group,
         };
 
         let time_range = request.predicate.time_range();

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -111,7 +111,7 @@ impl Default for Config {
             /// it.
             db_write_buffer_size: 0,
             scan_batch_size: 500,
-            sst_background_read_parallelism: 1,
+            sst_background_read_parallelism: 4,
             wal_storage: WalStorageConfig::RocksDB,
         }
     }

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -111,7 +111,7 @@ impl Default for Config {
             /// it.
             db_write_buffer_size: 0,
             scan_batch_size: 500,
-            sst_background_read_parallelism: 4,
+            sst_background_read_parallelism: 8,
             wal_storage: WalStorageConfig::RocksDB,
         }
     }

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -73,10 +73,13 @@ pub struct Config {
     pub space_write_buffer_size: usize,
     /// The maximum size of all Write Buffers across all spaces.
     pub db_write_buffer_size: usize,
-    // End of global write buffer options.
+    /// End of global write buffer options.
 
-    // Batch size for scan sst
+    // Iterator scanning options
+    /// Batch size for iterator
     pub scan_batch_size: usize,
+    /// Sst background reading parallelism
+    pub sst_background_read_parallelism: usize,
 
     /// Wal storage config
     ///
@@ -108,6 +111,7 @@ impl Default for Config {
             /// it.
             db_write_buffer_size: 0,
             scan_batch_size: 500,
+            sst_background_read_parallelism: 1,
             wal_storage: WalStorageConfig::RocksDB,
         }
     }

--- a/analytic_engine/src/row_iter/mod.rs
+++ b/analytic_engine/src/row_iter/mod.rs
@@ -28,17 +28,21 @@ const RECORD_BATCH_READ_BUF_SIZE: usize = 10;
 #[derive(Debug, Clone)]
 pub struct IterOptions {
     pub batch_size: usize,
+    pub sst_background_read_parallelism: usize,
 }
 
 impl IterOptions {
-    pub fn new(batch_size: usize) -> Self {
-        Self { batch_size }
+    pub fn new(batch_size: usize, sst_background_read_parallelism: usize) -> Self {
+        Self {
+            batch_size,
+            sst_background_read_parallelism,
+        }
     }
 }
 
 impl Default for IterOptions {
     fn default() -> Self {
-        Self::new(500)
+        Self::new(500, 1)
     }
 }
 

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -54,7 +54,7 @@ pub struct SstReaderOptions {
     pub runtime: Arc<Runtime>,
 
     /// The parallelism while reading sst
-    pub read_parallelism: usize,
+    pub background_read_parallelism: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -84,7 +84,7 @@ impl Factory for FactoryImpl {
                     let reader = ThreadedReader::new(
                         reader,
                         options.runtime.clone(),
-                        options.read_parallelism,
+                        options.background_read_parallelism,
                     );
                     Some(Box::new(reader))
                 }

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -53,7 +53,10 @@ pub struct SstReaderOptions {
     pub meta_cache: Option<MetaCacheRef>,
     pub runtime: Arc<Runtime>,
 
-    /// The parallelism while reading sst
+    /// The max number of rows in one row group
+    pub num_rows_per_row_group: usize,
+
+    /// The suggested parallelism while reading sst
     pub background_read_parallelism: usize,
 }
 

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -52,6 +52,9 @@ pub struct SstReaderOptions {
     pub predicate: PredicateRef,
     pub meta_cache: Option<MetaCacheRef>,
     pub runtime: Arc<Runtime>,
+
+    /// The parallelism while reading sst
+    pub read_parallelism: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -78,7 +81,11 @@ impl Factory for FactoryImpl {
                     Some(Box::new(ParquetSstReader::new(path, storage, options)))
                 } else {
                     let reader = AsyncParquetReader::new(path, storage, options);
-                    let reader = ThreadedReader::new(reader, options.runtime.clone());
+                    let reader = ThreadedReader::new(
+                        reader,
+                        options.runtime.clone(),
+                        options.read_parallelism,
+                    );
                     Some(Box::new(reader))
                 }
             }

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -20,7 +20,7 @@ use common_types::{
 use common_util::{runtime::Runtime, time::InstantExt};
 use datafusion::datasource::file_format;
 use futures::{future::BoxFuture, FutureExt, Stream, StreamExt, TryFutureExt};
-use log::{debug, error, info};
+use log::{error, info};
 use object_store::{ObjectMeta, ObjectStoreRef, Path};
 use parquet::{
     arrow::{async_reader::AsyncFileReader, ParquetRecordBatchStreamBuilder, ProjectionMask},
@@ -457,8 +457,13 @@ impl Stream for RecordBatchReceiver {
         let cur_rx = self.rx_group.get_mut(cur_rx_idx).unwrap();
         let poll_result = cur_rx.poll_recv(cx);
 
-        self.cur_rx_idx = (self.cur_rx_idx + 1) % self.rx_group.len();
-        poll_result
+        match poll_result {
+            Poll::Ready(result) => {
+                self.cur_rx_idx = (self.cur_rx_idx + 1) % self.rx_group.len();
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -534,5 +539,115 @@ impl<'a> SstReader for ThreadedReader<'a> {
             rx_group,
             cur_rx_idx: 0,
         }) as _)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        pin::Pin,
+        task::{Context, Poll},
+        time::Duration,
+    };
+
+    use futures::{Stream, StreamExt};
+    use tokio::sync::mpsc::{self, Receiver, Sender};
+
+    struct MockReceivers {
+        rx_group: Vec<Receiver<u32>>,
+        cur_rx_idx: usize,
+    }
+
+    impl Stream for MockReceivers {
+        type Item = u32;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let cur_rx_idx = self.cur_rx_idx;
+            // `cur_rx_idx` is impossible to be out-of-range, because it is got by round
+            // robin.
+            let cur_rx = self.rx_group.get_mut(cur_rx_idx).unwrap();
+            let poll_result = cur_rx.poll_recv(cx);
+
+            match poll_result {
+                Poll::Ready(result) => {
+                    self.cur_rx_idx = (self.cur_rx_idx + 1) % self.rx_group.len();
+                    Poll::Ready(result)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (0, None)
+        }
+    }
+
+    struct MockRandomSenders {
+        tx_group: Vec<Sender<u32>>,
+        test_datas: Vec<Vec<u32>>,
+    }
+
+    impl MockRandomSenders {
+        fn start_to_send(&mut self) {
+            while !self.tx_group.is_empty() {
+                let tx = self.tx_group.pop().unwrap();
+                let test_data = self.test_datas.pop().unwrap();
+                tokio::spawn(async move {
+                    for datum in test_data {
+                        let random_millis = rand::random::<u64>() % 30;
+                        tokio::time::sleep(Duration::from_millis(random_millis)).await;
+                        tx.send(datum).await.unwrap();
+                    }
+                });
+            }
+        }
+    }
+
+    fn gen_test_data(amount: usize) -> Vec<u32> {
+        (0..amount)
+            .into_iter()
+            .map(|_| rand::random::<u32>())
+            .collect()
+    }
+
+    // We mock a thread model same as the one in `ThreadedReader` to check its
+    // validity.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_simulated_threaded_reader() {
+        let test_data = gen_test_data(123);
+        let expected = test_data.clone();
+        let channel_cap_per_sub_reader = 10;
+        let reader_num = 5;
+        let (tx_group, rx_group): (Vec<_>, Vec<_>) = (0..reader_num)
+            .into_iter()
+            .map(|_| mpsc::channel::<u32>(channel_cap_per_sub_reader))
+            .unzip();
+
+        // Partition datas.
+        let chunk_len = reader_num;
+        let mut test_data_chunks = vec![Vec::new(); chunk_len];
+        for (idx, datum) in test_data.into_iter().enumerate() {
+            let chunk_idx = idx % chunk_len;
+            test_data_chunks.get_mut(chunk_idx).unwrap().push(datum);
+        }
+
+        // Start senders.
+        let mut mock_senders = MockRandomSenders {
+            tx_group,
+            test_datas: test_data_chunks,
+        };
+        mock_senders.start_to_send();
+
+        // Poll receivers.
+        let mut actual = Vec::new();
+        let mut mock_receivers = MockReceivers {
+            rx_group,
+            cur_rx_idx: 0,
+        };
+        while let Some(datum) = mock_receivers.next().await {
+            actual.push(datum);
+        }
+
+        assert_eq!(actual, expected);
     }
 }

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -142,7 +142,7 @@ impl<'a> Reader<'a> {
             &meta_data.custom().bloom_filter,
         )?;
 
-        debug!(
+        info!(
             "fetch_record_batch row_groups total:{}, after filter:{}, row_group_num_per_reader:{}",
             meta_data.parquet().num_row_groups(),
             filtered_row_groups.len(),

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -365,6 +365,7 @@ mod tests {
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: None,
                 runtime: runtime.clone(),
+                num_rows_per_row_group: 5,
                 background_read_parallelism: 1,
             };
 

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -365,7 +365,7 @@ mod tests {
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: None,
                 runtime: runtime.clone(),
-                read_parallelism: 1,
+                background_read_parallelism: 1,
             };
 
             let mut reader: Box<dyn SstReader + Send> = if async_reader {

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -365,6 +365,7 @@ mod tests {
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: None,
                 runtime: runtime.clone(),
+                read_parallelism: 1,
             };
 
             let mut reader: Box<dyn SstReader + Send> = if async_reader {

--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -143,6 +143,7 @@ impl<'a> ParquetSstReader<'a> {
         Ok(())
     }
 
+    // This method is not used since we are in favor of `maybe_read_parallelly` now.
     fn read_record_batches(&mut self, tx: Sender<Result<RecordBatchWithKey>>) -> Result<()> {
         let path = self.path.to_string();
         ensure!(self.reader_builder.is_some(), ReadAgain { path });

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -198,5 +198,6 @@ fn mock_sst_reader_options(
         meta_cache: None,
         runtime,
         background_read_parallelism: 1,
+        num_rows_per_row_group: 500,
     }
 }

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -197,5 +197,6 @@ fn mock_sst_reader_options(
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
+        read_parallelism: 1,
     }
 }

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -197,6 +197,6 @@ fn mock_sst_reader_options(
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
-        read_parallelism: 1,
+        background_read_parallelism: 1,
     }
 }

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -67,6 +67,7 @@ impl MergeSstBench {
             meta_cache: meta_cache.clone(),
             runtime: runtime.clone(),
             background_read_parallelism: 1,
+            num_rows_per_row_group: config.read_batch_row_num,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -66,6 +66,7 @@ impl MergeSstBench {
             predicate,
             meta_cache: meta_cache.clone(),
             runtime: runtime.clone(),
+            read_parallelism: 1,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -66,7 +66,7 @@ impl MergeSstBench {
             predicate,
             meta_cache: meta_cache.clone(),
             runtime: runtime.clone(),
-            read_parallelism: 1,
+            background_read_parallelism: 1,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -45,6 +45,7 @@ impl SstBench {
             predicate,
             meta_cache,
             runtime: runtime.clone(),
+            read_parallelism: 1,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -45,7 +45,7 @@ impl SstBench {
             predicate,
             meta_cache,
             runtime: runtime.clone(),
-            read_parallelism: 1,
+            background_read_parallelism: 1,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -46,6 +46,7 @@ impl SstBench {
             meta_cache,
             runtime: runtime.clone(),
             background_read_parallelism: 1,
+            num_rows_per_row_group: config.read_batch_row_num,
         };
         let max_projections = cmp::min(config.max_projections, schema.num_columns());
 

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -100,6 +100,7 @@ pub async fn rebuild_sst(config: RebuildSstConfig, runtime: Arc<Runtime>) {
         meta_cache: None,
         runtime,
         background_read_parallelism: 1,
+        num_rows_per_row_group: config.read_batch_row_num,
     };
 
     let record_batch_stream =
@@ -201,6 +202,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
             meta_cache: None,
             runtime: runtime.clone(),
             background_read_parallelism: iter_options.sst_background_read_parallelism,
+            num_rows_per_row_group: config.read_batch_row_num,
         };
 
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -99,6 +99,7 @@ pub async fn rebuild_sst(config: RebuildSstConfig, runtime: Arc<Runtime>) {
         predicate: config.predicate.into_predicate(),
         meta_cache: None,
         runtime,
+        read_parallelism: 1,
     };
 
     let record_batch_stream =
@@ -182,6 +183,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
     let schema = util::schema_from_sst(&store, &first_sst_path, &None).await;
     let iter_options = IterOptions {
         batch_size: config.read_batch_row_num,
+        sst_background_read_parallelism: 1,
     };
 
     let request_id = RequestId::next_id();
@@ -198,6 +200,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
             predicate: config.predicate.into_predicate(),
             meta_cache: None,
             runtime: runtime.clone(),
+            read_parallelism: iter_options.sst_background_read_parallelism,
         };
 
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -99,7 +99,7 @@ pub async fn rebuild_sst(config: RebuildSstConfig, runtime: Arc<Runtime>) {
         predicate: config.predicate.into_predicate(),
         meta_cache: None,
         runtime,
-        read_parallelism: 1,
+        background_read_parallelism: 1,
     };
 
     let record_batch_stream =
@@ -200,7 +200,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
             predicate: config.predicate.into_predicate(),
             meta_cache: None,
             runtime: runtime.clone(),
-            read_parallelism: iter_options.sst_background_read_parallelism,
+            background_read_parallelism: iter_options.sst_background_read_parallelism,
         };
 
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -103,7 +103,7 @@ pub async fn load_sst_to_memtable(
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
-        read_parallelism: 1,
+        background_read_parallelism: 1,
     };
     let sst_factory = FactoryImpl;
     let mut sst_reader = sst_factory

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -104,6 +104,7 @@ pub async fn load_sst_to_memtable(
         meta_cache: None,
         runtime,
         background_read_parallelism: 1,
+        num_rows_per_row_group: 500,
     };
     let sst_factory = FactoryImpl;
     let mut sst_reader = sst_factory

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -103,6 +103,7 @@ pub async fn load_sst_to_memtable(
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
+        read_parallelism: 1,
     };
     let sst_factory = FactoryImpl;
     let mut sst_reader = sst_factory

--- a/common_types/src/projected_schema.rs
+++ b/common_types/src/projected_schema.rs
@@ -40,7 +40,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RowProjector {
     schema_with_key: RecordSchemaWithKey,
     source_schema: Schema,

--- a/common_types/src/record_batch.rs
+++ b/common_types/src/record_batch.rs
@@ -544,7 +544,7 @@ impl RecordBatchWithKeyBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ArrowRecordBatchProjector {
     row_projector: RowProjector,
 }

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -79,6 +79,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
+        read_parallelism: 1,
     };
     let mut reader = factory
         .new_sst_reader(&reader_opts, &input_path, &storage)

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -80,6 +80,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         meta_cache: None,
         runtime,
         background_read_parallelism: 1,
+        num_rows_per_row_group: 8192,
     };
     let mut reader = factory
         .new_sst_reader(&reader_opts, &input_path, &storage)

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -79,7 +79,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,
-        read_parallelism: 1,
+        background_read_parallelism: 1,
     };
     let mut reader = factory
         .new_sst_reader(&reader_opts, &input_path, &storage)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Now, the concurrent level while pulling sst data is on file level, we can enhance it to row group level.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
