### PR TITLE
feat: support memory usage limit on background compaction

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -329,6 +329,17 @@ impl CompactionTask {
             }
         }
     }
+
+    // Estimate the size of the total input files.
+    pub fn estimate_total_input_size(&self) -> usize {
+        let total_input_size: u64 = self
+            .compaction_inputs
+            .iter()
+            .map(|v| v.files.iter().map(|f| f.size()).sum::<u64>())
+            .sum();
+
+        total_input_size as usize
+    }
 }
 
 pub struct PickerManager {

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -57,6 +57,7 @@ use crate::{
 const DEFAULT_CHANNEL_SIZE: usize = 5;
 
 #[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
 pub enum Error {
     #[snafu(display("Failed to store version edit, err:{}", source))]
     StoreVersionEdit {
@@ -132,7 +133,10 @@ pub enum Error {
     #[snafu(display("Runtime join error, source:{}", source))]
     RuntimeJoin { source: common_util::runtime::Error },
 
-    #[snafu(display("Unknown flush policy"))]
+    #[snafu(display("Other failure, msg:{}.\nBacktrace:\n{:?}", msg, backtrace))]
+    Other { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Unknown flush policy.\nBacktrace:\n{:?}", backtrace))]
     UnknownPolicy { backtrace: Backtrace },
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Currently, there is no limit on the memory usage by the background compaction task, leading to frequent OOM on the prod environment.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add memory usage limit for compaction scheduler, so the task will be skipped and put back to the request queue if the memory threshold is reached.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
New unit tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
