### PR TITLE
fix: heap profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,7 +445,7 @@ dependencies = [
  "object_store 1.0.0-alpha01",
  "parquet",
  "parquet_ext",
- "pprof",
+ "pprof 0.10.1",
  "rand 0.7.3",
  "serde",
  "serde_derive",
@@ -1044,7 +1044,7 @@ dependencies = [
  "bytes_ext 0.4.0",
  "chrono",
  "murmur3",
- "paste 1.0.8",
+ "paste",
  "prost",
  "proto 0.4.0",
  "serde",
@@ -1065,7 +1065,7 @@ dependencies = [
  "chrono",
  "datafusion",
  "murmur3",
- "paste 1.0.8",
+ "paste",
  "prost",
  "proto 1.0.0-alpha01",
  "serde",
@@ -1189,6 +1189,15 @@ name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b446fd40bcc17eddd6a4a78f24315eb90afdb3334999ddfd4909985c47722442"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1477,7 +1486,7 @@ dependencies = [
  "ordered-float 3.0.0",
  "parking_lot 0.12.1",
  "parquet",
- "paste 1.0.8",
+ "paste",
  "pin-project-lite",
  "rand 0.8.5",
  "smallvec 1.9.0",
@@ -1545,7 +1554,7 @@ dependencies = [
  "lazy_static",
  "md-5",
  "ordered-float 3.0.0",
- "paste 1.0.8",
+ "paste",
  "rand 0.8.5",
  "regex",
  "sha2 0.10.2",
@@ -1559,7 +1568,7 @@ source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=d84ea9c79c9e83
 dependencies = [
  "arrow",
  "datafusion-common",
- "paste 1.0.8",
+ "paste",
  "rand 0.8.5",
 ]
 
@@ -2295,6 +2304,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "heappy"
+version = "0.1.0"
+dependencies = [
+ "backtrace",
+ "bytes 1.2.1",
+ "lazy_static",
+ "libc",
+ "pprof 0.11.0",
+ "spin 0.9.4",
+ "thiserror",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,38 +2677,6 @@ name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
-
-[[package]]
-name = "jemalloc-ctl"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
-dependencies = [
- "jemalloc-sys",
- "libc",
- "paste 0.1.18",
-]
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "jobserver"
@@ -3628,7 +3619,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "serde_json",
- "spin",
+ "spin 0.5.2",
  "tokio-codec",
  "uuid 0.7.4",
  "zstd",
@@ -3910,28 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
 
 [[package]]
 name = "peeking_take_while"
@@ -4053,7 +4025,33 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "smallvec 1.9.0",
- "symbolic-demangle",
+ "symbolic-demangle 9.2.1",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "pprof"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20150f965e0e4c925982b9356da71c84bcd56cb66ef4e894825837cbcf6613e"
+dependencies = [
+ "backtrace",
+ "cfg-if 1.0.0",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix 0.24.2",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "prost",
+ "prost-build",
+ "prost-derive",
+ "protobuf",
+ "sha2 0.10.2",
+ "smallvec 1.9.0",
+ "symbolic-demangle 10.2.1",
  "tempfile",
  "thiserror",
 ]
@@ -4142,9 +4140,7 @@ dependencies = [
 name = "profile"
 version = "1.0.0-alpha01"
 dependencies = [
- "jemalloc-ctl",
- "jemalloc-sys",
- "jemallocator",
+ "heappy",
  "log",
  "tempfile",
 ]
@@ -4160,7 +4156,7 @@ dependencies = [
  "lazy_static",
  "protobuf",
  "quick-error",
- "spin",
+ "spin 0.5.2",
 ]
 
 [[package]]
@@ -5153,7 +5149,7 @@ dependencies = [
  "logger",
  "meta_client",
  "opensrv-mysql",
- "paste 1.0.8",
+ "paste",
  "profile",
  "prometheus 0.12.0",
  "prometheus-static-metric",
@@ -5466,6 +5462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api 0.4.9",
+]
+
+[[package]]
 name = "sql"
 version = "1.0.0-alpha01"
 dependencies = [
@@ -5479,7 +5484,7 @@ dependencies = [
  "df_operator",
  "hashbrown",
  "log",
- "paste 1.0.8",
+ "paste",
  "regex",
  "snafu 0.6.10",
  "sqlparser",
@@ -5647,14 +5652,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "symbolic-common"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid 1.1.2",
+]
+
+[[package]]
 name = "symbolic-demangle"
 version = "9.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b940a1fdbc72bb3369e38714efe6cd332dbbe46d093cf03d668b9ac390d1ad0"
 dependencies = [
- "cpp_demangle",
+ "cpp_demangle 0.3.5",
  "rustc-demangle",
- "symbolic-common",
+ "symbolic-common 9.2.1",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+dependencies = [
+ "cpp_demangle 0.4.0",
+ "rustc-demangle",
+ "symbolic-common 10.2.1",
 ]
 
 [[package]]
@@ -5872,6 +5900,17 @@ dependencies = [
  "byteorder",
  "integer-encoding 3.0.4",
  "ordered-float 1.1.1",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.2+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec45c14da997d0925c7835883e4d5c181f196fa142f8c19d7643d1e9af2592c3"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
 ]
 
 [[package]]

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -8,9 +8,4 @@ edition.workspace = true
 [dependencies]
 log = { workspace = true }
 tempfile = { workspace = true }
-jemallocator = "0.3.2"
-jemalloc-ctl = "0.3.2"
-
-[dependencies.jemalloc-sys]
-version = "0.3.2"
-features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
+heappy = { git = "https://github.com/mkmik/heappy", rev = "99a7ae15a49de3fdb4cc82abc0ead01df7a0db7d", features = ["enable_heap_profiler", "measure_free"], optional = true }

--- a/components/profile/src/lib.rs
+++ b/components/profile/src/lib.rs
@@ -11,14 +11,12 @@ use std::{
     thread, time,
 };
 
-use jemalloc_ctl::{Access, AsName};
 use log::{error, info};
 
 #[derive(Debug)]
 pub enum Error {
     Internal { msg: String },
     IO(io::Error),
-    Jemalloc(jemalloc_ctl::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -30,44 +28,6 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
-
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-const PROF_ACTIVE: &[u8] = b"prof.active\0";
-const PROF_DUMP: &[u8] = b"prof.dump\0";
-const PROFILE_OUTPUT: &[u8] = b"profile.out\0";
-const PROFILE_OUTPUT_FILE_PATH: &str = "/tmp/profile.out";
-
-fn set_prof_active(active: bool) -> Result<()> {
-    let name = PROF_ACTIVE.name();
-    name.write(active).map_err(Error::Jemalloc)
-}
-
-fn dump_profile() -> Result<()> {
-    let name = PROF_DUMP.name();
-    name.write(PROFILE_OUTPUT).map_err(Error::Jemalloc)
-}
-
-struct ProfLockGuard<'a>(MutexGuard<'a, ()>);
-
-/// ProfLockGuard hold the profile lock and take responsibilities for
-/// (de)activating mem profiling. NOTE: Keeping mem profiling on may cause some
-/// extra runtime cost so we choose to activating it  dynamically.
-impl<'a> ProfLockGuard<'a> {
-    pub fn new(guard: MutexGuard<'a, ()>) -> Result<Self> {
-        set_prof_active(true)?;
-        Ok(Self(guard))
-    }
-}
-
-impl<'a> Drop for ProfLockGuard<'a> {
-    fn drop(&mut self) {
-        if let Err(e) = set_prof_active(false) {
-            error!("Fail to deactivate profiling, err:{}", e);
-        }
-    }
-}
 
 pub struct Profiler {
     mem_prof_lock: Mutex<()>,
@@ -86,15 +46,13 @@ impl Profiler {
         }
     }
 
-    // dump_mem_prof collects mem profiling data in `seconds`.
-    // TODO(xikai): limit the profiling duration
-    pub fn dump_mem_prof(&self, seconds: u64) -> Result<Vec<u8>> {
+    pub fn dump_mem_prof(&self, seconds: u64, intervals: i32) -> Result<String> {
         // concurrent profiling is disabled.
         let lock_guard = self.mem_prof_lock.try_lock().map_err(|e| Error::Internal {
             msg: format!("failed to acquire mem_prof_lock, err:{}", e),
         })?;
 
-        let _guard = ProfLockGuard::new(lock_guard)?;
+        let heap_profiler_guard = heappy::HeapProfilerGuard::new(1).unwrap();
 
         info!(
             "Profiler::dump_mem_prof start memory profiling {} seconds",
@@ -103,39 +61,12 @@ impl Profiler {
         // wait for seconds for collect the profiling data
         thread::sleep(time::Duration::from_secs(seconds));
 
-        // clearing the profile output file before dumping profile results.
-        {
-            let f = File::open(PROFILE_OUTPUT_FILE_PATH).map_err(|e| {
-                error!("Failed to open prof data file, err:{}", e);
-                Error::IO(e)
-            })?;
-            f.set_len(0).map_err(|e| {
-                error!("Failed to truncate profile output file, err:{}", e);
-                Error::IO(e)
-            })?;
-        }
+        let report = heap_profiler_guard.report();
 
-        // dump the profile results to profile output file.
-        dump_profile().map_err(|e| {
-            error!(
-                "Failed to dump prof to {}, err:{}",
-                PROFILE_OUTPUT_FILE_PATH, e
-            );
-            e
-        })?;
+        let filename = "/tmp/memflame.svg";
+        let mut file = std::fs::File::create(filename).unwrap();
+        report.flamegraph(&mut file);
 
-        // read the profile results into buffer
-        let mut f = File::open(PROFILE_OUTPUT_FILE_PATH).map_err(|e| {
-            error!("Failed to open prof data file, err:{}", e);
-            Error::IO(e)
-        })?;
-
-        let mut buffer = Vec::new();
-        f.read_to_end(&mut buffer).map_err(|e| {
-            error!("Failed to read prof data file, err:{}", e);
-            Error::IO(e)
-        })?;
-
-        Ok(buffer)
+        Ok(filename.to_string())
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #471

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Use https://github.com/mkmik/heappy/ to heap profile
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Manually
For now, following errors will be thrown
```
error: failed to select a version for `libc`.
    ... required by package `heappy v0.1.0 (https://github.com/mkmik/heappy?rev=99a7ae15a49de3fdb4cc82abc0ead01df7a0db7d#99a7ae15)`
    ... which satisfies git dependency `heappy` of package `profile v1.0.0-alpha01 (/code/misc/CeresDB/components/profile)`
    ... which satisfies path dependency `profile` (locked to 1.0.0-alpha01) of package `server v1.0.0-alpha01 (/code/misc/CeresDB/server)`
    ... which satisfies path dependency `server` (locked to 1.0.0-alpha01) of package `catalog_impls v1.0.0-alpha01 (/code/misc/CeresDB/catalog_impls)`
    ... which satisfies path dependency `catalog_impls` (locked to 1.0.0-alpha01) of package `ceresdb v1.0.0-alpha01 (/code/misc/CeresDB)`
versions that meet the requirements `^0.2.138` are: 0.2.138

all possible versions conflict with previously selected packages.

  previously selected package `libc v0.2.127`
    ... which satisfies dependency `libc = "^0.2.94"` (locked to 0.2.127) of package `backtrace v0.3.66`
    ... which satisfies dependency `backtrace = "^0.3.9"` (locked to 0.3.66) of package `common_util v1.0.0-alpha01 (/code/misc/CeresDB/common_util)`
    ... which satisfies path dependency `common_util` (locked to 1.0.0-alpha01) of package `analytic_engine v1.0.0-alpha01 (/code/misc/CeresDB/analytic_engine)`
    ... which satisfies path dependency `analytic_engine` (locked to 1.0.0-alpha01) of package `benchmarks v1.0.0-alpha01 (/code/misc/CeresDB/benchmarks)`

failed to select a version for `libc` which could resolve this conflict
```

