### PR TITLE
feat: support bloom filter in hybrid format

### DIFF
--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -16,14 +16,11 @@ use log::debug;
 use object_store::{ObjectStoreRef, Path};
 use snafu::ResultExt;
 
-use crate::{
-    sst::{
-        builder::{RecordBatchStream, SstBuilder, *},
-        factory::SstBuilderOptions,
-        file::{BloomFilter, SstMetaData},
-        parquet::encoding::ParquetEncoder,
-    },
-    table_options::StorageFormat,
+use crate::sst::{
+    builder::{RecordBatchStream, SstBuilder, *},
+    factory::SstBuilderOptions,
+    file::{BloomFilter, SstMetaData},
+    parquet::encoding::ParquetEncoder,
 };
 
 /// The implementation of sst based on parquet and object storage.
@@ -136,10 +133,6 @@ impl RecordBytesReader {
     }
 
     fn build_bloom_filter(&self) -> BloomFilter {
-        // TODO: support bloom filter in hybrid storage format [#435](https://github.com/CeresDB/ceresdb/issues/435)
-        if self.meta_data.storage_format_opts.format == StorageFormat::Hybrid {
-            return BloomFilter::default();
-        }
         let filters = self
             .partitioned_record_batch
             .iter()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Now, parquet builder has support manual flushing api, we can try to support bloom filter in hybrid format. 

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Manual flushing after writing a hybrid row group.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
