### PR TITLE
fix: lru-weighted-cache mem leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807"
+
+[[package]]
 name = "cluster"
 version = "1.0.0-alpha01"
 dependencies = [
@@ -2973,11 +2979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-weighted-cache"
-version = "0.1.2"
-source = "git+https://github.com/jiacai2050/lru-weighted-cache.git?rev=1cf61aaf88469387e610dc7154fa318843491428#1cf61aaf88469387e610dc7154fa318843491428"
-
-[[package]]
 name = "lz4"
 version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,12 +3584,12 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "chrono",
+ "clru",
  "common_util",
  "crc",
  "futures 0.3.21",
  "log",
  "lru",
- "lru-weighted-cache",
  "object_store 0.5.1",
  "oss-rust-sdk",
  "prost",

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -15,12 +15,12 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 common_util = { workspace = true }
+clru = "0.6.1"
 crc = "3.0.0"
 futures = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
-lru-weighted-cache = { git = "https://github.com/jiacai2050/lru-weighted-cache.git", rev = "1cf61aaf88469387e610dc7154fa318843491428" }
 oss-rust-sdk = "0.6.1"
 prost = { workspace = true }
 proto = { workspace = true }
@@ -31,10 +31,6 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
-clru = "0.6.1"
-log = { workspace = true }
-proto = { workspace = true }
-prost = { workspace = true }
 upstream = { package = "object_store", version = "0.5.1" }
 
 [dev-dependencies]

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -19,7 +19,7 @@ snafu = { workspace = true }
 lru = { workspace = true }
 chrono = { workspace = true }
 tokio = { workspace = true }
-lru-weighted-cache = { git = "https://github.com/jiacai2050/lru-weighted-cache.git" , rev="1cf61aaf88469387e610dc7154fa318843491428"}
+clru = "0.6.1"
 log = { workspace = true }
 proto = { workspace = true }
 prost = { workspace = true }

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -5,56 +5,68 @@
 //! 2. Builtin Partition to reduce lock contention
 
 use std::{
-    collections::hash_map::DefaultHasher,
-    fmt::Display,
+    collections::hash_map::{DefaultHasher, RandomState},
+    fmt::{self, Display},
     hash::{Hash, Hasher},
+    num::NonZeroUsize,
     ops::Range,
     sync::Arc,
 };
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use clru::{CLruCache, CLruCacheConfig, WeightScale};
 use futures::stream::BoxStream;
-use lru_weighted_cache::{LruWeightedCache, Weighted};
 use tokio::{io::AsyncWrite, sync::Mutex};
 use upstream::{path::Path, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result};
 
-struct CachedBytes(Bytes);
+struct CustomScale;
 
-impl Weighted for CachedBytes {
-    fn weight(&self) -> usize {
-        self.0.len()
+impl WeightScale<String, Bytes> for CustomScale {
+    fn weight(&self, _key: &String, value: &Bytes) -> usize {
+        value.len()
     }
 }
 
-#[derive(Debug)]
 struct Partition {
-    inner: Mutex<LruWeightedCache<String, CachedBytes>>,
+    inner: Mutex<CLruCache<String, Bytes, RandomState, CustomScale>>,
 }
 
 impl Partition {
     fn new(mem_cap: usize) -> Self {
+        let cache = CLruCache::with_config(
+            CLruCacheConfig::new(NonZeroUsize::new(mem_cap).expect("mem cap must large than 0"))
+                .with_scale(CustomScale),
+        );
+
         Self {
-            inner: Mutex::new(LruWeightedCache::new(1, mem_cap).expect("invalid params")),
+            inner: Mutex::new(cache),
         }
     }
 }
 impl Partition {
-    // TODO(chenxiang): also support `&str`, this need to changes to
-    // lru_weighted_cache
-    async fn get(&self, key: &String) -> Option<Bytes> {
+    async fn get(&self, key: &str) -> Option<Bytes> {
         let mut guard = self.inner.lock().await;
-        guard.get(key).map(|v| v.0.clone())
+        guard.get(key).cloned()
     }
 
     async fn insert(&self, key: String, value: Bytes) {
         let mut guard = self.inner.lock().await;
         // don't care error now.
-        _ = guard.insert(key, CachedBytes(value));
+        _ = guard.put_with_weight(key, value);
+    }
+
+    #[cfg(test)]
+    async fn keys(&self) -> Vec<String> {
+        let guard = self.inner.lock().await;
+        guard
+            .iter()
+            .map(|(key, _)| key)
+            .cloned()
+            .collect::<Vec<_>>()
     }
 }
 
-#[derive(Debug)]
 struct MemCache {
     /// Max memory this store can use
     mem_cap: usize,
@@ -77,13 +89,13 @@ impl MemCache {
         }
     }
 
-    fn locate_partition(&self, key: &String) -> Arc<Partition> {
+    fn locate_partition(&self, key: &str) -> Arc<Partition> {
         let mut hasher = DefaultHasher::new();
         key.hash(&mut hasher);
         self.partitions[hasher.finish() as usize & self.partition_mask].clone()
     }
 
-    async fn get(&self, key: &String) -> Option<Bytes> {
+    async fn get(&self, key: &str) -> Option<Bytes> {
         let partition = self.locate_partition(key);
         partition.get(key).await
     }
@@ -92,6 +104,21 @@ impl MemCache {
         let partition = self.locate_partition(&key);
         partition.insert(key, value).await;
     }
+
+    #[cfg(test)]
+    async fn to_string(&self) -> String {
+        futures::future::join_all(
+            self.partitions
+                .iter()
+                .map(|part| async { part.keys().await.join(",") }),
+        )
+        .await
+        .into_iter()
+        .enumerate()
+        .map(|(part_no, keys)| format!("{}: [{}]", part_no, keys))
+        .collect::<Vec<_>>()
+        .join("\n")
+    }
 }
 
 impl Display for MemCache {
@@ -99,12 +126,11 @@ impl Display for MemCache {
         f.debug_struct("MemCache")
             .field("mem_cap", &self.mem_cap)
             .field("mask", &self.partition_mask)
-            .field("partitons", &self.partitions)
+            .field("partitons", &self.partitions.len())
             .finish()
     }
 }
 
-#[derive(Debug)]
 pub struct MemCacheStore {
     cache: MemCache,
     underlying_store: Arc<dyn ObjectStore>,
@@ -133,6 +159,12 @@ impl MemCacheStore {
 impl Display for MemCacheStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.cache.fmt(f)
+    }
+}
+
+impl fmt::Debug for MemCacheStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MemCacheStore").finish()
     }
 }
 
@@ -239,10 +271,6 @@ mod test {
             .get(&MemCacheStore::cache_key(&location, &range0_5))
             .await
             .is_some());
-        assert_eq!(
-            r#"MemCache { mem_cap: 13, mask: 0, partitons: [Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 13, max_total_weight: 13, current_weight: 5 } } }] }"#,
-            format!("{}", store)
-        );
 
         // get bytes from [5, 10), insert to cache
         let range5_10 = 5..10;
@@ -257,18 +285,19 @@ mod test {
             .get(&MemCacheStore::cache_key(&location, &range5_10))
             .await
             .is_some());
-        assert_eq!(
-            r#"MemCache { mem_cap: 13, mask: 0, partitons: [Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 13, max_total_weight: 13, current_weight: 10 } } }] }"#,
-            format!("{}", store)
-        );
 
-        // get bytes from [5, 10), insert to cache
+        // get bytes from [10, 15), insert to cache
         // cache is full, evict [0, 5)
-        let range10_15 = 5..10;
+        let range10_15 = 10..15;
         _ = store
             .get_range(&location, range10_15.clone())
             .await
             .unwrap();
+        assert!(store
+            .cache
+            .get(&MemCacheStore::cache_key(&location, &range0_5))
+            .await
+            .is_none());
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range5_10))
@@ -279,20 +308,6 @@ mod test {
             .get(&MemCacheStore::cache_key(&location, &range10_15))
             .await
             .is_some());
-        assert_eq!(
-            r#"MemCache { mem_cap: 13, mask: 0, partitons: [Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 13, max_total_weight: 13, current_weight: 10 } } }] }"#,
-            format!("{}", store)
-        );
-
-        let range10_13 = 10..13;
-        _ = store
-            .get_range(&location, range10_13.clone())
-            .await
-            .unwrap();
-        assert_eq!(
-            r#"MemCache { mem_cap: 13, mask: 0, partitons: [Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 13, max_total_weight: 13, current_weight: 13 } } }] }"#,
-            format!("{}", store)
-        );
     }
 
     #[tokio::test]
@@ -314,8 +329,11 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            r#"MemCache { mem_cap: 100, mask: 3, partitons: [Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 25, max_total_weight: 25, current_weight: 0 } } }, Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 25, max_total_weight: 25, current_weight: 5 } } }, Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 25, max_total_weight: 25, current_weight: 0 } } }, Partition { inner: Mutex { data: LruWeightedCache { max_item_weight: 25, max_total_weight: 25, current_weight: 5 } } }] }"#,
-            format!("{}", store)
+            r#"0: []
+1: [partition.sst-100-105]
+2: []
+3: [partition.sst-0-5]"#,
+            store.cache.to_string().await
         );
 
         assert!(store


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In our test env, OOM happens a lot when memory store is on, when disable it the OOM also disappear, so I suspect the LRU dependence has mem leak bug.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Change LRU to https://github.com/marmeladema/clru-rs/, which has more testcases, and smaller amount of unsafe code.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

Unit tests, and will also check in test env.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

