### PR TITLE
chore: support Cargo.toml format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,9 @@ jobs:
       - name: Run Style Check
         run: |
           make check-license
+          make clippy
           make fmt
           make check-cargo-toml
-          make clippy
       - name: Run Unit Tests
         run: |
           make test-ut

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,13 @@ jobs:
         run: |
           rustup component add clippy
           rustup component add rustfmt
+          cargo install cargo-sort
       - name: Run Style Check
         run: |
           make check-license
-          make clippy
           make fmt
+          make check-cargo-toml
+          make clippy
       - name: Run Unit Tests
         run: |
           make test-ut

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0-alpha01"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
 edition = "2021"
 
-
 [workspace.package]
 version = "1.0.0-alpha01"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "ceresdb"
 version = "1.0.0-alpha01"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [workspace.package]
 version = "1.0.0-alpha01"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "ceresdb"
 version = "1.0.0-alpha01"
 authors = ["CeresDB Authors <ceresdbservice@gmail.com>"]
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace.package]
@@ -21,17 +20,17 @@ members = [
     "cluster",
     "common_types",
     "common_util",
-    "components/arrow_ext",
     "components/arena",
+    "components/arrow_ext",
     "components/bytes_ext",
     "components/logger",
+    "components/message_queue",
     "components/object_store",
     "components/parquet_ext",
     "components/profile",
     "components/skiplist",
     "components/table_kv",
     "components/tracing_util",
-    "components/message_queue",
     "df_operator",
     "interpreters",
     "meta_client",
@@ -88,7 +87,7 @@ proto = { path = "proto" }
 prost = "0.11"
 query_engine = { path = "query_engine" }
 rand = "0.7"
-snafu = { version ="0.6.10", features = ["backtraces"] }
+snafu = { version = "0.6.10", features = ["backtraces"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0.60"
@@ -126,6 +125,7 @@ clap = { workspace = true }
 cluster = { workspace = true }
 common_util = { workspace = true }
 df_operator = { workspace = true }
+interpreters = { workspace = true }
 log = { workspace = true }
 logger = { workspace = true }
 meta_client = { workspace = true }
@@ -134,7 +134,6 @@ server = { workspace = true }
 signal-hook = "0.3"
 table_engine = { workspace = true }
 tracing_util = { workspace = true }
-interpreters = { workspace = true }
 
 [build-dependencies]
 vergen = { version = "5", default-features = false, features = ["build", "git"] }

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ test-ut:
 fmt:
 	cd $(DIR); cargo fmt -- --check
 
+check-cargo-toml:
+	cd $(DIR); cargo sort --workspace --check 
+
 check-license:
 	cd $(DIR); sh scripts/check-license.sh
 

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "analytic_engine"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -25,12 +29,13 @@ futures = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
+message_queue = { workspace = true }
 object_store = { workspace = true }
 parquet = { workspace = true }
 parquet_ext = { workspace = true }
 prometheus = { workspace = true }
-proto = { workspace = true }
 prost = { workspace = true }
+proto = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 skiplist = { path = "../components/skiplist" }
@@ -41,7 +46,6 @@ table_kv = { workspace = true }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true }
 wal = { workspace = true }
-message_queue = { workspace = true }
 
 [dev-dependencies]
 common_types = { workspace = true, features = ["test"] }

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "analytic_engine"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 test = ["tempfile"]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "benchmarks"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arena = { workspace = true }
-arrow2 = { version = "0.12.0", features = [ "io_parquet" ] }
-arrow = { workspace = true }
 analytic_engine = { workspace = true }
+arena = { workspace = true }
+arrow = { workspace = true }
+arrow2 = { version = "0.12.0", features = [ "io_parquet" ] }
 base64 = { workspace = true }
 clap = { workspace = true }
 common_types = { workspace = true }
@@ -21,6 +25,7 @@ log = { workspace = true }
 object_store = { workspace = true }
 parquet = { workspace = true }
 parquet_ext = { workspace = true }
+pprof = { version = "0.10", features = ["flamegraph", "criterion"] }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
@@ -29,7 +34,6 @@ table_engine = { workspace = true }
 table_kv = { workspace = true }
 tokio = { workspace = true }
 wal = { workspace = true }
-pprof = { version = "0.10", features = ["flamegraph", "criterion"] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [package.edition]
 workspace = true
+
 [dependencies]
 analytic_engine = { workspace = true }
 arena = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "benchmarks"
+
 [package.version]
 workspace = true
 
@@ -8,8 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 analytic_engine = { workspace = true }
 arena = { workspace = true }

--- a/catalog/Cargo.toml
+++ b/catalog/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "catalog"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/catalog/Cargo.toml
+++ b/catalog/Cargo.toml
@@ -1,15 +1,19 @@
 [package]
 name = "catalog"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # Workspace dependencies, in alphabetical order
 async-trait = { workspace = true }
-snafu = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }
+snafu = { workspace = true }
 table_engine = { workspace = true }

--- a/catalog_impls/Cargo.toml
+++ b/catalog_impls/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "catalog_impls"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # Workspace dependencies, in alphabetical order

--- a/catalog_impls/Cargo.toml
+++ b/catalog_impls/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "catalog_impls"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/cluster/Cargo.toml
+++ b/cluster/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cluster"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 analytic_engine = { workspace = true }

--- a/cluster/Cargo.toml
+++ b/cluster/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "cluster"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "common_types"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 default = ["arrow", "datafusion"]

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "common_types"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -13,18 +17,18 @@ test = []
 [dependencies]
 # In alphabetical order
 arrow = { workspace = true, optional = true }
-datafusion = { workspace = true, optional = true }
 arrow_ext = { workspace = true }
 byteorder = "1.2"
 bytes_ext = { workspace = true }
 chrono = { workspace = true }
+datafusion = { workspace = true, optional = true }
 murmur3 = "0.4.1"
 paste = { workspace = true }
-proto = { workspace = true }
 prost = { workspace = true }
-snafu = { workspace = true }
-# TODO(yingwen): Make sqlparser support a feature
-sqlparser = { version = "0.23.0", features = ["serde"] }
+proto = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
+snafu = { workspace = true }
+# TODO(yingwen): Make sqlparser support a feature
+sqlparser = { version = "0.23.0", features = ["serde"] }

--- a/common_util/Cargo.toml
+++ b/common_util/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "common_util"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -13,23 +17,28 @@ test = ["env_logger"]
 # In alphabetical order
 arrow = { workspace = true }
 backtrace = "0.3.9"
-common_types = { workspace = true , features = ["test"] }
 chrono = { workspace = true }
+common_types = { workspace = true, features = ["test"] }
 crossbeam-utils = "0.8.7"
 env_logger = { workspace = true, optional = true }
 lazy_static = { workspace = true }
 libc = "0.2"
 log = { workspace = true }
 logger = { workspace = true }
-snafu = { workspace = true }
-serde = { workspace = true}
-serde_derive = { workspace = true }
 pin-project-lite = "0.2.8"
 prometheus = { workspace = true }
 proto = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+snafu = { workspace = true }
 time = "0.1"
 tokio = { workspace = true }
 toml = "0.5"
+
+[dev-dependencies.slog-global]
+version = "0.1"
+git = "https://github.com/tikv/slog-global.git"
+rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9"
 
 [dev-dependencies]
 env_logger = { workspace = true }
@@ -38,8 +47,3 @@ nix = "0.22"
 slog = { workspace = true }
 tempfile = { workspace = true }
 tokio-test = "0.4.2"
-
-[dev-dependencies.slog-global]
-version = "0.1"
-git = "https://github.com/tikv/slog-global.git"
-rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9"

--- a/common_util/Cargo.toml
+++ b/common_util/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "common_util"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 test = ["env_logger"]

--- a/components/arena/Cargo.toml
+++ b/components/arena/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "arena"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/components/arena/Cargo.toml
+++ b/components/arena/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arena"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 parking_lot = "0.11.1"

--- a/components/arrow_ext/Cargo.toml
+++ b/components/arrow_ext/Cargo.toml
@@ -1,15 +1,19 @@
 [package]
 name = "arrow_ext"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.authors]
+workspace = true
 
-[dependencies]
-arrow = { workspace = true }
+[package.edition]
+workspace = true
 
 [dependencies.uncover]
 git = "https://github.com/matklad/uncover.git"
 rev = "1d0770d997e29731b287e9e11e4ffbbea5f456da"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+arrow = { workspace = true }
 

--- a/components/arrow_ext/Cargo.toml
+++ b/components/arrow_ext/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 git = "https://github.com/matklad/uncover.git"
 rev = "1d0770d997e29731b287e9e11e4ffbbea5f456da"
 
-
 [dependencies]
 arrow = { workspace = true }
 

--- a/components/arrow_ext/Cargo.toml
+++ b/components/arrow_ext/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "arrow_ext"
+
 [package.version]
 workspace = true
 
@@ -8,11 +9,10 @@ workspace = true
 
 [package.edition]
 workspace = true
-
 [dependencies.uncover]
 git = "https://github.com/matklad/uncover.git"
 rev = "1d0770d997e29731b287e9e11e4ffbbea5f456da"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
 arrow = { workspace = true }

--- a/components/bytes_ext/Cargo.toml
+++ b/components/bytes_ext/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bytes_ext"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 bytes = { workspace = true }

--- a/components/bytes_ext/Cargo.toml
+++ b/components/bytes_ext/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "bytes_ext"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/components/logger/Cargo.toml
+++ b/components/logger/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "logger"
+
 [package.version]
 workspace = true
 
@@ -8,12 +9,11 @@ workspace = true
 
 [package.edition]
 workspace = true
-
 [dependencies.slog-global]
 version = "0.1"
 git = "https://github.com/tikv/slog-global.git"
 rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
 chrono = { workspace = true }

--- a/components/logger/Cargo.toml
+++ b/components/logger/Cargo.toml
@@ -1,9 +1,18 @@
 [package]
 name = "logger"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
+
+[dependencies.slog-global]
+version = "0.1"
+git = "https://github.com/tikv/slog-global.git"
+rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -13,8 +22,3 @@ slog = { workspace = true }
 slog-async = "2.6"
 slog-term = "2.8"
 slog_derive = "0.2"
-
-[dependencies.slog-global]
-version = "0.1"
-git = "https://github.com/tikv/slog-global.git"
-rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9"

--- a/components/logger/Cargo.toml
+++ b/components/logger/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.1"
 git = "https://github.com/tikv/slog-global.git"
 rev = "d592f88e4dbba5eb439998463054f1a44fbf17b9"
 
-
 [dependencies]
 chrono = { workspace = true }
 log = { workspace = true }

--- a/components/message_queue/Cargo.toml
+++ b/components/message_queue/Cargo.toml
@@ -4,18 +4,17 @@ version = "0.1.0"
 
 [package.edition]
 workspace = true
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = { workspace = true }
+chrono = { workspace = true }
 common_util = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 snafu = { workspace = true }
-chrono = { workspace = true }
-async-trait = { workspace = true }
-log = { workspace = true }
-futures = { workspace = true }
 tokio = { workspace = true }
 
 [dependencies.rskafka]

--- a/components/message_queue/Cargo.toml
+++ b/components/message_queue/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = { workspace = true }

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-
 [dependencies]
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -22,10 +22,10 @@ lazy_static = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 oss-rust-sdk = "0.6.1"
-prost = { workspace = true }
-proto = { workspace = true }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
+prost = { workspace = true }
+proto = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [package.edition]
 workspace = true
+
 [dependencies]
 async-trait = { workspace = true }
 bytes = { workspace = true }

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -14,8 +14,8 @@ workspace = true
 async-trait = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
-common_util = { workspace = true }
 clru = "0.6.1"
+common_util = { workspace = true }
 crc = "3.0.0"
 futures = { workspace = true }
 lazy_static = { workspace = true }

--- a/components/parquet_ext/Cargo.toml
+++ b/components/parquet_ext/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "parquet_ext"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 arrow = { workspace = true }

--- a/components/parquet_ext/Cargo.toml
+++ b/components/parquet_ext/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "parquet_ext"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 version = "0.3.2"
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
 
-
 [dependencies]
 jemalloc-ctl = "0.3.2"
 jemallocator = "0.3.2"

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "profile"
+
 [package.version]
 workspace = true
 
@@ -8,12 +9,11 @@ workspace = true
 
 [package.edition]
 workspace = true
-
 [dependencies.jemalloc-sys]
 version = "0.3.2"
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [dependencies]
 jemalloc-ctl = "0.3.2"
 jemallocator = "0.3.2"

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -1,16 +1,21 @@
 [package]
 name = "profile"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[dependencies]
-log = { workspace = true }
-tempfile = { workspace = true }
-jemallocator = "0.3.2"
-jemalloc-ctl = "0.3.2"
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 
 [dependencies.jemalloc-sys]
 version = "0.3.2"
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+jemalloc-ctl = "0.3.2"
+jemallocator = "0.3.2"
+log = { workspace = true }
+tempfile = { workspace = true }

--- a/components/skiplist/Cargo.toml
+++ b/components/skiplist/Cargo.toml
@@ -1,19 +1,21 @@
 [package]
 name = "skiplist"
-version.workspace = true
-edition.workspace = true
 authors = ["Jay Lee <busyjaylee@gmail.com>", "CeresDB Authors <ceresdbservice@gmail.com>"]
 
+[package.version]
+workspace = true
+
+[package.edition]
+workspace = true
 
 [dependencies]
-rand = { workspace = true }
-bytes = { workspace = true }
 arena = { workspace = true }
+bytes = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
-yatp = { git = "https://github.com/tikv/yatp.git", rev = "4b71f8abd86890f0d1e95778c2b6bf5a9ee4c502" }
 criterion = { workspace = true }
-
+yatp = { git = "https://github.com/tikv/yatp.git", rev = "4b71f8abd86890f0d1e95778c2b6bf5a9ee4c502" }
 # [target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
 # tikv-jemallocator = "0.4.0"
 

--- a/components/skiplist/Cargo.toml
+++ b/components/skiplist/Cargo.toml
@@ -2,12 +2,12 @@
 name = "skiplist"
 authors = ["Jay Lee <busyjaylee@gmail.com>", "CeresDB Authors <ceresdbservice@gmail.com>"]
 
-
 [package.version]
 workspace = true
 
 [package.edition]
 workspace = true
+
 [dependencies]
 arena = { workspace = true }
 bytes = { workspace = true }

--- a/components/skiplist/Cargo.toml
+++ b/components/skiplist/Cargo.toml
@@ -2,12 +2,12 @@
 name = "skiplist"
 authors = ["Jay Lee <busyjaylee@gmail.com>", "CeresDB Authors <ceresdbservice@gmail.com>"]
 
+
 [package.version]
 workspace = true
 
 [package.edition]
 workspace = true
-
 [dependencies]
 arena = { workspace = true }
 bytes = { workspace = true }

--- a/components/table_kv/Cargo.toml
+++ b/components/table_kv/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "table_kv"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 common_util = { workspace = true }

--- a/components/table_kv/Cargo.toml
+++ b/components/table_kv/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "table_kv"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/components/tracing_util/Cargo.toml
+++ b/components/tracing_util/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "tracing_util"
-version.workspace = true
-edition.workspace = true
 authors = ["Databend Authors <opensource@datafuselabs.com>", "CeresDB Authors <ceresdbservice@gmail.com>"]
 license = "Apache-2.0"
 publish = false
+
+[package.version]
+workspace = true
+
+[package.edition]
+workspace = true
 
 [dependencies] # In alphabetical order
 lazy_static = { workspace = true }

--- a/components/tracing_util/Cargo.toml
+++ b/components/tracing_util/Cargo.toml
@@ -4,12 +4,12 @@ authors = ["Databend Authors <opensource@datafuselabs.com>", "CeresDB Authors <c
 license = "Apache-2.0"
 publish = false
 
-
 [package.version]
 workspace = true
 
 [package.edition]
 workspace = true
+
 [dependencies] # In alphabetical order
 lazy_static = { workspace = true }
 tracing = "0.1.26"

--- a/components/tracing_util/Cargo.toml
+++ b/components/tracing_util/Cargo.toml
@@ -4,12 +4,12 @@ authors = ["Databend Authors <opensource@datafuselabs.com>", "CeresDB Authors <c
 license = "Apache-2.0"
 publish = false
 
+
 [package.version]
 workspace = true
 
 [package.edition]
 workspace = true
-
 [dependencies] # In alphabetical order
 lazy_static = { workspace = true }
 tracing = "0.1.26"

--- a/df_operator/Cargo.toml
+++ b/df_operator/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "df_operator"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/df_operator/Cargo.toml
+++ b/df_operator/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "df_operator"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 arrow = { workspace = true }

--- a/interpreters/Cargo.toml
+++ b/interpreters/Cargo.toml
@@ -1,12 +1,17 @@
 [package]
 name = "interpreters"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arrow = { workspace = true }
 # In alphabetical order
 async-trait = { workspace = true }
 catalog = { workspace = true }
@@ -17,12 +22,11 @@ datafusion-expr = { workspace = true }
 df_operator = { workspace = true }
 log = { workspace = true }
 meta_client = { workspace = true }
+query_engine = { workspace = true }
+regex = "1"
 snafu = { workspace = true }
 sql = { workspace = true }
 table_engine = { workspace = true }
-query_engine = { workspace = true }
-arrow = { workspace = true }
-regex = "1"
 [dev-dependencies]
 analytic_engine = { workspace = true, features = ["test"] }
 catalog_impls = { workspace = true }

--- a/interpreters/Cargo.toml
+++ b/interpreters/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "interpreters"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 arrow = { workspace = true }

--- a/meta_client/Cargo.toml
+++ b/meta_client/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "meta_client"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/meta_client/Cargo.toml
+++ b/meta_client/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "meta_client"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = { workspace = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "proto"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 prost = { workspace = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
 name = "proto"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 prost = { workspace = true }
 
 [build-dependencies]
-tonic-build = "0.8"
 protoc-bin-vendored = "3.0.0"
+tonic-build = "0.8"

--- a/query_engine/Cargo.toml
+++ b/query_engine/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "query_engine"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/query_engine/Cargo.toml
+++ b/query_engine/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "query_engine"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # In alphabetical order

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "server"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 analytic_engine = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "server"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -11,6 +15,7 @@ analytic_engine = { workspace = true }
 arrow = { workspace = true }
 async-trait = { workspace = true }
 avro-rs = "0.13"
+bytes = { workspace = true }
 catalog = { workspace = true }
 ceresdbproto = { workspace = true }
 cluster = { workspace = true }
@@ -28,10 +33,10 @@ meta_client = { workspace = true }
 opensrv-mysql = "0.1.0"
 paste = { workspace = true }
 profile = { workspace = true }
-prost = { workspace = true }
-query_engine = { workspace = true }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
+prost = { workspace = true }
+query_engine = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
@@ -44,7 +49,6 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { workspace = true }
 twox-hash = "1.6"
 warp = "0.3"
-bytes = { workspace = true }
 
 [dev-dependencies]
-sql = { workspace = true , features=["test"] }
+sql = { workspace = true, features = ["test"] }

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "sql"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
@@ -16,16 +20,16 @@ catalog = { workspace = true }
 ceresdbproto = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }
-df_operator = { workspace = true }
 datafusion = { workspace = true }
 datafusion-expr = { workspace = true }
+df_operator = { workspace = true }
 hashbrown = { version = "0.12", features = ["raw"] }
 log = { workspace = true }
 paste = { workspace = true }
+regex = "1"
 snafu = { workspace = true }
 sqlparser = "0.23.0"
 table_engine = { workspace = true }
-regex = "1"
 
 [dev-dependencies]
 common_types = { workspace = true, features = ["test"] }

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "sql"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 test = []

--- a/system_catalog/Cargo.toml
+++ b/system_catalog/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "system_catalog"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # In alphabetical order

--- a/system_catalog/Cargo.toml
+++ b/system_catalog/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "system_catalog"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -15,8 +19,8 @@ common_types = { workspace = true }
 common_util = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
-proto = { workspace = true }
 prost = { workspace = true }
+proto = { workspace = true }
 snafu = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }

--- a/table_engine/Cargo.toml
+++ b/table_engine/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "table_engine"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # In alphabetical order

--- a/table_engine/Cargo.toml
+++ b/table_engine/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "table_engine"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -18,8 +22,8 @@ futures = { workspace = true }
 log = { workspace = true }
 parquet = { workspace = true }
 parquet_ext = { workspace = true }
-proto = { workspace = true }
 prost = { workspace = true }
+proto = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 smallvec = { workspace = true }

--- a/tests/harness/Cargo.toml
+++ b/tests/harness/Cargo.toml
@@ -4,12 +4,11 @@ version = "0.1.0"
 
 [package.edition]
 workspace = true
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.58"
 ceresdb-client-rs = { git = "https://github.com/CeresDB/ceresdb-client-rs.git", rev = "a9d9190f4f7b55171ea2ad142fb41dc9909c19c5" }
-prettydiff = { version = "0.6.1", features = [ "prettytable-rs"]}
+prettydiff = { version = "0.6.1", features = [ "prettytable-rs"] }
 tokio = { workspace = true }
 walkdir = "2.3.2"

--- a/tests/harness/Cargo.toml
+++ b/tests/harness/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.58"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,21 +1,25 @@
 [package]
 name = "tools"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
 
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 analytic_engine = { workspace = true }
+anyhow = { version = "1.0", features = ["backtrace"] }
+clap = { workspace = true, features = ["derive"] }
 common_types = { workspace = true }
 common_util = { workspace = true }
 env_logger = { workspace = true }
+futures = { workspace = true }
 object_store = { workspace = true }
-tokio = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
-anyhow = { version = "1.0", features = ["backtrace"] }
 parquet = { workspace = true }
 parquet_ext = { workspace = true }
 table_engine = { workspace = true }
-futures = { workspace = true }
+tokio = { workspace = true }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tools"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 analytic_engine = { workspace = true }

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -17,7 +17,6 @@ git = "https://github.com/tikv/rust-rocksdb.git"
 rev = "084102f7e4d1901cbe3f2782c5c63cb7af628bac" # at branch tikv-6.1
 features = ["portable"]
 
-
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -1,40 +1,44 @@
 [package]
 name = "wal"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
+[package.version]
+workspace = true
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
 
 [features]
 test = ["tempfile", "futures", "uuid"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-async-trait = { workspace = true }
-common_util = { workspace = true }
-common_types = { workspace = true }
-chrono = { workspace = true }
-futures = { workspace = true, features = ["async-await"], optional = true }
-log = { workspace = true }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-snafu = { workspace = true }
-table_kv = { workspace = true }
-smallvec = { workspace = true }
-tokio = { workspace = true }
-tempfile = { workspace = true, optional = true }
-message_queue = { workspace = true }
-proto = { workspace = true }
-prost = { workspace = true }
-uuid = { version = "1.0", features = ["v4"], optional = true }
-
-[dev-dependencies]
-futures = { workspace = true, features = ["async-await"] }
-env_logger = { workspace = true }
-rand = "0.8.5"
 
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
 rev = "084102f7e4d1901cbe3f2782c5c63cb7af628bac" # at branch tikv-6.1
 features = ["portable"]
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = { workspace = true }
+chrono = { workspace = true }
+common_types = { workspace = true }
+common_util = { workspace = true }
+futures = { workspace = true, features = ["async-await"], optional = true }
+log = { workspace = true }
+message_queue = { workspace = true }
+prost = { workspace = true }
+proto = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+smallvec = { workspace = true }
+snafu = { workspace = true }
+table_kv = { workspace = true }
+tempfile = { workspace = true, optional = true }
+tokio = { workspace = true }
+uuid = { version = "1.0", features = ["v4"], optional = true }
+
+[dev-dependencies]
+env_logger = { workspace = true }
+futures = { workspace = true, features = ["async-await"] }
+rand = "0.8.5"

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "wal"
+
 [package.version]
 workspace = true
 
@@ -8,7 +9,6 @@ workspace = true
 
 [package.edition]
 workspace = true
-
 [features]
 test = ["tempfile", "futures", "uuid"]
 
@@ -16,7 +16,7 @@ test = ["tempfile", "futures", "uuid"]
 git = "https://github.com/tikv/rust-rocksdb.git"
 rev = "084102f7e4d1901cbe3f2782c5c63cb7af628bac" # at branch tikv-6.1
 features = ["portable"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
 async-trait = { workspace = true }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Currently, all the `Cargo.toml`s in the workspace has no linter check, leading to some kinds of mess in these tomls.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Introduce the `cargo-sort` dev dependency;
- Impose the format check on all the `Cargo.toml`s in the workspace;

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
By existing CI.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

# Additional
Currently, the `cargo sort` doesn't support such syntax:
```toml
[package]
version.workspace = true
authors.workspace = true
edition.workspace = true
```
So this PR change such block into:
```toml
[package.version]
workspace = true

[package.authors]
workspace = true

[package.edition]
workspace = true
```