### PR TITLE
fix: compact table in background scheduler

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -418,12 +418,15 @@ impl Drop for WaiterNotifier {
 /// Request to compact single table.
 pub struct TableCompactionRequest {
     pub table_data: TableDataRef,
-    pub compaction_notifier: CompactionNotifier,
+    pub compaction_notifier: Option<CompactionNotifier>,
     pub waiter: Option<oneshot::Sender<WaitResult<()>>>,
 }
 
 impl TableCompactionRequest {
-    pub fn no_waiter(table_data: TableDataRef, compaction_notifier: CompactionNotifier) -> Self {
+    pub fn no_waiter(
+        table_data: TableDataRef,
+        compaction_notifier: Option<CompactionNotifier>,
+    ) -> Self {
         TableCompactionRequest {
             table_data,
             compaction_notifier,

--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -302,7 +302,7 @@ pub struct CompactionInputFiles {
     pub output_level: Level,
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct ExpiredFiles {
     /// Level of the expired files.
     pub level: Level,
@@ -310,7 +310,7 @@ pub struct ExpiredFiles {
     pub files: Vec<FileHandle>,
 }
 
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct CompactionTask {
     pub compaction_inputs: Vec<CompactionInputFiles>,
     pub expired: Vec<ExpiredFiles>,

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -159,7 +159,7 @@ fn find_uncompact_files(
         .iter_ssts_at_level(level)
         // Only use files not being compacted and not expired.
         .filter(|file| !file.being_compacted() && !file.time_range().is_expired(expire_time))
-        .map(Clone::clone)
+        .cloned()
         .collect()
 }
 
@@ -312,6 +312,11 @@ impl SizeTieredPicker {
         min_threshold: usize,
         max_threshold: usize,
     ) -> Option<Vec<FileHandle>> {
+        debug!(
+            "Find most_interesting_bucket buckets:{:?}, min:{}, max:{}",
+            buckets, min_threshold, max_threshold
+        );
+
         let mut pruned_bucket_and_hotness = Vec::with_capacity(buckets.len());
         // skip buckets containing less than min_threshold sstables,
         // and limit other buckets to max_threshold sstables

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -614,13 +614,14 @@ impl ScheduleWorker {
         self.space_store.list_all_tables(&mut tables_buf);
 
         let request_id = RequestId::next_id();
-        // Spawn a background job to purge ssts and avoid schedule thread blocked.
         for table_data in tables_buf {
             info!(
                 "Period purge, table:{}, table_id:{}, request_id:{}",
                 table_data.name, table_data.id, request_id
             );
 
+            // This will spawn a background job to purge ssts and avoid schedule thread
+            // blocked.
             self.handle_table_compaction_request(TableCompactionRequest::no_waiter(
                 table_data, None,
             ))

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use common_types::{request_id::RequestId, time::Timestamp};
+use common_types::request_id::RequestId;
 use common_util::{
     config::{ReadableDuration, ReadableSize},
     define_result,
@@ -441,11 +441,11 @@ impl ScheduleWorker {
         };
     }
 
-    async fn do_table_compaction_task(
+    fn do_table_compaction_task(
         &self,
         table_data: TableDataRef,
         compaction_task: CompactionTask,
-        compaction_notifier: CompactionNotifier,
+        compaction_notifier: Option<CompactionNotifier>,
         waiter_notifier: WaiterNotifier,
         token: MemoryUsageToken,
     ) {
@@ -489,8 +489,9 @@ impl ScheduleWorker {
             // Notify the background compact table result.
             match res {
                 Ok(()) => {
-                    let new_compaction_notifier = compaction_notifier.clone();
-                    compaction_notifier.notify_ok();
+                    if let Some(notifier) = compaction_notifier.clone() {
+                        notifier.notify_ok();
+                    }
                     waiter_notifier.notify_wait_result(Ok(()));
 
                     if keep_scheduling_compaction {
@@ -498,7 +499,7 @@ impl ScheduleWorker {
                             sender,
                             TableCompactionRequest::no_waiter(
                                 table_data.clone(),
-                                new_compaction_notifier,
+                                compaction_notifier.clone(),
                             ),
                         )
                         .await;
@@ -506,7 +507,10 @@ impl ScheduleWorker {
                 }
                 Err(e) => {
                     let e = Arc::new(e);
-                    compaction_notifier.notify_err(e.clone());
+                    if let Some(notifier) = compaction_notifier {
+                        notifier.notify_err(e.clone());
+                    }
+
                     let wait_err = WaitError::Compaction { source: e };
                     waiter_notifier.notify_wait_result(Err(wait_err));
                 }
@@ -574,8 +578,7 @@ impl ScheduleWorker {
             compaction_notifier,
             waiter_notifier,
             token,
-        )
-        .await;
+        );
     }
 
     async fn put_back_compaction_request(&self, req: TableCompactionRequest) {
@@ -591,7 +594,9 @@ impl ScheduleWorker {
                 }
                 .build(),
             );
-            compaction_notifier.notify_err(e.clone());
+            if let Some(notifier) = compaction_notifier {
+                notifier.notify_err(e.clone());
+            }
 
             let waiter_notifier = WaiterNotifier::new(waiter);
             let wait_err = WaitError::Compaction { source: e };
@@ -600,65 +605,27 @@ impl ScheduleWorker {
     }
 
     async fn schedule(&mut self) {
-        self.purge_tables();
+        self.purge_tables().await;
         self.flush_tables().await;
     }
 
-    fn purge_tables(&mut self) {
+    async fn purge_tables(&mut self) {
         let mut tables_buf = Vec::new();
         self.space_store.list_all_tables(&mut tables_buf);
 
-        let mut to_purge = Vec::new();
-
-        let now = Timestamp::now();
-        for table_data in &tables_buf {
-            let expire_time = table_data
-                .table_options()
-                .ttl()
-                .map(|ttl| now.sub_duration_or_min(ttl.0));
-
-            let version = table_data.current_version();
-            if !version.has_expired_sst(expire_time) {
-                debug!(
-                    "Table has no expired sst, table:{}, table_id:{}, expire_time:{:?}",
-                    table_data.name, table_data.id, expire_time
-                );
-            }
-
-            // Create a compaction task that only purge expired files.
-            let compaction_task = CompactionTask {
-                expired: version.expired_ssts(expire_time),
-                ..Default::default()
-            };
-
-            // Marks being compacted.
-            compaction_task.mark_files_being_compacted(true);
-
-            to_purge.push((table_data.clone(), compaction_task));
-        }
-
-        let runtime = self.runtime.clone();
-        let space_store = self.space_store.clone();
         let request_id = RequestId::next_id();
         // Spawn a background job to purge ssts and avoid schedule thread blocked.
-        self.runtime.spawn(async move {
-            for (table_data, compaction_task) in to_purge {
-                info!("Period purge expired files, table:{}, table_id:{}, request_id:{}", table_data.name, table_data.id, request_id);
+        for table_data in tables_buf {
+            info!(
+                "Period purge, table:{}, table_id:{}, request_id:{}",
+                table_data.name, table_data.id, request_id
+            );
 
-                if let Err(e) = space_store
-                    .compact_table(runtime.clone(), &table_data, request_id, &compaction_task)
-                    .await
-                {
-                    error!(
-                        "Failed to purge expired files of table, table:{}, table_id:{}, request_id:{}, err:{}",
-                        table_data.name, table_data.id, request_id, e
-                    );
-
-                    // Unset the compaction mark.
-                    compaction_task.mark_files_being_compacted(false);
-                }
-            }
-        });
+            self.handle_table_compaction_request(TableCompactionRequest::no_waiter(
+                table_data, None,
+            ))
+            .await;
+        }
     }
 
     async fn flush_tables(&self) {

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -623,8 +623,6 @@ impl ScheduleWorker {
                     "Table has no expired sst, table:{}, table_id:{}, expire_time:{:?}",
                     table_data.name, table_data.id, expire_time
                 );
-
-                continue;
             }
 
             // Create a compaction task that only purge expired files.

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -605,11 +605,11 @@ impl ScheduleWorker {
     }
 
     async fn schedule(&mut self) {
-        self.purge_tables().await;
+        self.compact_tables().await;
         self.flush_tables().await;
     }
 
-    async fn purge_tables(&mut self) {
+    async fn compact_tables(&mut self) {
         let mut tables_buf = Vec::new();
         self.space_store.list_all_tables(&mut tables_buf);
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -18,7 +18,7 @@ use futures::{
     future::try_join_all,
     stream, SinkExt, TryStreamExt,
 };
-use log::{error, info};
+use log::{debug, error, info};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::{predicate::Predicate, table::Result as TableResult};
 use tokio::sync::oneshot;
@@ -800,6 +800,10 @@ impl SpaceStore {
         request_id: RequestId,
         task: &CompactionTask,
     ) -> Result<()> {
+        debug!(
+            "Begin compact table, table_name:{}, id:{},task:{:?}",
+            table_data.name, table_data.id, task
+        );
         let mut edit_meta = VersionEditMeta {
             space_id: table_data.space_id,
             table_id: table_data.id,
@@ -853,6 +857,10 @@ impl SpaceStore {
         input: &CompactionInputFiles,
         edit_meta: &mut VersionEditMeta,
     ) -> Result<()> {
+        debug!(
+            "Compact input files, table_name:{}, id:{}, input::{:?}, edit_meta:{:?}",
+            table_data.name, table_data.id, input, edit_meta
+        );
         if input.files.is_empty() {
             return Ok(());
         }

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -801,7 +801,7 @@ impl SpaceStore {
         task: &CompactionTask,
     ) -> Result<()> {
         debug!(
-            "Begin compact table, table_name:{}, id:{},task:{:?}",
+            "Begin compact table, table_name:{}, id:{}, task:{:?}",
             table_data.name, table_data.id, task
         );
         let mut edit_meta = VersionEditMeta {

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -345,7 +345,7 @@ impl Instance {
 
         let compact_req = TableCompactionRequest::no_waiter(
             table_data.clone(),
-            worker_local.compaction_notifier(),
+            Some(worker_local.compaction_notifier()),
         );
         let instance = self.clone();
 

--- a/analytic_engine/src/instance/write_worker.rs
+++ b/analytic_engine/src/instance/write_worker.rs
@@ -967,7 +967,7 @@ impl WriteWorker {
 
         let request = TableCompactionRequest {
             table_data,
-            compaction_notifier: self.local.compaction_notifier(),
+            compaction_notifier: Some(self.local.compaction_notifier()),
             waiter,
         };
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In current implementation, when a table has no write any more, its data will never be compacted.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Update scheduler, do table compact at fixed interval.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

Manullay.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

