### PR TITLE
feat: add max_input_sstable_size

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -2,7 +2,7 @@
 
 //! Compaction.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use common_util::config::{ReadableSize, TimeUnit};
 use serde_derive::Deserialize;
@@ -81,6 +81,16 @@ pub struct TimeWindowCompactionOptions {
     pub timestamp_resolution: TimeUnit,
 }
 
+// TODO: MAX_INPUT_SSTABLE_SIZE is a temp solution to control sst size
+// Remove this when we can control compaction's output size
+// https://github.com/CeresDB/ceresdb/issues/408
+pub fn get_max_input_sstable_size() -> ReadableSize {
+    match std::env::var("CERESDB_MAX_INPUT_SSTABLE_SIZE") {
+        Ok(size) => ReadableSize::from_str(&size).unwrap_or_else(|_| ReadableSize::mb(1200)),
+        Err(_) => ReadableSize::mb(1200),
+    }
+}
+
 impl Default for SizeTieredCompactionOptions {
     fn default() -> Self {
         Self {
@@ -89,7 +99,7 @@ impl Default for SizeTieredCompactionOptions {
             min_sstable_size: ReadableSize::mb(50),
             min_threshold: 4,
             max_threshold: 16,
-            max_input_sstable_size: ReadableSize::mb(1200),
+            max_input_sstable_size: get_max_input_sstable_size(),
         }
     }
 }

--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -87,7 +87,7 @@ impl Default for SizeTieredCompactionOptions {
             bucket_low: 0.5,
             bucket_high: 1.5,
             min_sstable_size: ReadableSize::mb(50),
-            min_threshold: 2,
+            min_threshold: 4,
             max_threshold: 16,
             max_input_sstable_size: ReadableSize::mb(1200),
         }
@@ -477,13 +477,14 @@ mod tests {
         let c = CompactionStrategy::SizeTiered(opts);
         let mut m = HashMap::new();
         c.fill_raw_map(&mut m);
-        assert_eq!(6, m.len());
+        assert_eq!(7, m.len());
         assert_eq!(m[COMPACTION_STRATEGY], "size_tiered");
         assert_eq!(m[BUCKET_LOW_KEY], "0.1");
         assert_eq!(m[BUCKET_HIGH_KEY], "1.5");
         assert_eq!(m[MIN_SSTABLE_SIZE_KEY], "1024");
         assert_eq!(m[MIN_THRESHOLD_KEY], "4");
         assert_eq!(m[MAX_THRESHOLD_KEY], "10");
+        assert_eq!(m[MAX_INPUT_SSTABLE_SIZE_KEY], "1258291200");
         assert_eq!(
             c,
             CompactionStrategy::parse_from("size_tiered", &m).unwrap()
@@ -497,7 +498,7 @@ mod tests {
         let mut m = HashMap::new();
         c.fill_raw_map(&mut m);
 
-        assert_eq!(7, m.len());
+        assert_eq!(8, m.len());
         assert_eq!(m[COMPACTION_STRATEGY], "time_window");
         assert_eq!(m[BUCKET_LOW_KEY], "0.1");
         assert_eq!(m[BUCKET_HIGH_KEY], "1.5");
@@ -505,6 +506,8 @@ mod tests {
         assert_eq!(m[MIN_THRESHOLD_KEY], "4");
         assert_eq!(m[MAX_THRESHOLD_KEY], "10");
         assert_eq!(m[TIMESTAMP_RESOLUTION_KEY], "milliseconds");
+        assert_eq!(m[MAX_INPUT_SSTABLE_SIZE_KEY], "1258291200");
+
         assert_eq!(
             c,
             CompactionStrategy::parse_from("time_window", &m).unwrap()

--- a/analytic_engine/src/table_options.rs
+++ b/analytic_engine/src/table_options.rs
@@ -459,7 +459,6 @@ impl From<SizeTieredCompactionOptions> for common_pb::CompactionOptions {
             max_threshold: opts.max_threshold as u32,
             // FIXME: Is it ok to use the default timestamp resolution here?
             timestamp_resolution: common_pb::TimeUnit::Nanoseconds as i32,
-            max_input_sstable_size: opts.max_input_sstable_size.as_bytes() as u32,
         }
     }
 }
@@ -472,7 +471,7 @@ impl From<common_pb::CompactionOptions> for SizeTieredCompactionOptions {
             min_sstable_size: ReadableSize(opts.min_sstable_size as u64),
             min_threshold: opts.min_threshold as usize,
             max_threshold: opts.max_threshold as usize,
-            max_input_sstable_size: ReadableSize(opts.max_input_sstable_size as u64),
+            max_input_sstable_size: ReadableSize(1200),
         }
     }
 }
@@ -486,7 +485,6 @@ impl From<TimeWindowCompactionOptions> for common_pb::CompactionOptions {
             min_threshold: v.size_tiered.min_threshold as u32,
             max_threshold: v.size_tiered.max_threshold as u32,
             timestamp_resolution: common_pb::TimeUnit::from(v.timestamp_resolution) as i32,
-            max_input_sstable_size: v.size_tiered.max_input_sstable_size.as_bytes() as u32,
         }
     }
 }

--- a/analytic_engine/src/table_options.rs
+++ b/analytic_engine/src/table_options.rs
@@ -459,6 +459,7 @@ impl From<SizeTieredCompactionOptions> for common_pb::CompactionOptions {
             max_threshold: opts.max_threshold as u32,
             // FIXME: Is it ok to use the default timestamp resolution here?
             timestamp_resolution: common_pb::TimeUnit::Nanoseconds as i32,
+            max_input_sstable_size: opts.max_input_sstable_size.as_bytes() as u32,
         }
     }
 }
@@ -471,6 +472,7 @@ impl From<common_pb::CompactionOptions> for SizeTieredCompactionOptions {
             min_sstable_size: ReadableSize(opts.min_sstable_size as u64),
             min_threshold: opts.min_threshold as usize,
             max_threshold: opts.max_threshold as usize,
+            max_input_sstable_size: ReadableSize(opts.max_input_sstable_size as u64),
         }
     }
 }
@@ -484,6 +486,7 @@ impl From<TimeWindowCompactionOptions> for common_pb::CompactionOptions {
             min_threshold: v.size_tiered.min_threshold as u32,
             max_threshold: v.size_tiered.max_threshold as u32,
             timestamp_resolution: common_pb::TimeUnit::from(v.timestamp_resolution) as i32,
+            max_input_sstable_size: v.size_tiered.max_input_sstable_size.as_bytes() as u32,
         }
     }
 }

--- a/analytic_engine/src/table_options.rs
+++ b/analytic_engine/src/table_options.rs
@@ -17,7 +17,7 @@ use snafu::{Backtrace, GenerateBacktrace, ResultExt, Snafu};
 use table_engine::OPTION_KEY_ENABLE_TTL;
 
 use crate::compaction::{
-    CompactionStrategy, SizeTieredCompactionOptions, TimeWindowCompactionOptions,
+    self, CompactionStrategy, SizeTieredCompactionOptions, TimeWindowCompactionOptions,
 };
 
 pub const SEGMENT_DURATION: &str = "segment_duration";
@@ -471,7 +471,7 @@ impl From<common_pb::CompactionOptions> for SizeTieredCompactionOptions {
             min_sstable_size: ReadableSize(opts.min_sstable_size as u64),
             min_threshold: opts.min_threshold as usize,
             max_threshold: opts.max_threshold as usize,
-            max_input_sstable_size: ReadableSize(1200),
+            max_input_sstable_size: compaction::get_max_input_sstable_size(),
         }
     }
 }

--- a/proto/protos/analytic_common.proto
+++ b/proto/protos/analytic_common.proto
@@ -47,6 +47,7 @@ message CompactionOptions {
   uint32 max_threshold = 5;
   // Options for TWCS
   TimeUnit timestamp_resolution = 6;
+  uint32 max_input_sstable_size = 7;
 }
 
 enum TimeUnit {

--- a/proto/protos/analytic_common.proto
+++ b/proto/protos/analytic_common.proto
@@ -47,7 +47,6 @@ message CompactionOptions {
   uint32 max_threshold = 5;
   // Options for TWCS
   TimeUnit timestamp_resolution = 6;
-  uint32 max_input_sstable_size = 7;
 }
 
 enum TimeUnit {


### PR DESCRIPTION
# Which issue does this PR close?

Part of #408

# Rationale for this change
 
The target of #408 plan to limit output sst file, but there is no easy way to tell how large the output file will be, so
this PR use another strategy: limit total input size.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

When pick files for compaction, add a new limit: `max_input_sstable_size`,
it will control total input file size to compact.

For now, we can custom it via environment variables, such as
```
export CERESDB_MAX_INPUT_SSTABLE_SIZE=1G
```


<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->
No
# How does this change test

New unit test `test_size_tiered_picker`

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

