### PR TITLE
fix: wrong profile output os path for heap profiling

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -331,7 +331,7 @@ impl CompactionTask {
     }
 
     // Estimate the size of the total input files.
-    pub fn estimate_total_input_size(&self) -> usize {
+    pub fn estimated_total_input_file_size(&self) -> usize {
         let total_input_size: u64 = self
             .compaction_inputs
             .iter()
@@ -339,6 +339,10 @@ impl CompactionTask {
             .sum();
 
         total_input_size as usize
+    }
+
+    pub fn num_input_files(&self) -> usize {
+        self.compaction_inputs.iter().map(|v| v.files.len()).sum()
     }
 }
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -822,6 +822,14 @@ impl SpaceStore {
             self.delete_expired_files(table_data, request_id, files, &mut edit_meta);
         }
 
+        info!(
+            "try do compaction for table:{}#{}, estimated input files size:{}, input files number:{}",
+            table_data.name,
+            table_data.id,
+            task.estimated_total_input_file_size(),
+            task.num_input_files(),
+        );
+
         for input in &task.compaction_inputs {
             self.compact_input_files(
                 runtime.clone(),

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [package.edition]
 workspace = true
+
 [dependencies.jemalloc-sys]
 version = "0.3.2"
 features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]

--- a/components/profile/src/lib.rs
+++ b/components/profile/src/lib.rs
@@ -4,7 +4,7 @@
 
 use std::{
     fmt::Formatter,
-    fs::File,
+    fs::{File, OpenOptions},
     io,
     io::Read,
     sync::{Mutex, MutexGuard},
@@ -105,16 +105,15 @@ impl Profiler {
         thread::sleep(time::Duration::from_secs(seconds));
 
         // clearing the profile output file before dumping profile results.
-        {
-            let f = File::open(PROFILE_OUTPUT_FILE_PATH).map_err(|e| {
+        let _ = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(PROFILE_OUTPUT_FILE_PATH)
+            .map_err(|e| {
                 error!("Failed to open prof data file, err:{}", e);
                 Error::IO(e)
             })?;
-            f.set_len(0).map_err(|e| {
-                error!("Failed to truncate profile output file, err:{}", e);
-                Error::IO(e)
-            })?;
-        }
 
         // dump the profile results to profile output file.
         dump_profile().map_err(|e| {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #471 

# Rationale for this change
 The #471 is caused by the wrong path of profile result output. And this PR will fix it.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add some logs for some module.
- Fix wrong path for the profile result output.
- Create the profile output file if not exists.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
