### PR TITLE
feat: support parsing partition table creating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5586,6 +5586,7 @@ dependencies = [
  "common_util",
  "datafusion",
  "datafusion-expr",
+ "datafusion-proto",
  "df_operator",
  "hashbrown",
  "log",

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -22,6 +22,7 @@ common_types = { workspace = true }
 common_util = { workspace = true }
 datafusion = { workspace = true }
 datafusion-expr = { workspace = true }
+datafusion-proto = { workspace = true }
 df_operator = { workspace = true }
 hashbrown = { version = "0.12", features = ["raw"] }
 log = { workspace = true }

--- a/sql/src/ast.rs
+++ b/sql/src/ast.rs
@@ -13,7 +13,7 @@ pub enum Statement {
     Standard(Box<SqlStatement>),
     // Other extensions
     /// CREATE TABLE
-    Create(CreateTable),
+    Create(Box<CreateTable>),
     /// Drop TABLE
     Drop(DropTable),
     Describe(DescribeTable),
@@ -69,6 +69,22 @@ pub struct CreateTable {
     pub constraints: Vec<TableConstraint>,
     /// Table options in `WITH`.
     pub options: Vec<SqlOption>,
+    pub partition: Option<Partition>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Partition {
+    Hash(HashPartition),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct HashPartition {
+    /// Decide to use which hash algorithm
+    ///
+    /// You can see: https://dev.mysql.com/doc/refman/8.0/en/partitioning-hash.html
+    pub linear: bool,
+    pub partition_num: u64,
+    pub expr: sqlparser::ast::Expr,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/sql/src/lib.rs
+++ b/sql/src/lib.rs
@@ -11,6 +11,7 @@ pub mod ast;
 pub mod container;
 pub mod frontend;
 pub mod parser;
+pub(crate) mod partition;
 pub mod plan;
 pub mod planner;
 pub mod promql;

--- a/sql/src/partition.rs
+++ b/sql/src/partition.rs
@@ -1,0 +1,66 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Parse partition statement to partition info
+
+use datafusion::prelude::Column;
+use datafusion_expr::Expr;
+use datafusion_proto::bytes::Serializeable;
+use snafu::ResultExt;
+use sqlparser::ast::Expr as SqlExpr;
+use table_engine::partition::{Definition, HashPartitionInfo, PartitionInfo};
+
+use crate::{
+    ast::{HashPartition, Partition},
+    planner::{ParsePartitionWithCause, Result, UnsupportedPartition},
+};
+
+pub struct PartitionParser;
+
+impl PartitionParser {
+    pub fn parse(partition_stmt: Partition) -> Result<PartitionInfo> {
+        Ok(match partition_stmt {
+            Partition::Hash(stmt) => PartitionInfo::Hash(PartitionParser::parse_hash(stmt)?),
+        })
+    }
+
+    pub fn parse_hash(hash_stmt: HashPartition) -> Result<HashPartitionInfo> {
+        let HashPartition {
+            linear,
+            partition_num,
+            expr,
+        } = hash_stmt;
+
+        let definitions = parse_to_definition(partition_num);
+
+        if let SqlExpr::Identifier(id) = expr {
+            let expr = Expr::Column(Column::from_name(id.value));
+            let expr =
+                expr.to_bytes()
+                    .map_err(|e| Box::new(e) as _)
+                    .context(ParsePartitionWithCause {
+                        msg: format!("found invalid expr in hash, expr:{}", expr),
+                    })?;
+
+            Ok(HashPartitionInfo {
+                definitions,
+                expr,
+                linear,
+            })
+        } else {
+            UnsupportedPartition {
+                msg: format!("unsupported expr:{}", expr),
+            }
+            .fail()
+        }
+    }
+}
+
+fn parse_to_definition(partition_num: u64) -> Vec<Definition> {
+    (0..partition_num)
+        .into_iter()
+        .map(|p| Definition {
+            name: format!("{}", p),
+            origin_name: None,
+        })
+        .collect()
+}

--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -268,7 +268,7 @@ impl<'a, P: MetaProvider> Planner<'a, P> {
 
         match statement {
             Statement::Standard(s) => planner.sql_statement_to_plan(*s),
-            Statement::Create(s) => planner.create_table_to_plan(s),
+            Statement::Create(s) => planner.create_table_to_plan(*s),
             Statement::Drop(s) => planner.drop_table_to_plan(s),
             Statement::Describe(s) => planner.describe_table_to_plan(s),
             Statement::AlterModifySetting(s) => planner.alter_modify_setting_to_plan(s),

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -85,5 +85,5 @@ impl From<meta_pb::add_table_meta::PartitionInfo> for PartitionInfo {
 }
 
 pub fn format_sub_partition_table_name(table_name: &str, partition_name: &str) -> String {
-    format!("__{}_{}", table_name, partition_name)
+    format!("____{}_{}", table_name, partition_name)
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
We need to support table partition now, this pr is for supporting parsing the related sql to statement.
The syntax is same as [Mysql](https://dev.mysql.com/doc/refman/8.0/en/partitioning-types.html) .
But now, we only support the hash strategy. 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Add sql syntax support for creating partition table(only hash strategy).
Mainly modify `sql/src/parser.rs`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Ceresdb can accept related sql syntax now(but related function is not supported yet).
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
