### PR TITLE
feat: make the bloom filter optional in sst meta

### DIFF
--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -131,12 +131,12 @@ impl<'a> Reader<'a> {
         &self,
         schema: SchemaRef,
         row_groups: &[RowGroupMetaData],
-        bloom_filter: &BloomFilter,
+        bloom_filter: &Option<BloomFilter>,
     ) -> Result<Vec<usize>> {
         let filter = RowGroupFilter::try_new(
             &schema,
             row_groups,
-            bloom_filter.filters(),
+            bloom_filter.as_ref().map(|v| v.filters()),
             self.predicate.exprs(),
         )?;
 

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -159,8 +159,8 @@ impl RecordBytesReader {
 
     async fn read_all(mut self) -> Result<Vec<u8>> {
         self.partition_record_batch().await?;
-        let filters = self.build_bloom_filter();
-        self.meta_data.bloom_filter = filters;
+        let filter = self.build_bloom_filter();
+        self.meta_data.bloom_filter = Some(filter);
 
         let mut parquet_encoder = ParquetEncoder::try_new(
             self.num_rows_per_row_group,

--- a/analytic_engine/src/sst/parquet/reader.rs
+++ b/analytic_engine/src/sst/parquet/reader.rs
@@ -253,7 +253,7 @@ impl ProjectAndFilterReader {
         let filter = RowGroupFilter::try_new(
             self.schema.as_arrow_schema_ref(),
             row_groups,
-            self.meta_data.bloom_filter.filters(),
+            self.meta_data.bloom_filter.as_ref().map(|v| v.filters()),
             self.predicate.exprs(),
         )?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Prepare for #489 

# Rationale for this change
 Currently, bloom filter index is necessary in the sst reader. However, this is actually optional.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Make the bloom filter index in the sst reader optional.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Current tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
