### PR TITLE
feat: support store with readonly cache

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -644,7 +644,7 @@ impl Instance {
                     .new_sst_builder(
                         &sst_builder_options_clone,
                         &sst_file_path,
-                        store.store_ref(),
+                        store.default_store(),
                     )
                     .context(InvalidSstType { sst_type })?;
 
@@ -754,7 +754,7 @@ impl Instance {
             .new_sst_builder(
                 &sst_builder_options,
                 &sst_file_path,
-                self.space_store.store_ref(),
+                self.space_store.default_store(),
             )
             .context(InvalidSstType {
                 sst_type: table_data.sst_type,
@@ -930,7 +930,7 @@ impl SpaceStore {
                 predicate: Arc::new(Predicate::empty()),
                 sst_factory: &self.sst_factory,
                 sst_reader_options,
-                store: self.store_ref(),
+                store: self.store_with_readonly_cache(),
                 merge_iter_options: iter_options.clone(),
                 need_dedup: table_options.need_dedup(),
                 reverse: false,
@@ -966,7 +966,7 @@ impl SpaceStore {
         };
         let mut sst_builder = self
             .sst_factory
-            .new_sst_builder(&sst_builder_options, &sst_file_path, self.store_ref())
+            .new_sst_builder(&sst_builder_options, &sst_file_path, self.default_store())
             .context(InvalidSstType {
                 sst_type: table_data.sst_type,
             })?;

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -101,6 +101,8 @@ pub struct SpaceStore {
     wal_manager: WalManagerRef,
     /// Sst storage.
     store: ObjectStoreRef,
+    /// Sst storage with read only storage cache.
+    store_with_readonly_cache: ObjectStoreRef,
     /// Sst factory.
     sst_factory: SstFactoryRef,
 
@@ -126,8 +128,12 @@ impl SpaceStore {
 }
 
 impl SpaceStore {
-    fn store_ref(&self) -> &ObjectStoreRef {
+    fn default_store(&self) -> &ObjectStoreRef {
         &self.store
+    }
+
+    fn store_with_readonly_cache(&self) -> &ObjectStoreRef {
+        &self.store_with_readonly_cache
     }
 
     /// List all tables of all spaces

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -48,6 +48,7 @@ impl Instance {
         manifest: ManifestRef,
         wal_manager: WalManagerRef,
         store: ObjectStoreRef,
+        store_with_readonly_cache: ObjectStoreRef,
         sst_factory: SstFactoryRef,
     ) -> Result<Arc<Self>> {
         let space_store = Arc::new(SpaceStore {
@@ -55,6 +56,7 @@ impl Instance {
             manifest,
             wal_manager: wal_manager.clone(),
             store: store.clone(),
+            store_with_readonly_cache,
             sst_factory,
             meta_cache: ctx.meta_cache.clone(),
         });

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -179,7 +179,7 @@ impl Instance {
                 predicate: request.predicate.clone(),
                 sst_factory: &self.space_store.sst_factory,
                 sst_reader_options: sst_reader_options.clone(),
-                store: self.space_store.store_ref(),
+                store: self.space_store.default_store(),
                 merge_iter_options: iter_options.clone(),
                 need_dedup: table_options.need_dedup(),
                 reverse: request.order.is_in_desc_order(),
@@ -241,7 +241,7 @@ impl Instance {
                 predicate: request.predicate.clone(),
                 sst_reader_options: sst_reader_options.clone(),
                 sst_factory: &self.space_store.sst_factory,
-                store: self.space_store.store_ref(),
+                store: self.space_store.default_store(),
             };
             let builder = chain::Builder::new(chain_config);
             let chain_iter = builder

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -456,7 +456,7 @@ fn open_storage(
             );
             let default_store = Arc::new(MemCacheStore::new(mem_cache.clone(), store.clone())) as _;
             let store_with_readonly_cache =
-                Arc::new(MemCacheStore::new_read_only(mem_cache, store)) as _;
+                Arc::new(MemCacheStore::new_with_readonly_cache(mem_cache, store)) as _;
             Ok(OpenedStorages {
                 default_store,
                 store_with_readonly_cache,

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -158,6 +158,7 @@ pub struct MemCacheStore {
 }
 
 impl MemCacheStore {
+    /// Create a default [`MemCacheStore`].
     pub fn new(cache: MemCacheRef, underlying_store: ObjectStoreRef) -> Self {
         Self {
             cache,
@@ -166,7 +167,8 @@ impl MemCacheStore {
         }
     }
 
-    pub fn new_read_only(cache: MemCacheRef, underlying_store: ObjectStoreRef) -> Self {
+    /// Create a [`MemCacheStore`] with a readonly cache.
+    pub fn new_with_readonly_cache(cache: MemCacheRef, underlying_store: ObjectStoreRef) -> Self {
         Self {
             cache,
             underlying_store,


### PR DESCRIPTION
# Which issue does this PR close?

Prepare #489 

# Rationale for this change
 Mentioned by #489, some data from the object store is not necessary to do caching so an object store with readonly cache are needed.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add object store with readonly cache for the instance.
- Object store with readonly cache is used for reading input data in compaction procedure.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
