### PR TITLE
feat: introduce ObjectStorePicker to replace the two object stores

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -644,7 +644,7 @@ impl Instance {
                     .new_sst_builder(
                         &sst_builder_options_clone,
                         &sst_file_path,
-                        store.default_store(),
+                        store.store_picker(),
                     )
                     .context(InvalidSstType { sst_type })?;
 
@@ -754,7 +754,7 @@ impl Instance {
             .new_sst_builder(
                 &sst_builder_options,
                 &sst_file_path,
-                self.space_store.default_store(),
+                self.space_store.store_picker(),
             )
             .context(InvalidSstType {
                 sst_type: table_data.sst_type,
@@ -930,7 +930,7 @@ impl SpaceStore {
                 predicate: Arc::new(Predicate::empty()),
                 sst_factory: &self.sst_factory,
                 sst_reader_options,
-                store: self.store_with_readonly_cache(),
+                store_picker: self.store_picker(),
                 merge_iter_options: iter_options.clone(),
                 need_dedup: table_options.need_dedup(),
                 reverse: false,
@@ -966,7 +966,7 @@ impl SpaceStore {
         };
         let mut sst_builder = self
             .sst_factory
-            .new_sst_builder(&sst_builder_options, &sst_file_path, self.default_store())
+            .new_sst_builder(&sst_builder_options, &sst_file_path, self.store_picker())
             .context(InvalidSstType {
                 sst_type: table_data.sst_type,
             })?;

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -25,7 +25,6 @@ use std::{
 use common_util::{define_result, runtime::Runtime};
 use log::info;
 use mem_collector::MemUsageCollector;
-use object_store::ObjectStoreRef;
 use snafu::{ResultExt, Snafu};
 use table_engine::engine::EngineRuntimes;
 use wal::manager::WalManagerRef;
@@ -35,7 +34,11 @@ use crate::{
     meta::ManifestRef,
     row_iter::IterOptions,
     space::{SpaceId, SpaceRef},
-    sst::{factory::FactoryRef as SstFactoryRef, file::FilePurger, meta_cache::MetaCacheRef},
+    sst::{
+        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef},
+        file::FilePurger,
+        meta_cache::MetaCacheRef,
+    },
     table::data::TableDataRef,
     wal_synchronizer::WalSynchronizer,
     TableOptions,
@@ -99,10 +102,8 @@ pub struct SpaceStore {
     manifest: ManifestRef,
     /// Wal of all tables
     wal_manager: WalManagerRef,
-    /// Sst storage.
-    store: ObjectStoreRef,
-    /// Sst storage with read only storage cache.
-    store_with_readonly_cache: ObjectStoreRef,
+    /// Object store picker for persisting data.
+    store_picker: ObjectStorePickerRef,
     /// Sst factory.
     sst_factory: SstFactoryRef,
 
@@ -128,12 +129,8 @@ impl SpaceStore {
 }
 
 impl SpaceStore {
-    fn default_store(&self) -> &ObjectStoreRef {
-        &self.store
-    }
-
-    fn store_with_readonly_cache(&self) -> &ObjectStoreRef {
-        &self.store_with_readonly_cache
+    fn store_picker(&self) -> &ObjectStorePickerRef {
+        &self.store_picker
     }
 
     /// List all tables of all spaces

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -179,7 +179,7 @@ impl Instance {
                 predicate: request.predicate.clone(),
                 sst_factory: &self.space_store.sst_factory,
                 sst_reader_options: sst_reader_options.clone(),
-                store: self.space_store.default_store(),
+                store_picker: self.space_store.store_picker(),
                 merge_iter_options: iter_options.clone(),
                 need_dedup: table_options.need_dedup(),
                 reverse: request.order.is_in_desc_order(),
@@ -241,7 +241,7 @@ impl Instance {
                 predicate: request.predicate.clone(),
                 sst_reader_options: sst_reader_options.clone(),
                 sst_factory: &self.space_store.sst_factory,
-                store: self.space_store.default_store(),
+                store_picker: self.space_store.store_picker(),
             };
             let builder = chain::Builder::new(chain_config);
             let chain_iter = builder

--- a/analytic_engine/src/row_iter/chain.rs
+++ b/analytic_engine/src/row_iter/chain.rs
@@ -10,7 +10,6 @@ use common_types::{
 use common_util::define_result;
 use futures::StreamExt;
 use log::debug;
-use object_store::ObjectStoreRef;
 use snafu::{ResultExt, Snafu};
 use table_engine::{predicate::PredicateRef, table::TableId};
 
@@ -21,7 +20,7 @@ use crate::{
     },
     space::SpaceId,
     sst::{
-        factory::{FactoryRef as SstFactoryRef, SstReaderOptions},
+        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReaderOptions},
         file::FileHandle,
     },
     table::version::{MemTableVec, SamplingMemTable},
@@ -61,8 +60,8 @@ pub struct ChainConfig<'a> {
     pub sst_reader_options: SstReaderOptions,
     /// Sst factory
     pub sst_factory: &'a SstFactoryRef,
-    /// Sst storage
-    pub store: &'a ObjectStoreRef,
+    /// Store picker for persisting sst.
+    pub store_picker: &'a ObjectStorePickerRef,
 }
 
 /// Builder for [ChainIterator].
@@ -144,7 +143,7 @@ impl<'a> Builder<'a> {
                     sst,
                     self.config.sst_factory,
                     &self.config.sst_reader_options,
-                    self.config.store,
+                    self.config.store_picker,
                 )
                 .await
                 .context(BuildStreamFromSst)?;

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -21,7 +21,6 @@ use common_types::{
 use common_util::define_result;
 use futures::{future::try_join_all, StreamExt};
 use log::{debug, info, trace};
-use object_store::ObjectStoreRef;
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use table_engine::{predicate::PredicateRef, table::TableId};
 
@@ -33,7 +32,7 @@ use crate::{
     },
     space::SpaceId,
     sst::{
-        factory::{FactoryRef as SstFactoryRef, SstReaderOptions},
+        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReaderOptions},
         file::FileHandle,
         manager::{FileId, MAX_LEVEL},
     },
@@ -98,8 +97,8 @@ pub struct MergeConfig<'a> {
     pub sst_reader_options: SstReaderOptions,
     /// Sst factory
     pub sst_factory: &'a SstFactoryRef,
-    /// Sst storage
-    pub store: &'a ObjectStoreRef,
+    /// Store picker for persisting sst.
+    pub store_picker: &'a ObjectStorePickerRef,
 
     pub merge_iter_options: IterOptions,
 
@@ -208,7 +207,7 @@ impl<'a> MergeBuilder<'a> {
                     f,
                     self.config.sst_factory,
                     &self.config.sst_reader_options,
-                    self.config.store,
+                    self.config.store_picker,
                 )
                 .await
                 .context(BuildStreamFromSst)?;

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -16,7 +16,10 @@ use analytic_engine::{
     },
     space::SpaceId,
     sst::{
-        factory::{FactoryImpl, FactoryRef as SstFactoryRef, ReadFrequency, SstReaderOptions},
+        factory::{
+            FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
+            SstReaderOptions,
+        },
         meta_cache::MetaCacheRef,
     },
     table::{
@@ -136,6 +139,7 @@ impl MergeMemTableBench {
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
 
         let request_id = RequestId::next_id();
+        let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
             space_id,
@@ -145,7 +149,7 @@ impl MergeMemTableBench {
             predicate: Arc::new(Predicate::empty()),
             sst_factory: &sst_factory,
             sst_reader_options: self.sst_reader_options.clone(),
-            store: &self.store,
+            store_picker: &store_picker,
             merge_iter_options: iter_options.clone(),
             need_dedup: true,
             reverse: false,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -14,7 +14,10 @@ use analytic_engine::{
     },
     space::SpaceId,
     sst::{
-        factory::{FactoryImpl, FactoryRef as SstFactoryRef, ReadFrequency, SstReaderOptions},
+        factory::{
+            FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
+            SstReaderOptions,
+        },
         file::{FileHandle, FilePurgeQueue, Request},
         meta_cache::MetaCacheRef,
     },
@@ -119,6 +122,7 @@ impl MergeSstBench {
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
 
         let request_id = RequestId::next_id();
+        let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
             space_id,
@@ -128,7 +132,7 @@ impl MergeSstBench {
             predicate: Arc::new(Predicate::empty()),
             sst_factory: &sst_factory,
             sst_reader_options: self.sst_reader_options.clone(),
-            store: &self.store,
+            store_picker: &store_picker,
             merge_iter_options: iter_options.clone(),
             need_dedup: true,
             reverse: false,
@@ -168,6 +172,7 @@ impl MergeSstBench {
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
 
         let request_id = RequestId::next_id();
+        let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let builder = chain::Builder::new(ChainConfig {
             request_id,
             space_id,
@@ -176,7 +181,7 @@ impl MergeSstBench {
             predicate: Arc::new(Predicate::empty()),
             sst_factory: &sst_factory,
             sst_reader_options: self.sst_reader_options.clone(),
-            store: &self.store,
+            store_picker: &store_picker,
         })
         .ssts(vec![self.file_handles.clone()]);
 

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -5,7 +5,7 @@
 use std::{cmp, sync::Arc, time::Instant};
 
 use analytic_engine::sst::{
-    factory::{Factory, FactoryImpl, ReadFrequency, SstReaderOptions},
+    factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
     meta_cache::{MetaCache, MetaCacheRef},
 };
 use common_types::{projected_schema::ProjectedSchema, schema::Schema};
@@ -76,8 +76,9 @@ impl SstBench {
         let sst_path = Path::from(self.sst_file_name.clone());
 
         let sst_factory = FactoryImpl;
+        let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut sst_reader = sst_factory
-            .new_sst_reader(&self.sst_reader_options, &sst_path, &self.store)
+            .new_sst_reader(&self.sst_reader_options, &sst_path, &store_picker)
             .unwrap();
 
         self.runtime.block_on(async {

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -8,7 +8,7 @@ use analytic_engine::{
     memtable::{key::KeySequence, MemTableRef, PutContext},
     space::SpaceId,
     sst::{
-        factory::{Factory, FactoryImpl, ReadFrequency, SstReaderOptions},
+        factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
         file::{FileHandle, FileMeta, FilePurgeQueue, SstMetaData},
         manager::FileId,
         meta_cache::MetaCacheRef,
@@ -108,8 +108,9 @@ pub async fn load_sst_to_memtable(
         num_rows_per_row_group: 500,
     };
     let sst_factory = FactoryImpl;
+    let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
     let mut sst_reader = sst_factory
-        .new_sst_reader(&sst_reader_options, sst_path, store)
+        .new_sst_reader(&sst_reader_options, sst_path, &store_picker)
         .unwrap();
 
     let mut sst_stream = sst_reader.read().await.unwrap();

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -6,7 +6,8 @@ use std::{error::Error, sync::Arc};
 
 use analytic_engine::{
     sst::factory::{
-        Factory, FactoryImpl, ReadFrequency, SstBuilderOptions, SstReaderOptions, SstType,
+        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstBuilderOptions,
+        SstReaderOptions, SstType,
     },
     table_options::{Compression, StorageFormat, StorageFormatOptions},
 };
@@ -69,9 +70,9 @@ fn main() {
 
 async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let storage = LocalFileSystem::new_with_prefix(args.store_path).expect("invalid path");
-    let storage = Arc::new(storage) as _;
+    let store = Arc::new(storage) as _;
     let input_path = Path::from(args.input);
-    let mut sst_meta = sst_util::meta_from_sst(&storage, &input_path).await;
+    let mut sst_meta = sst_util::meta_from_sst(&store, &input_path).await;
     let factory = FactoryImpl;
     let reader_opts = SstReaderOptions {
         read_batch_row_num: 8192,
@@ -84,8 +85,9 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         background_read_parallelism: 1,
         num_rows_per_row_group: 8192,
     };
+    let store_picker: ObjectStorePickerRef = Arc::new(store);
     let mut reader = factory
-        .new_sst_reader(&reader_opts, &input_path, &storage)
+        .new_sst_reader(&reader_opts, &input_path, &store_picker)
         .expect("no sst reader found");
 
     let builder_opts = SstBuilderOptions {
@@ -96,7 +98,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     };
     let output = Path::from(args.output);
     let mut builder = factory
-        .new_sst_builder(&builder_opts, &output, &storage)
+        .new_sst_builder(&builder_opts, &output, &store_picker)
         .expect("no sst builder found");
     sst_meta.storage_format_opts = StorageFormatOptions::new(
         StorageFormat::try_from(args.format.as_str())


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
#490 introduced two object store for ceresdb instance, and that is a little bit ugly.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Introduce `ObjectStorePicker` to replace the two object stores.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
