### PR TITLE
feat: add implementation of key partition 

### DIFF
--- a/interpreters/src/show_create.rs
+++ b/interpreters/src/show_create.rs
@@ -139,6 +139,7 @@ impl ShowCreateInterpreter {
                     .as_str()
                 }
             }
+            PartitionInfo::Key(_) => {}
         }
 
         // TODO: update datafusion to remove `#`.

--- a/proto/protos/meta_update.proto
+++ b/proto/protos/meta_update.proto
@@ -28,7 +28,7 @@ message HashPartitionInfo {
 
 message KeyPartitionInfo {
   repeated Definition definitions = 1;
-  bytes partition_key = 2;
+  repeated string columns = 2;
   bool linear = 3;
 }
 

--- a/proto/protos/meta_update.proto
+++ b/proto/protos/meta_update.proto
@@ -26,6 +26,12 @@ message HashPartitionInfo {
   bool linear = 3;
 }
 
+message KeyPartitionInfo {
+  repeated Definition definitions = 1;
+  bytes partition_key = 2;
+  bool linear = 3;
+}
+
 // Meta update for a new table
 message AddTableMeta {
   uint32 space_id = 1;
@@ -37,6 +43,7 @@ message AddTableMeta {
   analytic_common.TableOptions options = 5;
   oneof partition_info {
     HashPartitionInfo hash  = 6;
+    KeyPartitionInfo key_partition = 7;
   }
 }
 

--- a/sql/src/ast.rs
+++ b/sql/src/ast.rs
@@ -75,6 +75,7 @@ pub struct CreateTable {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Partition {
     Hash(HashPartition),
+    Key(KeyPartition),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -85,6 +86,13 @@ pub struct HashPartition {
     pub linear: bool,
     pub partition_num: u64,
     pub expr: sqlparser::ast::Expr,
+}
+#[derive(Debug, PartialEq, Eq)]
+pub struct KeyPartition {
+    /// Key partition description: https://dev.mysql.com/doc/refman/5.7/en/partitioning-key.html
+    pub linear: bool,
+    pub partition_num: u64,
+    pub partition_key: ColumnDef,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/sql/src/ast.rs
+++ b/sql/src/ast.rs
@@ -92,7 +92,7 @@ pub struct KeyPartition {
     /// Key partition description: https://dev.mysql.com/doc/refman/5.7/en/partitioning-key.html
     pub linear: bool,
     pub partition_num: u64,
-    pub partition_key: ColumnDef,
+    pub partition_key: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -804,7 +804,10 @@ fn maybe_convert_table_name(object_name: &mut ObjectName) {
 
 #[cfg(test)]
 mod tests {
-    use sqlparser::ast::{ColumnOptionDef, DataType, Ident, ObjectName, Value};
+    use sqlparser::{
+        ast::{ColumnOptionDef, DataType, Ident, ObjectName, Value},
+        parser::ParserError::ParserError,
+    };
 
     use super::*;
     use crate::ast::TableName;
@@ -1361,6 +1364,54 @@ mod tests {
                 matches!(Parser::parse_sql(sql), Err(e) if format!("{:?}", e).contains("ParserError")
                     && format!("{:?}", e).contains("Expected literal number"))
             );
+        }
+    }
+
+    #[test]
+    fn test_key_partition() {
+        KeyPartitionTableCases::basic();
+        KeyPartitionTableCases::default_key_partition();
+        KeyPartitionTableCases::invalid_column_type();
+    }
+
+    struct KeyPartitionTableCases;
+
+    impl KeyPartitionTableCases {
+        fn basic() {
+            let sql = r#"CREATE TABLE `demo` (`name` string TAG, `value` double NOT NULL, `t` timestamp NOT NULL, TIMESTAMP KEY(t)) PARTITION BY KEY(name) PARTITIONS 2 ENGINE=Analytic with (enable_ttl="false")"#;
+            let stmt = Parser::parse_sql(sql).unwrap();
+            assert_eq!(stmt.len(), 1);
+            match &stmt[0] {
+                Statement::Create(v) => {
+                    if let Some(Partition::Key(p)) = &v.partition {
+                        assert!(!p.linear);
+                        assert_eq!(p.partition_key.name.value, "name");
+                        assert_eq!(p.partition_num, 2);
+                    } else {
+                        panic!("failed");
+                    };
+                }
+                _ => panic!("failed"),
+            }
+        }
+
+        fn default_key_partition() {
+            let sql = r#"CREATE TABLE `demo` (`name` string TAG, `value` double NOT NULL, `t` timestamp NOT NULL, TIMESTAMP KEY(t)) PARTITION BY KEY() PARTITIONS 2 ENGINE=Analytic with (enable_ttl="false")"#;
+            let stmt = Parser::parse_sql(sql);
+            assert_eq!(
+                stmt.err().unwrap(),
+                ParserError("Expected identifier, found: )".to_string())
+            );
+        }
+
+        fn invalid_column_type() {
+            let sql = r#"CREATE TABLE `demo` (`name` string TAG, `value` double NOT NULL, `t` timestamp NOT NULL, TIMESTAMP KEY(t)) PARTITION BY KEY(value) PARTITIONS 2 ENGINE=Analytic with (enable_ttl="false")"#;
+            let stmt = Parser::parse_sql(sql);
+
+            assert_eq!(
+                stmt.err().unwrap(),
+                ParserError(r#"partition key must be tag, key name:"value""#.to_string())
+            )
         }
     }
 }

--- a/sql/src/partition.rs
+++ b/sql/src/partition.rs
@@ -64,22 +64,9 @@ impl PartitionParser {
 
         let definitions = parse_to_definition(partition_num);
 
-        // TODO: In order to convert to pb format for persistence, columnDef is
-        // converted to expression, maybe there is better way?
-        let partition_key = Expr::Column(Column::from_name(partition_key.name.value));
-        let partition_key = partition_key
-            .to_bytes()
-            .map_err(|e| Box::new(e) as _)
-            .context(ParsePartitionWithCause {
-                msg: format!(
-                    "found invalid expr in partition key, partition_key:{}",
-                    partition_key
-                ),
-            })?;
-
         Ok(KeyPartitionInfo {
             definitions,
-            partition_key,
+            columns: partition_key,
             linear,
         })
     }

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -5,7 +5,6 @@
 pub mod rule;
 
 use common_types::bytes::Bytes;
-use datafusion::{common::Column, sql::sqlparser::ast::ColumnDef};
 use proto::meta_update as meta_pb;
 
 /// Info for how to partition table
@@ -40,7 +39,7 @@ pub struct HashPartitionInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyPartitionInfo {
     pub definitions: Vec<Definition>,
-    pub partition_key: Bytes,
+    pub columns: Vec<String>,
     pub linear: bool,
 }
 
@@ -80,7 +79,7 @@ impl From<PartitionInfo> for meta_pb::add_table_meta::PartitionInfo {
             }),
             PartitionInfo::Key(v) => Self::KeyPartition(meta_pb::KeyPartitionInfo {
                 definitions: v.definitions.into_iter().map(|v| v.into()).collect(),
-                partition_key: v.partition_key.to_vec(),
+                columns: v.columns,
                 linear: v.linear,
             }),
         }
@@ -98,7 +97,7 @@ impl From<meta_pb::add_table_meta::PartitionInfo> for PartitionInfo {
             meta_pb::add_table_meta::PartitionInfo::KeyPartition(v) => {
                 Self::Key(KeyPartitionInfo {
                     definitions: v.definitions.into_iter().map(|v| v.into()).collect(),
-                    partition_key: Bytes::from(v.partition_key),
+                    columns: v.columns,
                     linear: v.linear,
                 })
             }


### PR DESCRIPTION
# Which issue does this PR close?
https://github.com/CeresDB/ceresdb/issues/492

# Rationale for this change
Support the use of partition key to create partition tables.
```
CREATE TABLE `demo` (`name` string TAG, `value` double NOT NULL, `t` timestamp NOT NULL, TIMESTAMP KEY(t)) PARTITION BY KEY(name) PARTITIONS 2 ENGINE=Analytic with (enable_ttl="false")
```

# What changes are included in this PR?
* Add key partition parser.
* Add pb definition of `KeyPartition` to persist partition info.

# Are there any user-facing changes?
Users could create partition table by key partition sql.

# How does this change test
