### PR TITLE
chore: adjust usage of sst type

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -911,7 +911,6 @@ impl SpaceStore {
             let sequence = table_data.last_sequence();
             let projected_schema = ProjectedSchema::no_projection(schema.clone());
             let sst_reader_options = SstReaderOptions {
-                sst_type: table_data.sst_type,
                 read_batch_row_num: table_options.num_rows_per_row_group,
                 reverse: false,
                 frequency: ReadFrequency::Once,

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -153,7 +153,6 @@ impl Instance {
         let sequence = table_data.last_sequence();
         let projected_schema = request.projected_schema.clone();
         let sst_reader_options = SstReaderOptions {
-            sst_type: table_data.sst_type,
             read_batch_row_num: table_options.num_rows_per_row_group,
             reverse: request.order.is_in_desc_order(),
             frequency: ReadFrequency::Frequent,
@@ -216,7 +215,6 @@ impl Instance {
         assert!(request.order.is_out_of_order());
 
         let sst_reader_options = SstReaderOptions {
-            sst_type: table_data.sst_type,
             read_batch_row_num: table_options.num_rows_per_row_group,
             // no need to read in order so just read in asc order by default.
             reverse: false,

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -340,7 +340,6 @@ mod tests {
 
             // read sst back to test
             let sst_reader_options = SstReaderOptions {
-                sst_type: SstType::Parquet,
                 read_batch_row_num: 5,
                 reverse: false,
                 frequency: ReadFrequency::Frequent,

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -214,7 +214,7 @@ impl TableData {
             schema: Mutex::new(request.table_schema),
             space_id,
             // TODO(xikai): sst type should be decided by the `request`.
-            sst_type: SstType::Parquet,
+            sst_type: SstType::Auto,
             mutable_limit: AtomicU32::new(get_mutable_limit(&table_opts)),
             opts: ArcSwap::new(Arc::new(table_opts)),
             memtable_factory,

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -16,9 +16,7 @@ use analytic_engine::{
     },
     space::SpaceId,
     sst::{
-        factory::{
-            FactoryImpl, FactoryRef as SstFactoryRef, ReadFrequency, SstReaderOptions, SstType,
-        },
+        factory::{FactoryImpl, FactoryRef as SstFactoryRef, ReadFrequency, SstReaderOptions},
         meta_cache::MetaCacheRef,
     },
     table::{
@@ -192,7 +190,6 @@ fn mock_sst_reader_options(
     runtime: Arc<Runtime>,
 ) -> SstReaderOptions {
     SstReaderOptions {
-        sst_type: SstType::Parquet,
         read_batch_row_num: 500,
         reverse: false,
         frequency: ReadFrequency::Frequent,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -14,9 +14,7 @@ use analytic_engine::{
     },
     space::SpaceId,
     sst::{
-        factory::{
-            FactoryImpl, FactoryRef as SstFactoryRef, ReadFrequency, SstReaderOptions, SstType,
-        },
+        factory::{FactoryImpl, FactoryRef as SstFactoryRef, ReadFrequency, SstReaderOptions},
         file::{FileHandle, FilePurgeQueue, Request},
         meta_cache::MetaCacheRef,
     },
@@ -61,7 +59,6 @@ impl MergeSstBench {
         let predicate = config.predicate.into_predicate();
         let projected_schema = ProjectedSchema::no_projection(schema.clone());
         let sst_reader_options = SstReaderOptions {
-            sst_type: SstType::Parquet,
             read_batch_row_num: config.read_batch_row_num,
             reverse: false,
             frequency: ReadFrequency::Frequent,

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -5,7 +5,7 @@
 use std::{cmp, sync::Arc, time::Instant};
 
 use analytic_engine::sst::{
-    factory::{Factory, FactoryImpl, ReadFrequency, SstReaderOptions, SstType},
+    factory::{Factory, FactoryImpl, ReadFrequency, SstReaderOptions},
     meta_cache::{MetaCache, MetaCacheRef},
 };
 use common_types::{projected_schema::ProjectedSchema, schema::Schema};
@@ -38,7 +38,6 @@ impl SstBench {
         let predicate = config.predicate.into_predicate();
         let projected_schema = ProjectedSchema::no_projection(schema.clone());
         let sst_reader_options = SstReaderOptions {
-            sst_type: SstType::Parquet,
             read_batch_row_num: config.read_batch_row_num,
             reverse: config.reverse,
             frequency: ReadFrequency::Frequent,

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -92,7 +92,6 @@ pub async fn rebuild_sst(config: RebuildSstConfig, runtime: Arc<Runtime>) {
 
     let projected_schema = ProjectedSchema::no_projection(sst_meta.schema.clone());
     let sst_reader_options = SstReaderOptions {
-        sst_type: SstType::Parquet,
         read_batch_row_num: config.read_batch_row_num,
         reverse: false,
         frequency: ReadFrequency::Once,
@@ -195,7 +194,6 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
         let sequence = max_sequence + 1;
         let projected_schema = ProjectedSchema::no_projection(schema.clone());
         let sst_reader_options = SstReaderOptions {
-            sst_type: SstType::Parquet,
             read_batch_row_num: config.read_batch_row_num,
             reverse: false,
             frequency: ReadFrequency::Once,

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -8,7 +8,7 @@ use analytic_engine::{
     memtable::{key::KeySequence, MemTableRef, PutContext},
     space::SpaceId,
     sst::{
-        factory::{Factory, FactoryImpl, ReadFrequency, SstReaderOptions, SstType},
+        factory::{Factory, FactoryImpl, ReadFrequency, SstReaderOptions},
         file::{FileHandle, FileMeta, FilePurgeQueue, SstMetaData},
         manager::FileId,
         meta_cache::MetaCacheRef,
@@ -97,7 +97,6 @@ pub async fn load_sst_to_memtable(
     runtime: Arc<Runtime>,
 ) {
     let sst_reader_options = SstReaderOptions {
-        sst_type: SstType::Parquet,
         read_batch_row_num: 500,
         reverse: false,
         frequency: ReadFrequency::Frequent,

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -74,7 +74,6 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let mut sst_meta = sst_util::meta_from_sst(&storage, &input_path).await;
     let factory = FactoryImpl;
     let reader_opts = SstReaderOptions {
-        sst_type: SstType::Parquet,
         read_batch_row_num: 8192,
         reverse: false,
         frequency: ReadFrequency::Once,


### PR DESCRIPTION
# Which issue does this PR close?

Prepare for #495 

# Rationale for this change
 Refer to #495:
> Currently, the sst type is used to decide which type of sst reader/builder to create, but this option is configured for table level, that is to say, one table can only use one sst type. I guess this is not reasonable, and it is more flexible and elegant to allow the data of one table being encoded in different sst formats. So I guess we make this option only works when deciding the type of sst builder, and add a new sst type called Auto for the flexibility of choosing a better sst format.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Remove sst type option when reading sst;
- Add a new sst type called `Auto`;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
