### PR TITLE
fix: bugs when table migrate between shards

### DIFF
--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -105,7 +105,7 @@ impl Instance {
         });
         self.space_store
             .manifest
-            .store_update(MetaUpdateRequest::new(table_data.wal_location(), update))
+            .store_update(MetaUpdateRequest::new(table_data.table_location(), update))
             .await
             .context(WriteManifest {
                 space_id: space.id,

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -111,7 +111,7 @@ impl Instance {
         });
         self.space_store
             .manifest
-            .store_update(MetaUpdateRequest::new(table_data.wal_location(), update))
+            .store_update(MetaUpdateRequest::new(table_data.table_location(), update))
             .await
             .context(WriteManifest {
                 space_id: space.id,

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -22,12 +22,13 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use common_types::table::TableId;
 use common_util::{define_result, runtime::Runtime};
 use log::info;
 use mem_collector::MemUsageCollector;
 use snafu::{ResultExt, Snafu};
 use table_engine::{engine::EngineRuntimes, remote::RemoteEngineRef};
-use wal::manager::WalManagerRef;
+use wal::manager::{WalLocation, WalManagerRef};
 
 use crate::{
     compaction::scheduler::CompactionSchedulerRef,
@@ -39,7 +40,7 @@ use crate::{
         file::FilePurger,
         meta_data::cache::MetaCacheRef,
     },
-    table::data::TableDataRef,
+    table::data::{TableDataRef, TableShardInfo},
     wal_synchronizer::WalSynchronizer,
     TableOptions,
 };
@@ -239,3 +240,12 @@ impl Instance {
 
 /// Instance reference
 pub type InstanceRef = Arc<Instance>;
+
+#[inline]
+pub(crate) fn create_wal_location(table_id: TableId, shard_info: TableShardInfo) -> WalLocation {
+    WalLocation::new(
+        shard_info.shard_id as u64,
+        shard_info.cluster_version,
+        table_id,
+    )
+}

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -19,6 +19,7 @@ use tokio::sync::oneshot;
 use wal::manager::{SequenceNumber, WalLocation, WriteContext};
 
 use crate::{
+    instance,
     instance::{
         flush_compaction::TableFlushOptions,
         write_worker,
@@ -401,7 +402,9 @@ impl Instance {
 
         // Encode payload
         let payload = WritePayload::Write(&write_req_pb);
-        let wal_location = table_data.wal_location();
+        let table_location = table_data.table_location();
+        let wal_location =
+            instance::create_wal_location(table_location.id, table_location.shard_info);
         let log_batch_encoder =
             self.space_store
                 .wal_manager

--- a/wal/src/kv_encoder.rs
+++ b/wal/src/kv_encoder.rs
@@ -15,7 +15,7 @@ use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
 use crate::{
     log_batch::{LogWriteBatch, LogWriteEntry, Payload},
-    manager::{self, Encoding, RegionId, WalLocation},
+    manager::{self, Encoding, WalLocation},
 };
 
 pub const LOG_KEY_ENCODING_V0: u8 = 0;
@@ -119,7 +119,7 @@ pub enum Namespace {
 
 /// Log key in old wal design, map the `TableId` to `RegionId`
 #[allow(unused)]
-pub type LogKey = (RegionId, SequenceNumber);
+pub type LogKey = (u64, SequenceNumber);
 
 #[allow(unused)]
 #[derive(Debug, Clone)]
@@ -278,7 +278,7 @@ pub struct MetaKeyEncoder {
 
 #[derive(Clone, Debug)]
 pub struct MetaKey {
-    pub region_id: RegionId,
+    pub region_id: u64,
 }
 
 impl MetaKeyEncoder {
@@ -597,14 +597,14 @@ impl LogBatchEncoder {
 pub struct CommonLogKey {
     /// Id of region which the table belongs to,
     /// region may be mapped to table itself, shard, or others...
-    pub region_id: RegionId,
+    pub region_id: u64,
     pub table_id: TableId,
     pub sequence_num: SequenceNumber,
 }
 
 #[allow(unused)]
 impl CommonLogKey {
-    pub fn new(region_id: RegionId, table_id: TableId, sequence_num: SequenceNumber) -> Self {
+    pub fn new(region_id: u64, table_id: TableId, sequence_num: SequenceNumber) -> Self {
         Self {
             region_id,
             table_id,

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -135,7 +135,7 @@ pub struct WalLocation {
 }
 
 impl WalLocation {
-    pub fn new(region_id: RegionId, region_version: RegionVersion, table_id: TableId) -> Self {
+    pub fn new(region_id: u64, region_version: u64, table_id: TableId) -> Self {
         let versioned_region_id = VersionedRegionId {
             version: region_version,
             id: region_id,
@@ -150,18 +150,20 @@ impl WalLocation {
 
 /// Region id with version
 ///
-/// The `version` may be mapped to cluster version(while shard moved from nodes,
+/// Region is used to describe a set of table's log unit.
+///
+/// The `id` is used to identify the `Region`, can be mapped to table's related
+/// information(e.g. `shard id`, `table id`).
+///
+/// The `version` is introduced for solving the following bug:
+///     https://github.com/CeresDB/ceresdb/issues/441.
+/// It may be mapped to cluster version(while shard moved from nodes,
 /// it may changed to mark this moving) now.
-/// Introduce this field is for solving the following bug: https://github.com/CeresDB/ceresdb/issues/441
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct VersionedRegionId {
-    pub version: RegionVersion,
-    pub id: RegionId,
+    pub version: u64,
+    pub id: u64,
 }
-
-pub type RegionId = u64;
-pub const MAX_REGION_ID: RegionId = u64::MAX;
-pub type RegionVersion = u64;
 
 #[derive(Debug, Clone)]
 pub struct WriteContext {
@@ -258,7 +260,7 @@ impl Default for ReadRequest {
     fn default() -> Self {
         Self {
             location: WalLocation::new(
-                DEFAULT_SHARD_ID as RegionId,
+                DEFAULT_SHARD_ID as u64,
                 DEFAULT_CLUSTER_VERSION,
                 TableId::MIN,
             ),

--- a/wal/src/message_queue_impl/encoding.rs
+++ b/wal/src/message_queue_impl/encoding.rs
@@ -16,7 +16,7 @@ use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
 use crate::{
     kv_encoder::Namespace,
-    manager::{self, RegionId},
+    manager::{self},
     message_queue_impl::region_context::{RegionMetaSnapshot, TableMetaData},
 };
 
@@ -94,13 +94,13 @@ define_result!(Error);
 
 /// Generate wal data topic name
 #[allow(unused)]
-pub fn format_wal_data_topic_name(namespace: &str, region_id: RegionId) -> String {
+pub fn format_wal_data_topic_name(namespace: &str, region_id: u64) -> String {
     format!("{}_data_{}", namespace, region_id)
 }
 
 /// Generate wal meta topic name
 #[allow(unused)]
-pub fn format_wal_meta_topic_name(namespace: &str, region_id: RegionId) -> String {
+pub fn format_wal_meta_topic_name(namespace: &str, region_id: u64) -> String {
     format!("{}_meta_{}", namespace, region_id)
 }
 
@@ -179,7 +179,7 @@ impl MetaEncoding {
 /// Message queue implementation's meta key
 #[allow(unused)]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MetaKey(pub RegionId);
+pub struct MetaKey(pub u64);
 
 #[allow(unused)]
 #[derive(Clone, Debug)]

--- a/wal/src/message_queue_impl/log_cleaner.rs
+++ b/wal/src/message_queue_impl/log_cleaner.rs
@@ -9,7 +9,7 @@ use log::info;
 use message_queue::{MessageQueue, Offset};
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
-use crate::{manager::RegionId, message_queue_impl::region_context::RegionMetaSnapshot};
+use crate::message_queue_impl::region_context::RegionMetaSnapshot;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -20,7 +20,7 @@ pub enum Error {
         source
     ))]
     CleanLogsWithCause {
-        region_id: RegionId,
+        region_id: u64,
         topic: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -33,7 +33,7 @@ pub enum Error {
         backtrace,
     ))]
     CleanLogsNoCause {
-        region_id: RegionId,
+        region_id: u64,
         topic: String,
         msg: String,
         backtrace: Backtrace,
@@ -44,14 +44,14 @@ define_result!(Error);
 
 /// Check and clean the outdated logs
 pub struct LogCleaner<M: MessageQueue> {
-    region_id: RegionId,
+    region_id: u64,
     message_queue: Arc<M>,
     log_topic: String,
     last_deleted_offset: Option<Offset>,
 }
 
 impl<M: MessageQueue> LogCleaner<M> {
-    pub fn new(region_id: RegionId, message_queue: Arc<M>, log_topic: String) -> Self {
+    pub fn new(region_id: u64, message_queue: Arc<M>, log_topic: String) -> Self {
         info!(
             "Log cleaner init, region id:{}, log topic:{}",
             region_id, log_topic

--- a/wal/src/message_queue_impl/region.rs
+++ b/wal/src/message_queue_impl/region.rs
@@ -15,7 +15,7 @@ use util::*;
 use crate::{
     kv_encoder::CommonLogEncoding,
     log_batch::{LogEntry, LogWriteBatch},
-    manager::{self, RegionId},
+    manager::{self},
     message_queue_impl::{
         encoding::{format_wal_data_topic_name, format_wal_meta_topic_name, MetaEncoding},
         log_cleaner::LogCleaner,
@@ -39,7 +39,7 @@ pub enum Error {
         backtrace
     ))]
     ScanNoCause {
-        region_id: RegionId,
+        region_id: u64,
         table_id: Option<TableId>,
         msg: String,
         backtrace: Backtrace,
@@ -53,7 +53,7 @@ pub enum Error {
         source
     ))]
     ScanWithCause {
-        region_id: RegionId,
+        region_id: u64,
         table_id: Option<TableId>,
         msg: String,
         source: Box<dyn std::error::Error + Send + Sync>,
@@ -84,7 +84,7 @@ pub enum Error {
     ))]
     OpenWithCause {
         namespace: String,
-        region_id: RegionId,
+        region_id: u64,
         msg: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -98,7 +98,7 @@ pub enum Error {
     ))]
     OpenNoCause {
         namespace: String,
-        region_id: RegionId,
+        region_id: u64,
         msg: String,
         backtrace: Backtrace,
     },
@@ -126,7 +126,7 @@ pub struct Region<M: MessageQueue> {
 
 impl<M: MessageQueue> Region<M> {
     /// Init the region.
-    pub async fn open(namespace: &str, region_id: RegionId, message_queue: Arc<M>) -> Result<Self> {
+    pub async fn open(namespace: &str, region_id: u64, message_queue: Arc<M>) -> Result<Self> {
         info!(
             "Begin to open region in namespace, namespace:{}, region id:{}",
             namespace, region_id
@@ -211,7 +211,7 @@ impl<M: MessageQueue> Region<M> {
 
     async fn recover_region_meta_from_meta(
         namespace: &str,
-        region_id: RegionId,
+        region_id: u64,
         message_queue: &M,
         meta_topic: &str,
         meta_encoding: &MetaEncoding,
@@ -325,7 +325,7 @@ impl<M: MessageQueue> Region<M> {
 
     async fn recover_region_meta_from_log(
         namespace: &str,
-        region_id: RegionId,
+        region_id: u64,
         message_queue: &M,
         start_offset: Offset,
         log_topic: &str,
@@ -753,7 +753,7 @@ impl<M: MessageQueue> RegionInner<M> {
 #[derive(Debug)]
 pub struct MessageQueueLogIterator<C: ConsumeIterator> {
     /// Id of region
-    region_id: RegionId,
+    region_id: u64,
 
     /// Id of table id
     ///
@@ -784,7 +784,7 @@ pub struct MessageQueueLogIterator<C: ConsumeIterator> {
 
 impl<C: ConsumeIterator> MessageQueueLogIterator<C> {
     fn new(
-        region_id: RegionId,
+        region_id: u64,
         table_id: Option<TableId>,
         terminate_offset: Option<Offset>,
         iter: C,

--- a/wal/src/message_queue_impl/snapshot_synchronizer.rs
+++ b/wal/src/message_queue_impl/snapshot_synchronizer.rs
@@ -10,13 +10,10 @@ use log::info;
 use message_queue::MessageQueue;
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
-use crate::{
-    manager::RegionId,
-    message_queue_impl::{
-        self,
-        encoding::{MetaEncoding, MetaKey},
-        region_context::RegionMetaSnapshot,
-    },
+use crate::message_queue_impl::{
+    self,
+    encoding::{MetaEncoding, MetaKey},
+    region_context::RegionMetaSnapshot,
 };
 
 #[derive(Debug, Snafu)]
@@ -28,7 +25,7 @@ pub enum Error {
         source
     ))]
     SyncSnapshotWithCause {
-        region_id: RegionId,
+        region_id: u64,
         topic: String,
         source: Box<dyn std::error::Error + Send + Sync>,
     },
@@ -41,7 +38,7 @@ pub enum Error {
         backtrace
     ))]
     SyncSnapshotNoCause {
-        region_id: RegionId,
+        region_id: u64,
         topic: String,
         msg: String,
         backtrace: Backtrace,
@@ -54,7 +51,7 @@ define_result!(Error);
 ///
 /// It will be locked before being called to keep the order of snapshots.
 pub struct SnapshotSynchronizer<Mq: MessageQueue> {
-    region_id: RegionId,
+    region_id: u64,
     message_queue: Arc<Mq>,
     meta_topic: String,
     meta_encoding: MetaEncoding,
@@ -62,7 +59,7 @@ pub struct SnapshotSynchronizer<Mq: MessageQueue> {
 
 impl<Mq: MessageQueue> SnapshotSynchronizer<Mq> {
     pub fn new(
-        region_id: RegionId,
+        region_id: u64,
         message_queue: Arc<Mq>,
         meta_topic: String,
         meta_encoding: MetaEncoding,

--- a/wal/src/message_queue_impl/test_util.rs
+++ b/wal/src/message_queue_impl/test_util.rs
@@ -14,13 +14,13 @@ use super::{
 use crate::{
     kv_encoder::LogBatchEncoder,
     log_batch::LogWriteBatch,
-    manager::{RegionId, RegionVersion, WalLocation},
+    manager::WalLocation,
     tests::util::{TestPayload, TestPayloadDecoder},
 };
 
 pub struct TestContext<Mq: MessageQueue> {
-    pub region_id: RegionId,
-    pub region_version: RegionVersion,
+    pub region_id: u64,
+    pub region_version: u64,
     pub table_id: TableId,
     pub test_datas: Vec<(TableId, TestDataOfTable)>,
     pub test_payload_encoder: TestPayloadDecoder,
@@ -47,8 +47,8 @@ impl TestDataOfTable {
 impl<Mq: MessageQueue> TestContext<Mq> {
     pub async fn new(
         namespace: String,
-        region_id: RegionId,
-        region_version: RegionVersion,
+        region_id: u64,
+        region_version: u64,
         table_id: TableId,
         test_datas: Vec<(TableId, Vec<u32>)>,
         message_queue: Arc<Mq>,

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -27,8 +27,8 @@ use crate::{
     kv_encoder::{CommonLogEncoding, CommonLogKey, MaxSeqMetaEncoding, MaxSeqMetaValue, MetaKey},
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
-        error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId, ScanContext,
-        ScanRequest, SyncLogIterator, WalLocation, WalManager, WriteContext,
+        error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext, ScanRequest,
+        SyncLogIterator, WalLocation, WalManager, WriteContext,
     },
 };
 
@@ -60,7 +60,7 @@ impl TableUnit {
 
     #[inline]
     /// Generate [LogKey] from `region_id`, `table_id` and `sequence_num`.
-    fn log_key(&self, region_id: RegionId, sequence_num: SequenceNumber) -> CommonLogKey {
+    fn log_key(&self, region_id: u64, sequence_num: SequenceNumber) -> CommonLogKey {
         CommonLogKey::new(region_id, self.id, sequence_num)
     }
 
@@ -77,7 +77,7 @@ impl TableUnit {
     /// The delete procedure is ensured to be sequential.
     async fn delete_entries_up_to(
         &self,
-        region_id: RegionId,
+        region_id: u64,
         mut sequence_num: SequenceNumber,
     ) -> Result<()> {
         debug!(
@@ -280,7 +280,7 @@ impl RocksImpl {
         &self,
         table_max_seqs: &mut HashMap<TableId, SequenceNumber>,
     ) -> Result<()> {
-        let mut current_region_id = RegionId::MAX;
+        let mut current_region_id = u64::MAX;
         let mut end_boundary_key_buf = BytesMut::new();
         loop {
             debug!(
@@ -347,7 +347,7 @@ impl RocksImpl {
 
     fn find_table_seqs_from_table_log_by_table_id(
         &self,
-        region_id: RegionId,
+        region_id: u64,
         table_max_seqs: &mut HashMap<TableId, SequenceNumber>,
     ) -> Result<()> {
         let mut current_table_id = TableId::MAX;

--- a/wal/src/table_kv_impl/encoding.rs
+++ b/wal/src/table_kv_impl/encoding.rs
@@ -90,7 +90,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::{manager::RegionId, table_kv_impl::namespace};
+    use crate::table_kv_impl::namespace;
 
     #[test]
     fn test_format_namespace_key() {
@@ -178,10 +178,10 @@ mod tests {
         let key = format_table_unit_key(12345);
         assert_eq!("v1/table/12345", key);
 
-        let key = format_table_unit_key(RegionId::MIN);
+        let key = format_table_unit_key(u64::MIN);
         assert_eq!("v1/table/0", key);
 
-        let key = format_table_unit_key(RegionId::MAX);
+        let key = format_table_unit_key(u64::MAX);
         assert_eq!("v1/table/18446744073709551615", key);
     }
 }

--- a/wal/src/table_kv_impl/model.rs
+++ b/wal/src/table_kv_impl/model.rs
@@ -648,7 +648,7 @@ mod tests {
         );
 
         let table_unit_entry = TableUnitEntry {
-            table_id: crate::manager::MAX_REGION_ID,
+            table_id: TableId::MAX,
             start_sequence: common_types::MAX_SEQUENCE_NUMBER,
         };
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
While tables moved from shards, following bugs will be occurred:
+ manifest will drop, because `shard id` has changed, because now we locate manifest log by table id + shard id.
+ may loading a error last sequence, because we scan the wal data for this now. And while table just be moved to an new shard, no data will be scanned.
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Fix above bugs.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut and manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
