### PR TITLE
chore: define remote_engine grpc service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ version = "1.0.0-alpha01"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
+ "tonic",
  "tonic-build",
 ]
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 prost = { workspace = true }
+tonic = { workspace = true }
 
 [build-dependencies]
 protoc-bin-vendored = "3.0.0"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -15,6 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "protos/table_requests.proto",
             "protos/wal_on_mq.proto",
             "protos/oss_cache.proto",
+            "protos/remote_engine.proto",
         ],
         &["protos"],
     )?;

--- a/proto/protos/remote_engine.proto
+++ b/proto/protos/remote_engine.proto
@@ -1,0 +1,82 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+syntax = "proto3";
+package remote_engine;
+
+import "common.proto";
+
+message ResponseHeader {
+  uint32 code = 1;
+  string error = 2;
+}
+
+service RemoteEngineService {
+  rpc Read(ReadRequest) returns (stream ReadResponse) {}
+  rpc Write(WriteRequest) returns (WriteResponse) {}
+}
+
+message TableIdentifier {
+  string catalog = 1;
+  string schema = 2;
+  string table = 3;
+}
+
+message ReadOptions {
+  uint64 batch_size = 1;
+  uint64 read_parallelism = 2;
+}
+
+message Projection {
+  repeated uint64 idx = 1;
+}
+
+message ProjectedSchema {
+  common.TableSchema table_schema = 1;
+  Projection projection = 2;
+}
+
+message Predicate {
+  repeated bytes exprs = 1;
+  common.TimeRange time_range = 2;
+}
+
+enum ReadOrder {
+  None = 0;
+  Asc = 1;
+  Desc = 2;
+}
+
+message TableReadRequest {
+  uint64 request_id = 1;
+  ReadOptions opts = 2;
+  ProjectedSchema projected_schema = 3;
+  Predicate predicate = 4;
+  ReadOrder order = 5;
+}
+
+message ReadRequest {
+  TableIdentifier table = 1;
+  TableReadRequest read_request = 2;
+}
+
+message ReadResponse {
+  ResponseHeader header = 1;
+  repeated bytes rows = 2;
+}
+
+message RowGroup {
+  common.TableSchema table_schema = 1;
+  repeated bytes rows = 2;
+  int64 min_timestamp = 3;
+  int64 max_timestamp = 4;
+}
+
+message WriteRequest {
+  TableIdentifier table = 1;
+  RowGroup row_group = 2;
+}
+
+message WriteResponse {
+  ResponseHeader header = 1;
+  uint64 affected_rows = 2;
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -12,3 +12,4 @@ pub mod sst;
 pub mod sys_catalog;
 pub mod table_requests;
 pub mod wal_on_mq;
+pub mod remote_engine;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
In the process of implementing the partition table, remote calls between ceresdb-server are involved.
So `remote_engine` grpc service is needed.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
 Define remote_engine grpc service.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
