### PR TITLE
feat: support parse key partition

### DIFF
--- a/interpreters/src/show_create.rs
+++ b/interpreters/src/show_create.rs
@@ -139,6 +139,7 @@ impl ShowCreateInterpreter {
                     .as_str()
                 }
             }
+            PartitionInfo::Key(_) => {}
         }
 
         // TODO: update datafusion to remove `#`.

--- a/interpreters/src/show_create.rs
+++ b/interpreters/src/show_create.rs
@@ -140,24 +140,18 @@ impl ShowCreateInterpreter {
                 }
             }
             PartitionInfo::Key(v) => {
-                let partition_key = match Expr::from_bytes(&v.partition_key) {
-                    Ok(expr) => expr,
-                    Err(e) => {
-                        error!("show create table parse partition info failed, err:{}", e);
-                        return res;
-                    }
-                };
+                let rendered_partition_key = v.partition_key.join(",");
                 if v.linear {
                     res += format!(
                         " PARTITION BY LINEAR KEY({}) PARTITIONS {}",
-                        partition_key,
+                        rendered_partition_key,
                         v.definitions.len()
                     )
                     .as_str()
                 } else {
                     res += format!(
                         " PARTITION BY KEY({}) PARTITIONS {}",
-                        partition_key,
+                        rendered_partition_key,
                         v.definitions.len()
                     )
                     .as_str()
@@ -223,7 +217,7 @@ mod test {
 
     #[test]
     fn test_render_key_partition_info() {
-        let expr = col("col1");
+        let partition_key_col_name = "col1";
         let partition_info = PartitionInfo::Key(KeyPartitionInfo {
             definitions: vec![
                 Definition {
@@ -235,7 +229,7 @@ mod test {
                     origin_name: None,
                 },
             ],
-            partition_key: expr.to_bytes().unwrap(),
+            partition_key: vec![partition_key_col_name.to_string()],
             linear: false,
         });
 

--- a/proto/protos/meta_update.proto
+++ b/proto/protos/meta_update.proto
@@ -26,6 +26,12 @@ message HashPartitionInfo {
   bool linear = 3;
 }
 
+message KeyPartitionInfo {
+  repeated Definition definitions = 1;
+  bytes partition_key = 2;
+  bool linear = 3;
+}
+
 // Meta update for a new table
 message AddTableMeta {
   uint32 space_id = 1;
@@ -37,6 +43,7 @@ message AddTableMeta {
   analytic_common.TableOptions options = 5;
   oneof partition_info {
     HashPartitionInfo hash  = 6;
+    KeyPartitionInfo key_partition = 7;
   }
 }
 

--- a/proto/protos/meta_update.proto
+++ b/proto/protos/meta_update.proto
@@ -15,7 +15,7 @@ message AddSpaceMeta {
 
 message Definition {
   string name = 1;
-  oneof origin_name{
+  oneof origin_name {
     string origin = 2;
   }
 }
@@ -28,7 +28,7 @@ message HashPartitionInfo {
 
 message KeyPartitionInfo {
   repeated Definition definitions = 1;
-  bytes partition_key = 2;
+  repeated string partition_key = 2;
   bool linear = 3;
 }
 

--- a/sql/src/ast.rs
+++ b/sql/src/ast.rs
@@ -87,12 +87,13 @@ pub struct HashPartition {
     pub partition_num: u64,
     pub expr: sqlparser::ast::Expr,
 }
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct KeyPartition {
     /// Key partition description: https://dev.mysql.com/doc/refman/5.7/en/partitioning-key.html
     pub linear: bool,
     pub partition_num: u64,
-    pub partition_key: ColumnDef,
+    pub partition_key: Vec<String>,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/sql/src/ast.rs
+++ b/sql/src/ast.rs
@@ -75,6 +75,7 @@ pub struct CreateTable {
 #[derive(Debug, PartialEq, Eq)]
 pub enum Partition {
     Hash(HashPartition),
+    Key(KeyPartition),
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -85,6 +86,13 @@ pub struct HashPartition {
     pub linear: bool,
     pub partition_num: u64,
     pub expr: sqlparser::ast::Expr,
+}
+#[derive(Debug, PartialEq, Eq)]
+pub struct KeyPartition {
+    /// Key partition description: https://dev.mysql.com/doc/refman/5.7/en/partitioning-key.html
+    pub linear: bool,
+    pub partition_num: u64,
+    pub partition_key: ColumnDef,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -1370,7 +1370,7 @@ mod tests {
                 Statement::Create(v) => {
                     if let Some(Partition::Key(p)) = &v.partition {
                         assert!(!p.linear);
-                        assert_eq!(p.partition_key.name.value, "name");
+                        assert_eq!(&p.partition_key[0], "name");
                         assert_eq!(p.partition_num, 2);
                     } else {
                         panic!("failed");

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -1378,7 +1378,9 @@ mod tests {
             let stmt = Parser::parse_sql(sql);
             assert_eq!(
                 stmt.err().unwrap(),
-                ParserError("Expected identifier, found: )".to_string())
+                ParserError(
+                    "Fail to parse partition key, err:sql parser error: Expected identifier, found: )".to_string()
+                )
             );
         }
 

--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -585,7 +585,12 @@ impl<'a> Parser<'a> {
             return Ok(None);
         };
 
-        let key_columns = self.parser.parse_parenthesized_column_list(Mandatory)?;
+        let key_columns = self
+            .parser
+            .parse_parenthesized_column_list(Mandatory)
+            .map_err(|e| {
+                ParserError::ParserError(format!("Fail to parse partition key, err:{}", e))
+            })?;
 
         // Ensure at least one column for partition key.
         if key_columns.is_empty() {

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -5,7 +5,6 @@
 pub mod rule;
 
 use common_types::bytes::Bytes;
-use datafusion::{common::Column, sql::sqlparser::ast::ColumnDef};
 use proto::meta_update as meta_pb;
 
 /// Info for how to partition table
@@ -40,7 +39,7 @@ pub struct HashPartitionInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyPartitionInfo {
     pub definitions: Vec<Definition>,
-    pub partition_key: Bytes,
+    pub partition_key: Vec<String>,
     pub linear: bool,
 }
 
@@ -80,7 +79,7 @@ impl From<PartitionInfo> for meta_pb::add_table_meta::PartitionInfo {
             }),
             PartitionInfo::Key(v) => Self::KeyPartition(meta_pb::KeyPartitionInfo {
                 definitions: v.definitions.into_iter().map(|v| v.into()).collect(),
-                partition_key: v.partition_key.to_vec(),
+                partition_key: v.partition_key,
                 linear: v.linear,
             }),
         }
@@ -98,7 +97,7 @@ impl From<meta_pb::add_table_meta::PartitionInfo> for PartitionInfo {
             meta_pb::add_table_meta::PartitionInfo::KeyPartition(v) => {
                 Self::Key(KeyPartitionInfo {
                     definitions: v.definitions.into_iter().map(|v| v.into()).collect(),
-                    partition_key: Bytes::from(v.partition_key),
+                    partition_key: v.partition_key,
                     linear: v.linear,
                 })
             }

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -18,7 +18,7 @@ impl PartitionInfo {
     pub fn get_definitions(&self) -> Vec<Definition> {
         match self {
             Self::Hash(v) => v.definitions.clone(),
-            PartitionInfo::Key(v) => v.definitions.clone(),
+            Self::Key(v) => v.definitions.clone(),
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 In order to support the key partition feature, it is necessary to support parse the statement.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Support parse key partition;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
Now user can use key partition statement to create table.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
TODO
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
