### PR TITLE
fix: remove size from sst metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - breaking-changes
     paths-ignore:
       - 'docs/**'
       - 'etc/**'
@@ -17,6 +18,7 @@ on:
   pull_request:
     branches:
       - main
+      - breaking-changes
     paths-ignore:
       - 'docs/**'
       - 'etc/**'

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -617,15 +617,13 @@ mod tests {
         },
     };
 
-    fn build_sst_meta_data(time_range: TimeRange, size: u64) -> SstMetaData {
+    fn build_sst_meta_data(time_range: TimeRange, _size: u64) -> SstMetaData {
         SstMetaData {
             min_key: Bytes::from_static(b"100"),
             max_key: Bytes::from_static(b"200"),
             time_range,
             max_sequence: 200,
             schema: build_schema(),
-            size,
-            row_num: 2,
             storage_format_opts: Default::default(),
             bloom_filter: Default::default(),
         }
@@ -769,6 +767,8 @@ mod tests {
             .map(|size| {
                 let file_meta = FileMeta {
                     id: 1,
+                    size,
+                    row_num: 0,
                     meta: build_sst_meta_data(TimeRange::empty(), size),
                 };
                 let queue = FilePurgeQueue::new(1, 1.into(), tx.clone());

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -617,7 +617,7 @@ mod tests {
         },
     };
 
-    fn build_sst_meta_data(time_range: TimeRange, _size: u64) -> SstMetaData {
+    fn build_sst_meta_data(time_range: TimeRange) -> SstMetaData {
         SstMetaData {
             min_key: Bytes::from_static(b"100"),
             max_key: Bytes::from_static(b"200"),
@@ -633,22 +633,22 @@ mod tests {
     fn build_old_bucket_case(now: i64) -> LevelsController {
         let builder = LevelsControllerMockBuilder::default();
         let sst_meta_vec = vec![
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 14000), Timestamp::new(now - 13000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 14000), Timestamp::new(now - 13000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(100), Timestamp::new(200)),
-                2,
-            ),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 14000),
+                Timestamp::new(now - 13000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 14000),
+                Timestamp::new(now - 13000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(100),
+                Timestamp::new(200),
+            )),
         ];
         builder.add_sst(sst_meta_vec).build()
     }
@@ -658,30 +658,30 @@ mod tests {
     fn build_newest_bucket_case(now: i64) -> LevelsController {
         let builder = LevelsControllerMockBuilder::default();
         let sst_meta_vec = vec![
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 14000), Timestamp::new(now - 13000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 14000), Timestamp::new(now - 13000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 14000),
+                Timestamp::new(now - 13000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 14000),
+                Timestamp::new(now - 13000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
         ];
         builder.add_sst(sst_meta_vec).build()
     }
@@ -691,22 +691,22 @@ mod tests {
     fn build_newest_bucket_no_match_case(now: i64) -> LevelsController {
         let builder = LevelsControllerMockBuilder::default();
         let sst_meta_vec = vec![
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 14000), Timestamp::new(now - 13000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
-            build_sst_meta_data(
-                TimeRange::new_unchecked(Timestamp::new(now - 4000), Timestamp::new(now - 3000)),
-                2,
-            ),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 14000),
+                Timestamp::new(now - 13000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
+            build_sst_meta_data(TimeRange::new_unchecked(
+                Timestamp::new(now - 4000),
+                Timestamp::new(now - 3000),
+            )),
         ];
         builder.add_sst(sst_meta_vec).build()
     }
@@ -769,7 +769,7 @@ mod tests {
                     id: 1,
                     size,
                     row_num: 0,
-                    meta: build_sst_meta_data(TimeRange::empty(), size),
+                    meta: build_sst_meta_data(TimeRange::empty()),
                 };
                 let queue = FilePurgeQueue::new(1, 1.into(), tx.clone());
                 FileHandle::new(file_meta, queue)

--- a/analytic_engine/src/row_iter/record_batch_stream.rs
+++ b/analytic_engine/src/row_iter/record_batch_stream.rs
@@ -291,8 +291,9 @@ pub async fn stream_from_sst_file(
 ) -> Result<SequencedRecordBatchStream> {
     sst_file.read_meter().mark();
     let path = sst_util::new_sst_file_path(space_id, table_id, sst_file.id());
+
     let mut sst_reader = sst_factory
-        .new_sst_reader(sst_reader_options, &path, store_picker)
+        .new_sst_reader(sst_reader_options, &path, store_picker, sst_file.size())
         .with_context(|| SstReaderNotFound {
             options: sst_reader_options.clone(),
         })?;

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -185,7 +185,7 @@ impl FileHandle {
 
     #[inline]
     pub fn row_num(&self) -> u64 {
-        self.inner.meta.meta.row_num
+        self.inner.meta.row_num
     }
 
     #[inline]
@@ -235,7 +235,7 @@ impl FileHandle {
 
     #[inline]
     pub fn size(&self) -> u64 {
-        self.inner.meta.meta.size
+        self.inner.meta.size
     }
 
     #[inline]
@@ -424,6 +424,10 @@ impl FileHandleSet {
 pub struct FileMeta {
     /// Id of the sst file
     pub id: FileId,
+    /// file size in bytes
+    pub size: u64,
+    // total row number
+    pub row_num: u64,
     pub meta: SstMetaData,
 }
 
@@ -508,10 +512,6 @@ pub struct SstMetaData {
     /// Max sequence number in the sst
     pub max_sequence: SequenceNumber,
     pub schema: Schema,
-    /// file size in bytes
-    pub size: u64,
-    // total row number
-    pub row_num: u64,
     pub storage_format_opts: StorageFormatOptions,
     pub bloom_filter: Option<BloomFilter>,
 }
@@ -532,8 +532,6 @@ impl From<SstMetaData> for sst_pb::SstMetaData {
             max_sequence: src.max_sequence,
             time_range: Some(src.time_range.into()),
             schema: Some(common_pb::TableSchema::from(&src.schema)),
-            size: src.size,
-            row_num: src.row_num,
             storage_format_opts: Some(src.storage_format_opts.into()),
             bloom_filter: src.bloom_filter.map(|v| v.into()),
         }
@@ -564,8 +562,6 @@ impl TryFrom<sst_pb::SstMetaData> for SstMetaData {
             time_range,
             max_sequence: src.max_sequence,
             schema,
-            size: src.size,
-            row_num: src.row_num,
             storage_format_opts,
             bloom_filter,
         })
@@ -726,9 +722,6 @@ pub fn merge_sst_meta(files: &[FileHandle], schema: Schema) -> SstMetaData {
     let mut time_range_start = files[0].time_range().inclusive_start();
     let mut time_range_end = files[0].time_range().exclusive_end();
     let mut max_sequence = files[0].max_sequence();
-    // TODO(jiacai2050): what if format of different file is different?
-    // pick first now
-    let storage_format = files[0].storage_format();
 
     if files.len() > 1 {
         for file in &files[1..] {
@@ -746,11 +739,8 @@ pub fn merge_sst_meta(files: &[FileHandle], schema: Schema) -> SstMetaData {
         time_range: TimeRange::new(time_range_start, time_range_end).unwrap(),
         max_sequence,
         schema,
-        // we don't know file size and total row number yet
-        size: 0,
-        row_num: 0,
-        storage_format_opts: StorageFormatOptions::new(storage_format),
-        // bloom filter is rebuilt when write sst, so use default here
+        // we don't know those info yet
+        storage_format_opts: Default::default(),
         bloom_filter: Default::default(),
     }
 }
@@ -805,8 +795,6 @@ pub mod tests {
                 time_range: self.time_range,
                 max_sequence: self.max_sequence,
                 schema: self.schema.clone(),
-                row_num: 0,
-                size: 0,
                 storage_format_opts: Default::default(),
                 bloom_filter: Default::default(),
             }

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -424,9 +424,9 @@ impl FileHandleSet {
 pub struct FileMeta {
     /// Id of the sst file
     pub id: FileId,
-    /// file size in bytes
+    /// File size in bytes
     pub size: u64,
-    // total row number
+    /// Total row number
     pub row_num: u64,
     pub meta: SstMetaData,
 }

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -149,6 +149,8 @@ pub mod tests {
                     0,
                     FileMeta {
                         id: id as FileId,
+                        size: 0,
+                        row_num: 0,
                         meta: sst_meta,
                     },
                 );

--- a/analytic_engine/src/sst/meta_cache.rs
+++ b/analytic_engine/src/sst/meta_cache.rs
@@ -48,11 +48,7 @@ impl MetaData {
     ///
     /// After the building, a new parquet meta data will be generated which
     /// contains no extended custom information.
-    pub fn try_new(
-        parquet_meta_data: &ParquetMetaData,
-        sst_size: usize,
-        ignore_bloom_filter: bool,
-    ) -> Result<Self> {
+    pub fn try_new(parquet_meta_data: &ParquetMetaData, ignore_bloom_filter: bool) -> Result<Self> {
         let file_meta_data = parquet_meta_data.file_metadata();
         let kv_metas = file_meta_data
             .key_value_metadata()
@@ -65,11 +61,6 @@ impl MetaData {
             if ignore_bloom_filter {
                 sst_meta.bloom_filter = None;
             }
-
-            // FIXME: After the issue fixed, let's remove the `sst_size` parameter.
-            // The size in sst_meta is always 0, so overwrite it here.
-            // Refer to https://github.com/CeresDB/ceresdb/issues/321
-            sst_meta.size = sst_size as u64;
 
             Arc::new(sst_meta)
         };

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -335,8 +335,7 @@ impl<'a> Reader<'a> {
             let parquet_meta_data = self.load_meta_data_from_storage().await?;
 
             let ignore_bloom_filter = avoid_update_cache && empty_predicate;
-            let file_size = self.file_reader.file_size().await.context(DecodeSstMeta)?;
-            MetaData::try_new(&parquet_meta_data, file_size, ignore_bloom_filter)
+            MetaData::try_new(&parquet_meta_data, ignore_bloom_filter)
                 .map_err(|e| Box::new(e) as _)
                 .context(DecodeSstMeta)?
         };

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -357,9 +357,16 @@ mod tests {
             };
 
             let mut reader: Box<dyn SstReader + Send> = {
+                let meta = store_picker
+                    .default_store()
+                    .head(&sst_file_path)
+                    .await
+                    .unwrap();
+
                 let file_reader = FileReaderOnObjectStore::new(
                     sst_file_path.clone(),
                     store_picker.default_store().clone(),
+                    meta.size as u64,
                 );
                 let mut reader = AsyncParquetReader::new(
                     &sst_file_path,

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -311,8 +311,6 @@ mod tests {
                 time_range: TimeRange::new_unchecked(Timestamp::new(1), Timestamp::new(2)),
                 max_sequence: 200,
                 schema: schema.clone(),
-                size: 10,
-                row_num: 2,
                 storage_format_opts: Default::default(),
                 bloom_filter: Default::default(),
             };
@@ -368,13 +366,7 @@ mod tests {
                     Arc::new(file_reader),
                     &sst_reader_options,
                 );
-                let mut sst_meta_readback = {
-                    // FIXME: size of SstMetaData is not what this file's size, so overwrite it
-                    // https://github.com/CeresDB/ceresdb/issues/321
-                    let mut meta = reader.meta_data().await.unwrap().clone();
-                    meta.size = sst_meta.size;
-                    meta
-                };
+                let mut sst_meta_readback = { reader.meta_data().await.unwrap().clone() };
                 // bloom filter is built insider sst writer, so overwrite to default for
                 // comparsion
                 sst_meta_readback.bloom_filter = Default::default();
@@ -461,8 +453,6 @@ mod tests {
                 time_range: Default::default(),
                 max_sequence: 1,
                 schema,
-                size: 0,
-                row_num: 0,
                 storage_format_opts: Default::default(),
                 bloom_filter: Default::default(),
             },

--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -871,8 +871,6 @@ mod tests {
             time_range: TimeRange::new_unchecked(Timestamp::new(100), Timestamp::new(101)),
             max_sequence: 200,
             schema: schema.clone(),
-            size: 10,
-            row_num: 4,
             storage_format_opts,
             bloom_filter: Default::default(),
         };
@@ -1006,8 +1004,6 @@ mod tests {
             time_range: TimeRange::new_unchecked(Timestamp::new(100), Timestamp::new(101)),
             max_sequence: 200,
             schema: schema.clone(),
-            size: 10,
-            row_num: 4,
             storage_format_opts,
             bloom_filter: Default::default(),
         };

--- a/analytic_engine/src/table/version_edit.rs
+++ b/analytic_engine/src/table/version_edit.rs
@@ -62,8 +62,8 @@ impl From<AddFile> for meta_pb::AddFileMeta {
             time_range: Some(v.file.meta.time_range.into()),
             max_seq: v.file.meta.max_sequence,
             schema: Some(common_pb::TableSchema::from(&v.file.meta.schema)),
-            size: v.file.meta.size,
-            row_num: v.file.meta.row_num,
+            size: v.file.size,
+            row_num: v.file.row_num,
             storage_format: analytic_common_pb::StorageFormat::from(v.file.meta.storage_format())
                 as i32,
         }
@@ -91,14 +91,14 @@ impl TryFrom<meta_pb::AddFileMeta> for AddFile {
                 .context(InvalidLevel { level: src.level })?,
             file: FileMeta {
                 id: src.file_id,
+                size: src.size,
+                row_num: src.row_num,
                 meta: SstMetaData {
                     min_key: Bytes::from(src.min_key),
                     max_key: Bytes::from(src.max_key),
                     time_range,
                     max_sequence: src.max_seq,
                     schema,
-                    size: src.size,
-                    row_num: src.row_num,
                     storage_format_opts: StorageFormatOptions::new(storage_format.into()),
                     bloom_filter: Default::default(),
                 },
@@ -186,6 +186,8 @@ pub mod tests {
                 level: 0,
                 file: FileMeta {
                     id: self.file_id,
+                    size: 0,
+                    row_num: 0,
                     meta: self.sst_meta.clone(),
                 },
             }

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -77,11 +77,18 @@ impl SstBench {
 
         let sst_factory = FactoryImpl;
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
-        let mut sst_reader = sst_factory
-            .new_sst_reader(&self.sst_reader_options, &sst_path, &store_picker)
-            .unwrap();
 
         self.runtime.block_on(async {
+            let meta = store_picker.default_store().head(&sst_path).await.unwrap();
+
+            let mut sst_reader = sst_factory
+                .new_sst_reader(
+                    &self.sst_reader_options,
+                    &sst_path,
+                    &store_picker,
+                    meta.size as u64,
+                )
+                .unwrap();
             let begin_instant = Instant::now();
             let mut sst_stream = sst_reader.read().await.unwrap();
 

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -128,8 +128,14 @@ async fn sst_to_record_batch_stream(
 ) -> RecordBatchStream {
     let sst_factory = FactoryImpl;
     let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
+    let meta = store_picker.default_store().head(input_path).await.unwrap();
     let mut sst_reader = sst_factory
-        .new_sst_reader(sst_reader_options, input_path, &store_picker)
+        .new_sst_reader(
+            sst_reader_options,
+            input_path,
+            &store_picker,
+            meta.size as u64,
+        )
         .unwrap();
 
     let sst_stream = sst_reader.read().await.unwrap();

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -109,8 +109,14 @@ pub async fn load_sst_to_memtable(
     };
     let sst_factory = FactoryImpl;
     let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
+    let meta = store_picker.default_store().head(sst_path).await.unwrap();
     let mut sst_reader = sst_factory
-        .new_sst_reader(&sst_reader_options, sst_path, &store_picker)
+        .new_sst_reader(
+            &sst_reader_options,
+            sst_path,
+            &store_picker,
+            meta.size as u64,
+        )
         .unwrap();
 
     let mut sst_stream = sst_reader.read().await.unwrap();

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -150,6 +150,8 @@ pub async fn file_handles_from_ssts(
         let sst_meta = meta_from_sst(store, &path, meta_cache).await;
         let file_meta = FileMeta {
             id: *file_id,
+            size: 0,
+            row_num: 0,
             meta: sst_meta,
         };
 

--- a/proto/protos/sst.proto
+++ b/proto/protos/sst.proto
@@ -25,8 +25,6 @@ message SstMetaData {
   // The time range of the sst
   common.TimeRange time_range = 4;
   common.TableSchema schema = 5;
-  uint64 size = 6;
-  uint64 row_num = 7;
-  analytic_common.StorageFormatOptions storage_format_opts = 8;
-  SstBloomFilter bloom_filter = 9;
+  analytic_common.StorageFormatOptions storage_format_opts = 6;
+  SstBloomFilter bloom_filter = 7;
 }

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -86,8 +86,14 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         num_rows_per_row_group: 8192,
     };
     let store_picker: ObjectStorePickerRef = Arc::new(store);
+    let meta = store_picker
+        .default_store()
+        .head(&input_path)
+        .await
+        .unwrap();
+
     let mut reader = factory
-        .new_sst_reader(&reader_opts, &input_path, &store_picker)
+        .new_sst_reader(&reader_opts, &input_path, &store_picker, meta.size as u64)
         .expect("no sst reader found");
 
     let builder_opts = SstBuilderOptions {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #321

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

1. Remove size, row_num from sst metadata. Those two fields cannot be known before write sst, so we have to store them in other place(manifest now).
2. When read sst, pass one more arg: file_size, which is stored inside FileHandle.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No 
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
Existing UT

