### PR TITLE
feat: update ceresdb proto & adapter to partition info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4820,7 +4820,7 @@ name = "remote_engine_client"
 version = "1.0.0-alpha01"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=b9c45bcdbf7d55d5889d42b4c8017282819e6049)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2)",
  "clru",
  "common_types 1.0.0-alpha01",
  "common_util",
@@ -4952,7 +4952,7 @@ name = "router"
 version = "1.0.0-alpha01"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=b9c45bcdbf7d55d5889d42b4c8017282819e6049)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2)",
  "cluster",
  "common_types 1.0.0-alpha01",
  "common_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=b9c45bcdbf7d55d5889d42b4c8017282819e6049#b9c45bcdbf7d55d5889d42b4c8017282819e6049"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2#1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1019,7 +1019,7 @@ name = "cluster"
 version = "1.0.0-alpha01"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=b9c45bcdbf7d55d5889d42b4c8017282819e6049)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2)",
  "common_types 1.0.0-alpha01",
  "common_util",
  "log",
@@ -3190,7 +3190,7 @@ name = "meta_client"
 version = "1.0.0-alpha01"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=b9c45bcdbf7d55d5889d42b4c8017282819e6049)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2)",
  "common_types 1.0.0-alpha01",
  "common_util",
  "futures 0.3.21",
@@ -5280,7 +5280,7 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=b9c45bcdbf7d55d5889d42b4c8017282819e6049)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2)",
  "cluster",
  "common_types 1.0.0-alpha01",
  "common_util",
@@ -5619,7 +5619,7 @@ version = "1.0.0-alpha01"
 dependencies = [
  "arrow",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=b9c45bcdbf7d55d5889d42b4c8017282819e6049)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2)",
  "common_types 1.0.0-alpha01",
  "common_util",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ message_queue = { path = "components/message_queue" }
 
 [workspace.dependencies.ceresdbproto]
 git = "https://github.com/CeresDB/ceresdbproto.git"
-rev = "b9c45bcdbf7d55d5889d42b4c8017282819e6049"
+rev = "1ea76ec99bebee298dfb27b6a15feeb4f42c3aa2"
 
 [workspace.dependencies.datafusion]
 git = "https://github.com/CeresDB/arrow-datafusion.git"

--- a/analytic_engine/src/meta/meta_update.rs
+++ b/analytic_engine/src/meta/meta_update.rs
@@ -219,7 +219,9 @@ impl From<AddTableMeta> for meta_pb::AddTableMeta {
             table_name: v.table_name,
             schema: Some(common_pb::TableSchema::from(&v.schema)),
             options: Some(analytic_common::TableOptions::from(v.opts)),
-            partition_info: v.partition_info.map(|info| info.into()),
+            partition_info: Some(meta_pb::PartitionInfo {
+                partition_info_enum: Some(v.partition_info.unwrap().into()),
+            }),
         }
     }
 }
@@ -236,7 +238,9 @@ impl TryFrom<meta_pb::AddTableMeta> for AddTableMeta {
             table_name: src.table_name,
             schema: Schema::try_from(table_schema).context(ConvertSchema)?,
             opts: TableOptions::from(opts),
-            partition_info: src.partition_info.map(|v| v.into()),
+            partition_info: Some(PartitionInfo::from(
+                src.partition_info.unwrap().partition_info_enum.unwrap(),
+            )),
         })
     }
 }

--- a/analytic_engine/src/meta/meta_update.rs
+++ b/analytic_engine/src/meta/meta_update.rs
@@ -36,6 +36,11 @@ pub enum Error {
     #[snafu(display("Failed to convert schema, err:{}", source))]
     ConvertSchema { source: common_types::schema::Error },
 
+    #[snafu(display("Failed to convert partition info, err:{}", source))]
+    ConvertPartitionInfo {
+        source: table_engine::partition::Error,
+    },
+
     #[snafu(display("Empty table schema.\nBacktrace:\n{}", backtrace))]
     EmptyTableSchema { backtrace: Backtrace },
 
@@ -213,15 +218,14 @@ pub struct AddTableMeta {
 
 impl From<AddTableMeta> for meta_pb::AddTableMeta {
     fn from(v: AddTableMeta) -> Self {
+        let partition_info = v.partition_info.map(|v| v.into());
         meta_pb::AddTableMeta {
             space_id: v.space_id,
             table_id: v.table_id.as_u64(),
             table_name: v.table_name,
             schema: Some(common_pb::TableSchema::from(&v.schema)),
             options: Some(analytic_common::TableOptions::from(v.opts)),
-            partition_info: Some(meta_pb::PartitionInfo {
-                partition_info_enum: Some(v.partition_info.unwrap().into()),
-            }),
+            partition_info,
         }
     }
 }
@@ -232,15 +236,20 @@ impl TryFrom<meta_pb::AddTableMeta> for AddTableMeta {
     fn try_from(src: meta_pb::AddTableMeta) -> Result<Self> {
         let table_schema = src.schema.context(EmptyTableSchema)?;
         let opts = src.options.context(EmptyTableOptions)?;
+        let partition_info = match src.partition_info {
+            Some(partition_info) => {
+                Some(PartitionInfo::try_from(partition_info).context(ConvertPartitionInfo)?)
+            }
+            None => None,
+        };
+
         Ok(Self {
             space_id: src.space_id,
             table_id: TableId::from(src.table_id),
             table_name: src.table_name,
             schema: Schema::try_from(table_schema).context(ConvertSchema)?,
             opts: TableOptions::from(opts),
-            partition_info: Some(PartitionInfo::from(
-                src.partition_info.unwrap().partition_info_enum.unwrap(),
-            )),
+            partition_info,
         })
     }
 }

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -33,8 +33,8 @@ pub struct AllocSchemaIdResponse {
 }
 
 #[derive(Clone, Debug)]
-pub struct PartitionInfo {
-    pub names: Vec<String>,
+pub struct PartitionTableInfo {
+    pub sub_table_names: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -45,7 +45,8 @@ pub struct CreateTableRequest {
     pub engine: String,
     pub create_if_not_exist: bool,
     pub options: HashMap<String, String>,
-    pub partition_info: Option<PartitionInfo>,
+    pub partition_table_info: Option<PartitionTableInfo>,
+    pub encoded_partition_info: Vec<u8>,
 }
 
 #[derive(Clone, Debug)]
@@ -314,9 +315,12 @@ impl From<CreateTableRequest> for meta_service_pb::CreateTableRequest {
             engine: req.engine,
             create_if_not_exist: req.create_if_not_exist,
             options: req.options,
-            partition_info: req
-                .partition_info
-                .map(|v| meta_service_pb::PartitionInfo { names: v.names }),
+            encoded_partition_info: vec![],
+            partition_table_info: req.partition_table_info.map(|v| {
+                meta_service_pb::PartitionTableInfo {
+                    sub_table_names: v.sub_table_names,
+                }
+            }),
         }
     }
 }

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -307,6 +307,11 @@ impl From<meta_service_pb::AllocSchemaIdResponse> for AllocSchemaIdResponse {
 
 impl From<CreateTableRequest> for meta_service_pb::CreateTableRequest {
     fn from(req: CreateTableRequest) -> Self {
+        let partition_table_info =
+            req.partition_table_info
+                .map(|v| meta_service_pb::PartitionTableInfo {
+                    sub_table_names: v.sub_table_names,
+                });
         Self {
             header: None,
             schema_name: req.schema_name,
@@ -315,12 +320,8 @@ impl From<CreateTableRequest> for meta_service_pb::CreateTableRequest {
             engine: req.engine,
             create_if_not_exist: req.create_if_not_exist,
             options: req.options,
-            encoded_partition_info: vec![],
-            partition_table_info: req.partition_table_info.map(|v| {
-                meta_service_pb::PartitionTableInfo {
-                    sub_table_names: v.sub_table_names,
-                }
-            }),
+            encoded_partition_info: req.encoded_partition_info,
+            partition_table_info,
         }
     }
 }

--- a/proto/protos/meta_update.proto
+++ b/proto/protos/meta_update.proto
@@ -44,10 +44,10 @@ message AddTableMeta {
   PartitionInfo partition_info = 6;
 }
 
-message PartitionInfo{
-  oneof partition_info_enum{
+message PartitionInfo {
+  oneof partition_info_enum {
     HashPartitionInfo hash  = 1;
-    KeyPartitionInfo key_partition = 2;
+    KeyPartitionInfo key = 2;
   }
 }
 

--- a/proto/protos/meta_update.proto
+++ b/proto/protos/meta_update.proto
@@ -41,9 +41,13 @@ message AddTableMeta {
   common.TableSchema schema = 4;
   // Options of the table
   analytic_common.TableOptions options = 5;
-  oneof partition_info {
-    HashPartitionInfo hash  = 6;
-    KeyPartitionInfo key_partition = 7;
+  PartitionInfo partition_info = 6;
+}
+
+message PartitionInfo{
+  oneof partition_info_enum{
+    HashPartitionInfo hash  = 1;
+    KeyPartitionInfo key_partition = 2;
   }
 }
 

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -28,6 +28,7 @@ use query_engine::executor::Executor as QueryExecutor;
 use snafu::{OptionExt, ResultExt};
 use table_engine::{
     engine::{CloseTableRequest, TableEngineRef, TableState},
+    partition::PartitionInfoEncoder,
     table::{SchemaId, TableId},
     ANALYTIC_ENGINE_TYPE,
 };
@@ -333,6 +334,20 @@ async fn handle_create_table_on_shard(
             ),
         })?;
 
+    let partition_info = match request.encoded_partition_info.is_empty() {
+        true => None,
+        false => PartitionInfoEncoder::default()
+            .decode(&request.encoded_partition_info)
+            .map_err(|e| Box::new(e) as _)
+            .context(ErrWithCause {
+                code: StatusCode::BadRequest,
+                msg: format!(
+                    "fail to decode encoded partition info bytes, raw_bytes:{:?}",
+                    request.encoded_partition_info
+                ),
+            })?,
+    };
+
     let create_table_request = CreateTableRequest {
         catalog_name: ctx.catalog_manager.default_catalog_name().to_string(),
         schema_name: table.schema_name,
@@ -344,7 +359,7 @@ async fn handle_create_table_on_shard(
         state: TableState::Stable,
         shard_id: shard_info.id,
         cluster_version: topology.cluster_topology_version,
-        partition_info: None,
+        partition_info,
     };
     let create_opts = CreateOptions {
         table_engine: ctx.table_engine,

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -265,7 +265,7 @@ impl PartitionInfoEncoder {
         self.ensure_version(buf[0])?;
 
         let pb_partition_info =
-            meta_pb::PartitionInfo::decode(buf[1..]).context(DecodePartitionInfoToPb { buf })?;
+            meta_pb::PartitionInfo::decode(&buf[1..]).context(DecodePartitionInfoToPb { buf })?;
 
         Ok(Some(PartitionInfo::try_from(pb_partition_info)?))
     }
@@ -277,4 +277,32 @@ impl PartitionInfoEncoder {
         );
         Ok(())
     }
+}
+
+#[test]
+fn test_partition_info_encoder() {
+    let partition_info = PartitionInfo::Key(KeyPartitionInfo {
+        definitions: vec![
+            Definition {
+                name: "table1".to_string(),
+                origin_name: None,
+            },
+            Definition {
+                name: "table2".to_string(),
+                origin_name: None,
+            },
+        ],
+        partition_key: vec!["col1".to_string(), "col2".to_string(), "col3".to_string()],
+        linear: false,
+    });
+    let partition_info_encoder = PartitionInfoEncoder::default();
+    let encode_partition_info = partition_info_encoder
+        .encode(partition_info.clone())
+        .unwrap();
+    let decode_partition_info = partition_info_encoder
+        .decode(&encode_partition_info)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(decode_partition_info, partition_info);
 }

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -265,7 +265,7 @@ impl PartitionInfoEncoder {
         self.ensure_version(buf[0])?;
 
         let pb_partition_info =
-            meta_pb::PartitionInfo::decode(buf).context(DecodePartitionInfoToPb { buf })?;
+            meta_pb::PartitionInfo::decode(buf[1..]).context(DecodePartitionInfoToPb { buf })?;
 
         Ok(Some(PartitionInfo::try_from(pb_partition_info)?))
     }

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -5,12 +5,14 @@
 pub mod rule;
 
 use common_types::bytes::Bytes;
+use prost::Message;
 use proto::meta_update as meta_pb;
-use snafu::{Backtrace, Snafu};
+use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
-// TODO: we should refactor for splitting the errors.
+const DEFAULT_PARTITION_INFO_VERSION: u32 = 1;
+const DEFAULT_PARTITION_INFO_ENCODING_VERSION: u8 = 0;
+
 #[derive(Debug, Snafu)]
-#[snafu(visibility(pub))]
 pub enum Error {
     #[snafu(display(
         "Failed to build partition rule, msg:{}.\nBacktrace:{}\n",
@@ -35,6 +37,29 @@ pub enum Error {
 
     #[snafu(display("Internal error occurred, msg:{}", msg,))]
     Internal { msg: String },
+
+    #[snafu(display("Failed to encode partition info by protobuf, err:{}", source))]
+    EncodePartitionInfoToPb { source: prost::EncodeError },
+
+    #[snafu(display(
+        "Failed to decode partition info from protobuf bytes, buf:{:?}, err:{}",
+        buf,
+        source,
+    ))]
+    DecodePartitionInfoTOPb {
+        buf: Vec<u8>,
+        source: prost::DecodeError,
+    },
+
+    #[snafu(display("Encoded partition info content is empty.\nBacktrace:\n{}", backtrace))]
+    EmptyEncodedPartitionInfo { backtrace: Backtrace },
+
+    #[snafu(display(
+        "Invalid partition info encoding version, version:{}.\nBacktrace:\n{}",
+        version,
+        backtrace
+    ))]
+    InvalidPartitionInfoEncodingVersion { version: u8, backtrace: Backtrace },
 }
 
 define_result!(Error);
@@ -101,7 +126,7 @@ impl From<meta_pb::Definition> for Definition {
     }
 }
 
-impl From<PartitionInfo> for meta_pb::add_table_meta::PartitionInfo {
+impl From<PartitionInfo> for meta_pb::partition_info::PartitionInfoEnum {
     fn from(partition_info: PartitionInfo) -> Self {
         match partition_info {
             PartitionInfo::Hash(v) => Self::Hash(meta_pb::HashPartitionInfo {
@@ -118,15 +143,15 @@ impl From<PartitionInfo> for meta_pb::add_table_meta::PartitionInfo {
     }
 }
 
-impl From<meta_pb::add_table_meta::PartitionInfo> for PartitionInfo {
-    fn from(pb: meta_pb::add_table_meta::PartitionInfo) -> Self {
+impl From<meta_pb::partition_info::PartitionInfoEnum> for PartitionInfo {
+    fn from(pb: meta_pb::partition_info::PartitionInfoEnum) -> Self {
         match pb {
-            meta_pb::add_table_meta::PartitionInfo::Hash(v) => Self::Hash(HashPartitionInfo {
+            meta_pb::partition_info::PartitionInfoEnum::Hash(v) => Self::Hash(HashPartitionInfo {
                 definitions: v.definitions.into_iter().map(|v| v.into()).collect(),
                 expr: Bytes::from(v.expr),
                 linear: v.linear,
             }),
-            meta_pb::add_table_meta::PartitionInfo::KeyPartition(v) => {
+            meta_pb::partition_info::PartitionInfoEnum::KeyPartition(v) => {
                 Self::Key(KeyPartitionInfo {
                     definitions: v.definitions.into_iter().map(|v| v.into()).collect(),
                     partition_key: v.partition_key,
@@ -139,4 +164,58 @@ impl From<meta_pb::add_table_meta::PartitionInfo> for PartitionInfo {
 
 pub fn format_sub_partition_table_name(table_name: &str, partition_name: &str) -> String {
     format!("____{}_{}", table_name, partition_name)
+}
+
+/// Encoder for partition info with version control.
+pub struct PartitionInfoEncoder {
+    version: u8,
+}
+
+impl Default for PartitionInfoEncoder {
+    fn default() -> Self {
+        Self::new(DEFAULT_PARTITION_INFO_ENCODING_VERSION)
+    }
+}
+
+impl PartitionInfoEncoder {
+    fn new(version: u8) -> Self {
+        Self { version }
+    }
+
+    pub fn encode(&self, partition_info: PartitionInfo) -> Result<Vec<u8>> {
+        let pb_partition_info = meta_pb::PartitionInfo {
+            partition_info_enum: Some(meta_pb::partition_info::PartitionInfoEnum::from(
+                partition_info,
+            )),
+        };
+        let mut buf = Vec::with_capacity(1 + pb_partition_info.encoded_len() as usize);
+        buf.push(self.version);
+
+        pb_partition_info
+            .encode(&mut buf)
+            .context(EncodePartitionInfoToPb)?;
+
+        Ok(buf)
+    }
+
+    pub fn decode(&self, buf: &[u8]) -> Result<PartitionInfo> {
+        ensure!(!buf.is_empty(), EmptyEncodedPartitionInfo);
+
+        self.ensure_version(buf[0])?;
+
+        let pb_partition_info =
+            meta_pb::PartitionInfo::decode(buf).context(DecodePartitionInfoTOPb { buf })?;
+
+        return Ok(PartitionInfo::from(
+            pb_partition_info.partition_info_enum.unwrap(),
+        ));
+    }
+
+    fn ensure_version(&self, version: u8) -> Result<()> {
+        ensure!(
+            self.version == version,
+            InvalidPartitionInfoEncodingVersion { version }
+        );
+        Ok(())
+    }
 }

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -284,11 +284,11 @@ fn test_partition_info_encoder() {
     let partition_info = PartitionInfo::Key(KeyPartitionInfo {
         definitions: vec![
             Definition {
-                name: "table1".to_string(),
-                origin_name: None,
+                name: "p0".to_string(),
+                origin_name: Some("partition_0".to_string()),
             },
             Definition {
-                name: "table2".to_string(),
+                name: "p1".to_string(),
                 origin_name: None,
             },
         ],


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
To support creation of partition tables, we have updated the data structure in ceresdbproto and added encodedPartitionInfo. CeresDB needs to adapt to this adjustment.

# What changes are included in this PR?
* Update ceresdbproto
* Adapt to new data structures.
* Modify `meta_update` to decode/encode oneof struct.

# Are there any user-facing changes?
None.

# How does this change test
Pass exists unit tests.
