### PR TITLE
fix: fix conversion by avro

### DIFF
--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -416,6 +416,11 @@ impl RecordSchema {
         self.column_schemas.column(i)
     }
 
+    pub fn column_by_name(&self, name: &str) -> Option<&ColumnSchema> {
+        let index = self.column_schemas.index_of(name)?;
+        Some(self.column_schemas.column(index))
+    }
+
     pub fn to_arrow_schema_ref(&self) -> ArrowSchemaRef {
         self.arrow_schema.clone()
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #
Part of #492 

# Rationale for this change
We convert all `int` related types to `int32` and `int64`, because only these two int types in `avro` now.
So when converting `Value`(`avro` datum) to `Datum`, we should convert it back to the right type in schema.
  

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Modify `avro_value_to_datum` in `avro.rs` for converting back to the right type.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
