### PR TITLE
support schema header for http/grpc service

### DIFF
--- a/docs/guides/src/operation/system_table.md
+++ b/docs/guides/src/operation/system_table.md
@@ -17,7 +17,7 @@ Query table information via table_name like this:
 ```shell
 curl --location --request POST 'http://localhost:5000/sql' \
 --header 'Content-Type: application/json' \
---header 'x-ceresdb-access-tenant: my_tenant' \
+--header 'x-ceresdb-access-schema: my_schema' \
 -d '{
     "query": "select * from system.public.tables where `table_name`=\"my_table\""
 }'

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -131,6 +131,8 @@ pub struct Config {
     pub grpc_port: u16,
     pub grpc_server_cq_count: usize,
     pub timeout: Option<ReadableDuration>,
+    /// Enable that use tenant as the schema if schema is not provided.
+    pub enable_tenant_as_schema: bool,
 
     /// Engine related configs:
     pub runtime: RuntimeConfig,
@@ -187,6 +189,7 @@ impl Default for Config {
             grpc_port,
             grpc_server_cq_count: 20,
             timeout: None,
+            enable_tenant_as_schema: true,
             runtime: RuntimeConfig::default(),
             log_level: "debug".to_string(),
             enable_async_log: true,

--- a/server/src/consts.rs
+++ b/server/src/consts.rs
@@ -4,5 +4,7 @@
 
 /// Header of catalog name
 pub const CATALOG_HEADER: &str = "x-ceresdb-catalog";
+/// Header of schema name
+pub const SCHEMA_HEADER: &str = "x-ceresdb-access-schema";
 /// Header of tenant name
 pub const TENANT_HEADER: &str = "x-ceresdb-access-tenant";

--- a/server/src/consts.rs
+++ b/server/src/consts.rs
@@ -5,6 +5,6 @@
 /// Header of catalog name
 pub const CATALOG_HEADER: &str = "x-ceresdb-catalog";
 /// Header of schema name
-pub const SCHEMA_HEADER: &str = "x-ceresdb-access-schema";
+pub const SCHEMA_HEADER: &str = "x-ceresdb-schema";
 /// Header of tenant name
 pub const TENANT_HEADER: &str = "x-ceresdb-access-tenant";

--- a/server/src/context.rs
+++ b/server/src/context.rs
@@ -13,8 +13,8 @@ pub enum Error {
     #[snafu(display("Missing catalog.\nBacktrace:\n{}", backtrace))]
     MissingCatalog { backtrace: Backtrace },
 
-    #[snafu(display("Missing tenant.\nBacktrace:\n{}", backtrace))]
-    MissingTenant { backtrace: Backtrace },
+    #[snafu(display("Missing schema.\nBacktrace:\n{}", backtrace))]
+    MissingSchema { backtrace: Backtrace },
 
     #[snafu(display("Missing runtime.\nBacktrace:\n{}", backtrace))]
     MissingRuntime { backtrace: Backtrace },
@@ -30,8 +30,8 @@ define_result!(Error);
 pub struct RequestContext {
     /// Catalog of the request
     pub catalog: String,
-    /// Tenant of request
-    pub tenant: String,
+    /// Schema of request
+    pub schema: String,
     /// Runtime of this request
     pub runtime: Arc<Runtime>,
     /// Request timeout
@@ -47,7 +47,7 @@ impl RequestContext {
 #[derive(Default)]
 pub struct Builder {
     catalog: String,
-    tenant: String,
+    schema: String,
     runtime: Option<Arc<Runtime>>,
     timeout: Option<Duration>,
 }
@@ -58,8 +58,8 @@ impl Builder {
         self
     }
 
-    pub fn tenant(mut self, tenant: String) -> Self {
-        self.tenant = tenant;
+    pub fn schema(mut self, schema: String) -> Self {
+        self.schema = schema;
         self
     }
 
@@ -75,14 +75,13 @@ impl Builder {
 
     pub fn build(self) -> Result<RequestContext> {
         ensure!(!self.catalog.is_empty(), MissingCatalog);
-        // We use tenant as schema, so we use default schema if tenant is not specific
-        ensure!(!self.tenant.is_empty(), MissingTenant);
+        ensure!(!self.schema.is_empty(), MissingSchema);
 
         let runtime = self.runtime.context(MissingRuntime)?;
 
         Ok(RequestContext {
             catalog: self.catalog,
-            tenant: self.tenant,
+            schema: self.schema,
             runtime,
             timeout: self.timeout,
         })

--- a/server/src/grpc/forward.rs
+++ b/server/src/grpc/forward.rs
@@ -19,7 +19,7 @@ use tonic::{
     transport::{self, Channel},
 };
 
-use crate::consts::TENANT_HEADER;
+use crate::consts::SCHEMA_HEADER;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -317,7 +317,7 @@ impl<B: ClientBuilder> Forwarder<B> {
             req.set_timeout(self.config.forward_timeout);
             let metadata = req.metadata_mut();
             metadata.insert(
-                TENANT_HEADER,
+                SCHEMA_HEADER,
                 schema.parse().context(InvalidSchema { schema })?,
             );
         }
@@ -474,8 +474,8 @@ mod tests {
         };
 
         let do_rpc = |_client, req: tonic::Request<QueryRequest>, endpoint: &Endpoint| {
-            let tenant = req.metadata().get(TENANT_HEADER).unwrap().to_str().unwrap();
-            assert_eq!(tenant, "public");
+            let schema = req.metadata().get(SCHEMA_HEADER).unwrap().to_str().unwrap();
+            assert_eq!(schema, "public");
             let req = req.into_inner();
             let expect_endpoint = mock_router.routing_tables.get(&req.metrics[0]).unwrap();
             assert_eq!(expect_endpoint, endpoint);

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -204,6 +204,7 @@ impl<Q: QueryExecutor + 'static> RpcServices<Q> {
 pub struct Builder<Q> {
     endpoint: String,
     timeout: Option<Duration>,
+    enable_tenant_as_schema: bool,
     local_endpoint: Option<String>,
     runtimes: Option<Arc<EngineRuntimes>>,
     instance: Option<InstanceRef<Q>>,
@@ -218,6 +219,7 @@ impl<Q> Builder<Q> {
         Self {
             endpoint: "0.0.0.0:8381".to_string(),
             timeout: None,
+            enable_tenant_as_schema: false,
             local_endpoint: None,
             runtimes: None,
             instance: None,
@@ -230,6 +232,11 @@ impl<Q> Builder<Q> {
 
     pub fn endpoint(mut self, endpoint: String) -> Self {
         self.endpoint = endpoint;
+        self
+    }
+
+    pub fn enable_tenant_as_schema(mut self, enable_tenant_as_schema: bool) -> Self {
+        self.enable_tenant_as_schema = enable_tenant_as_schema;
         self
     }
 
@@ -323,6 +330,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             schema_config_provider,
             forwarder,
             timeout: self.timeout,
+            enable_tenant_as_schema: self.enable_tenant_as_schema,
         };
         let rpc_server = StorageServiceServer::new(storage_service);
 

--- a/server/src/grpc/storage_service/mod.rs
+++ b/server/src/grpc/storage_service/mod.rs
@@ -196,20 +196,6 @@ pub struct StorageServiceImpl<Q: QueryExecutor + 'static> {
     pub enable_tenant_as_schema: bool,
 }
 
-// impl<Q: QueryExecutor + 'static> Clone for StorageServiceImpl<Q> {
-//     fn clone(&self) -> Self {
-//         Self {
-//             router: self.router.clone(),
-//             instance: self.instance.clone(),
-//             runtimes: self.runtimes.clone(),
-//             schema_config_provider: self.schema_config_provider.clone(),
-//             forwarder: self.forwarder.clone(),
-//             timeout: self.timeout,
-//             enable_tenant_as_schema: self.enable_tenant_as_schema,
-//         }
-//     }
-// }
-
 macro_rules! handle_request {
     ($mod_name: ident, $handle_fn: ident, $req_ty: ident, $resp_ty: ident) => {
         paste! {

--- a/server/src/grpc/storage_service/prom_query.rs
+++ b/server/src/grpc/storage_service/prom_query.rs
@@ -50,21 +50,20 @@ where
     let deadline = ctx.timeout.map(|t| begin_instant + t);
 
     debug!(
-        "Grpc handle query begin, catalog:{}, tenant:{}, request_id:{}, request:{:?}",
+        "Grpc handle query begin, catalog:{}, schema:{}, request_id:{}, request:{:?}",
         ctx.catalog(),
-        ctx.tenant(),
+        ctx.schema(),
         request_id,
         req,
     );
 
     let instance = &ctx.instance;
-    // We use tenant as schema
     // TODO(yingwen): Privilege check, cannot access data of other tenant
     // TODO(yingwen): Maybe move MetaProvider to instance
     let provider = CatalogMetaProvider {
         manager: instance.catalog_manager.clone(),
         default_catalog: ctx.catalog(),
-        default_schema: ctx.tenant(),
+        default_schema: ctx.schema(),
         function_registry: &*instance.function_registry,
     };
     let frontend = Frontend::new(provider);
@@ -104,8 +103,8 @@ where
 
     // Execute in interpreter
     let interpreter_ctx = InterpreterContext::builder(request_id, deadline)
-        // Use current ctx's catalog and tenant as default catalog and tenant
-        .default_catalog_and_schema(ctx.catalog().to_string(), ctx.tenant().to_string())
+        // Use current ctx's catalog and schema as default catalog and schema
+        .default_catalog_and_schema(ctx.catalog().to_string(), ctx.schema().to_string())
         .build();
     let interpreter_factory = Factory::new(
         instance.query_executor.clone(),

--- a/server/src/grpc/storage_service/route.rs
+++ b/server/src/grpc/storage_service/route.rs
@@ -13,7 +13,7 @@ pub async fn handle_route<Q>(
     ctx: &HandlerContext<'_, Q>,
     req: RouteRequest,
 ) -> Result<RouteResponse> {
-    let routes = ctx.router.route(ctx.tenant(), req).await?;
+    let routes = ctx.router.route(ctx.schema(), req).await?;
 
     let resp = RouteResponse {
         header: Some(error::build_ok_header()),

--- a/server/src/handlers/sql.rs
+++ b/server/src/handlers/sql.rs
@@ -121,13 +121,12 @@ pub async fn handle_sql<Q: QueryExecutor + 'static>(
         request_id, request
     );
 
-    // We use tenant as schema
     // TODO(yingwen): Privilege check, cannot access data of other tenant
     // TODO(yingwen): Maybe move MetaProvider to instance
     let provider = CatalogMetaProvider {
         manager: instance.catalog_manager.clone(),
         default_catalog: &ctx.catalog,
-        default_schema: &ctx.tenant,
+        default_schema: &ctx.schema,
         function_registry: &*instance.function_registry,
     };
     let frontend = Frontend::new(provider);
@@ -167,8 +166,8 @@ pub async fn handle_sql<Q: QueryExecutor + 'static>(
 
     // Execute in interpreter
     let interpreter_ctx = InterpreterContext::builder(request_id, deadline)
-        // Use current ctx's catalog and tenant as default catalog and tenant
-        .default_catalog_and_schema(ctx.catalog, ctx.tenant)
+        // Use current ctx's catalog and schema as default catalog and schema
+        .default_catalog_and_schema(ctx.catalog, ctx.schema)
         .build();
     let interpreter_factory = Factory::new(
         instance.query_executor.clone(),

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -278,23 +278,29 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
         let timeout = self.config.timeout;
 
         header::optional::<String>(consts::CATALOG_HEADER)
+            .and(header::optional::<String>(consts::SCHEMA_HEADER))
             .and(header::optional::<String>(consts::TENANT_HEADER))
-            .and_then(move |catalog: Option<_>, tenant: Option<_>| {
-                // Clone the captured variables
-                let default_catalog = default_catalog.clone();
-                let default_schema = default_schema.clone();
-                let runtime = runtime.clone();
-                async move {
-                    RequestContext::builder()
-                        .catalog(catalog.unwrap_or(default_catalog))
-                        .tenant(tenant.unwrap_or(default_schema))
-                        .runtime(runtime)
-                        .timeout(timeout)
-                        .build()
-                        .context(CreateContext)
-                        .map_err(reject::custom)
-                }
-            })
+            .and_then(
+                move |catalog: Option<_>, schema: Option<_>, tenant: Option<_>| {
+                    // Clone the captured variables
+                    let default_catalog = default_catalog.clone();
+                    let default_schema = default_schema.clone();
+                    let runtime = runtime.clone();
+                    // FIXME: for compatibility, we may use tenant as the schema if schema is
+                    // missing.
+                    let schema = schema.or(tenant).unwrap_or(default_schema);
+                    async move {
+                        RequestContext::builder()
+                            .catalog(catalog.unwrap_or(default_catalog))
+                            .schema(schema)
+                            .runtime(runtime)
+                            .timeout(timeout)
+                            .build()
+                            .context(CreateContext)
+                            .map_err(reject::custom)
+                    }
+                },
+            )
     }
 
     fn with_profiler(&self) -> impl Filter<Extract = (Arc<Profiler>,), Error = Infallible> + Clone {

--- a/server/src/mysql/worker.rs
+++ b/server/src/mysql/worker.rs
@@ -139,7 +139,7 @@ where
 
         RequestContext::builder()
             .catalog(default_catalog)
-            .tenant(default_schema)
+            .schema(default_schema)
             .runtime(runtime)
             .timeout(self.timeout)
             .build()

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -300,6 +300,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .engine_runtimes(engine_runtimes.clone())
             .log_runtime(log_runtime)
             .instance(instance.clone())
+            .enable_tenant_as_schema(self.config.enable_tenant_as_schema)
             .build()
             .context(StartHttpService)?;
 
@@ -324,6 +325,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .local_endpoint(
                 Endpoint::new(self.config.cluster.node.addr, self.config.grpc_port).to_string(),
             )
+            .enable_tenant_as_schema(self.config.enable_tenant_as_schema)
             .runtimes(engine_runtimes)
             .instance(instance.clone())
             .router(router)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Currently, it is unreasonable to use tenant as the schema when accessing grpc/http service.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add new header `x-ceresdb-schema`;
- For compatibility, `tenant` is still used as schema if `schema` is not set.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
User now can use `x-ceresdb-schema` header to set schema instead of `x-ceresdb-access-tenant`.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
