### PR TITLE
feat: add cached router for remote engine client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4832,6 +4832,7 @@ dependencies = [
  "common_types 1.0.0-alpha02",
  "common_util",
  "futures 0.3.21",
+ "log",
  "proto 1.0.0-alpha02",
  "router",
  "serde",

--- a/common_util/src/lib.rs
+++ b/common_util/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod error;
 pub mod metric;
 pub mod panic;
+pub mod partitioned_lock;
 pub mod record_batch;
 pub mod runtime;
 pub mod time;

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -1,3 +1,7 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Partitioned locks
+
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -1,0 +1,120 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    num::NonZeroUsize,
+    sync::Arc,
+};
+
+use tokio::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+/// Simple partitioned `RwLock`
+pub struct PartitionedRwLock<T> {
+    partitions: Vec<Arc<RwLock<T>>>,
+}
+
+impl<T> PartitionedRwLock<T> {
+    // TODO: we should get the nearest 2^n of `partition_num` as real
+    // `partition_num`. By doing so, we can use "&" to get partition rather than
+    // "%".
+    pub fn new(t: T, partition_num: NonZeroUsize) -> Self {
+        let partition_num = partition_num.get();
+        let locked_content = Arc::new(RwLock::new(t));
+        Self {
+            partitions: vec![locked_content; partition_num],
+        }
+    }
+
+    pub async fn read<K: Eq + Hash>(&self, key: &K) -> RwLockReadGuard<'_, T> {
+        let rwlock = self.get_partition(key);
+
+        rwlock.read().await
+    }
+
+    pub async fn write<K: Eq + Hash>(&self, key: &K) -> RwLockWriteGuard<'_, T> {
+        let rwlock = self.get_partition(key);
+
+        rwlock.write().await
+    }
+
+    fn get_partition<K: Eq + Hash>(&self, key: &K) -> &RwLock<T> {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let partition_num = self.partitions.len();
+
+        &self.partitions[(hasher.finish() as usize) % partition_num]
+    }
+}
+
+/// Simple partitioned `Mutex`
+pub struct PartitionedMutex<T> {
+    partitions: Vec<Arc<Mutex<T>>>,
+}
+
+impl<T> PartitionedMutex<T> {
+    // TODO: we should get the nearest 2^n of `partition_num` as real
+    // `partition_num`. By doing so, we can use "&" to get partition rather than
+    // "%".
+    pub fn new(t: T, partition_num: NonZeroUsize) -> Self {
+        let partition_num = partition_num.get();
+        let locked_content = Arc::new(Mutex::new(t));
+        Self {
+            partitions: vec![locked_content; partition_num],
+        }
+    }
+
+    pub async fn lock<K: Eq + Hash>(&self, key: &K) -> MutexGuard<'_, T> {
+        let mutex = self.get_partition(key);
+
+        mutex.lock().await
+    }
+
+    fn get_partition<K: Eq + Hash>(&self, key: &K) -> &Mutex<T> {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let partition_num = self.partitions.len();
+
+        &self.partitions[(hasher.finish() as usize) % partition_num]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_partitioned_rwlock() {
+        let test_locked_map =
+            PartitionedRwLock::new(HashMap::new(), NonZeroUsize::new(10).unwrap());
+        let test_key = "test_key".to_string();
+        let test_value = "test_value".to_string();
+
+        {
+            let mut map = test_locked_map.write(&test_key).await;
+            map.insert(test_key.clone(), test_value.clone());
+        }
+
+        {
+            let map = test_locked_map.read(&test_key).await;
+            assert_eq!(map.get(&test_key).unwrap(), &test_value);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_partitioned_mutex() {
+        let test_locked_map = PartitionedMutex::new(HashMap::new(), NonZeroUsize::new(10).unwrap());
+        let test_key = "test_key".to_string();
+        let test_value = "test_value".to_string();
+
+        {
+            let mut map = test_locked_map.lock(&test_key).await;
+            map.insert(test_key.clone(), test_value.clone());
+        }
+
+        {
+            let map = test_locked_map.lock(&test_key).await;
+            assert_eq!(map.get(&test_key).unwrap(), &test_value);
+        }
+    }
+}

--- a/remote_engine_client/Cargo.toml
+++ b/remote_engine_client/Cargo.toml
@@ -18,6 +18,7 @@ clru = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }
 futures = { workspace = true }
+log = { workspace = true }
 proto = { workspace = true }
 router = { workspace = true }
 serde = { workspace = true }
@@ -26,4 +27,3 @@ snafu = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
-log = { workspace = true }

--- a/remote_engine_client/Cargo.toml
+++ b/remote_engine_client/Cargo.toml
@@ -26,3 +26,4 @@ snafu = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
+log = { workspace = true }

--- a/remote_engine_client/src/cached_router.rs
+++ b/remote_engine_client/src/cached_router.rs
@@ -1,0 +1,110 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Cached router
+
+use std::num::NonZeroUsize;
+
+use ceresdbproto::storage;
+use clru::CLruCache;
+use router::RouterRef;
+use snafu::{OptionExt, ResultExt};
+use table_engine::remote::model::TableIdentifier;
+use tokio::sync::Mutex;
+use tonic::transport::Channel;
+
+use crate::{channel::ChannelPool, config::Config, error::*};
+
+pub struct CachedRouter {
+    /// Router which can route table to its endpoint
+    router: RouterRef,
+
+    /// Cache mapping table to channel of its endpoint
+    // TODO: should be replaced with a cache(like "moka")
+    // or partition the lock.
+    cache: Mutex<CLruCache<TableIdentifier, Channel>>,
+
+    /// Channel pool
+    channel_pool: ChannelPool,
+}
+
+impl CachedRouter {
+    pub fn new(router: RouterRef, config: Config) -> Self {
+        Self {
+            router,
+            cache: Mutex::new(CLruCache::new(
+                NonZeroUsize::new(config.route_cache_size).unwrap(),
+            )),
+            channel_pool: ChannelPool::new(config),
+        }
+    }
+
+    pub async fn route(&self, table_ident: &TableIdentifier) -> Result<Channel> {
+        // Find in cache first.
+        let channel_opt = {
+            let mut cache = self.cache.lock().await;
+            cache.get(table_ident).cloned()
+        };
+
+        let channel = if let Some(channel) = channel_opt {
+            // If found, return it.
+            channel
+        } else {
+            // If not found, do real route and put it into cache, and return then.
+            let mut cache = self.cache.lock().await;
+
+            // Double check here, it may have been put by others.
+            let channel_opt = cache.get(table_ident).cloned();
+            if let Some(channel) = channel_opt {
+                channel
+            } else {
+                self.do_route(table_ident).await?
+            }
+        };
+
+        Ok(channel)
+    }
+
+    pub async fn evict(&self, table_ident: &TableIdentifier) {
+        let mut cache = self.cache.lock().await;
+        let _ = cache.pop(table_ident);
+    }
+
+    async fn do_route(&self, table_ident: &TableIdentifier) -> Result<Channel> {
+        let schema = &table_ident.schema;
+        let table = table_ident.table.clone();
+        let route_request = storage::RouteRequest {
+            metrics: vec![table],
+        };
+        let route_infos =
+            self.router
+                .route(schema, route_request)
+                .await
+                .context(RouteWithCause {
+                    table_ident: table_ident.clone(),
+                })?;
+
+        if route_infos.is_empty() {
+            return RouteNoCause {
+                table_ident: table_ident.clone(),
+                msg: "route infos is empty",
+            }
+            .fail();
+        }
+
+        // Get channel from pool.
+        let endpoint = route_infos
+            .first()
+            .unwrap()
+            .endpoint
+            .clone()
+            .context(RouteNoCause {
+                table_ident: table_ident.clone(),
+                msg: "no endpoint in route info",
+            })?;
+
+        let endpoint = endpoint.into();
+        let channel = self.channel_pool.get(&endpoint).await?;
+
+        Ok(channel)
+    }
+}

--- a/remote_engine_client/src/cached_router.rs
+++ b/remote_engine_client/src/cached_router.rs
@@ -19,6 +19,7 @@ pub struct CachedRouter {
     router: RouterRef,
 
     /// Cache mapping table to channel of its endpoint
+    // TODO: we should add gc for the cache
     cache: RwLock<HashMap<TableIdentifier, Channel>>,
 
     /// Channel pool
@@ -112,7 +113,7 @@ impl CachedRouter {
             .unwrap()
             .endpoint
             .clone()
-            .context(RouteNoCause {
+            .with_context(|| RouteNoCause {
                 table_ident: table_ident.clone(),
                 msg: "no endpoint in route info",
             })?;

--- a/remote_engine_client/src/channel.rs
+++ b/remote_engine_client/src/channel.rs
@@ -16,8 +16,6 @@ use crate::error::*;
 /// Pool for reusing the built channel
 pub struct ChannelPool {
     /// Channels in pool
-    // TODO: should be replaced with a cache(like "moka")
-    // or partition the lock.
     channels: PartitionedMutex<CLruCache<Endpoint, Channel>>,
 
     /// Channel builder
@@ -26,10 +24,9 @@ pub struct ChannelPool {
 
 impl ChannelPool {
     pub fn new(config: Config) -> Self {
-        assert!(config.channel_pool_lock_partition_num > 0);
         let channels = PartitionedMutex::new(
-            CLruCache::new(NonZeroUsize::new(config.channel_pool_max_size).unwrap()),
-            NonZeroUsize::new(config.channel_pool_lock_partition_num).unwrap(),
+            CLruCache::new(NonZeroUsize::new(config.channel_pool_max_size_per_partition).unwrap()),
+            NonZeroUsize::new(config.channel_pool_partition_num).unwrap(),
         );
         let builder = ChannelBuilder::new(config);
 

--- a/remote_engine_client/src/client.rs
+++ b/remote_engine_client/src/client.rs
@@ -49,7 +49,7 @@ impl Client {
         let result = rpc_client
             .read(Request::new(request_pb))
             .await
-            .context(Rpc {
+            .with_context(|| Rpc {
                 table_ident: table_ident.clone(),
                 msg: "read from remote failed",
             });
@@ -89,7 +89,7 @@ impl Client {
         let result = rpc_client
             .write(Request::new(request_pb))
             .await
-            .context(Rpc {
+            .with_context(|| Rpc {
                 table_ident: table_ident.clone(),
                 msg: "write to remote failed",
             });

--- a/remote_engine_client/src/client.rs
+++ b/remote_engine_client/src/client.rs
@@ -8,44 +8,37 @@ use std::{
 };
 
 use arrow_ext::ipc;
-use ceresdbproto::storage;
 use common_types::{
     projected_schema::ProjectedSchema, record_batch::RecordBatch, schema::RecordSchema,
     RemoteEngineVersion,
 };
 use futures::{Stream, StreamExt};
 use proto::remote_engine::{self, remote_engine_service_client::*};
-use router::{endpoint::Endpoint, RouterRef};
-use snafu::{OptionExt, ResultExt};
+use router::RouterRef;
+use snafu::ResultExt;
 use table_engine::remote::model::{ReadRequest, TableIdentifier, WriteRequest};
 use tonic::{transport::Channel, Request, Streaming};
 
-use crate::{channel::ChannelPool, config::Config, error::*, status_code};
+use crate::{cached_router::CachedRouter, config::Config, error::*, status_code};
 
 pub struct Client {
-    channel_pool: ChannelPool,
-    router: RouterRef,
+    cached_router: CachedRouter,
 }
 
 impl Client {
     pub fn new(config: Config, router: RouterRef) -> Self {
-        let channel_pool = ChannelPool::new(config);
+        let cached_router = CachedRouter::new(router, config);
 
-        Self {
-            channel_pool,
-            router,
-        }
+        Self { cached_router }
     }
 
     pub async fn read(&self, request: ReadRequest) -> Result<ClientReadRecordBatchStream> {
-        // Find the endpoint from router firstly.
-        let endpoint = self.route(&request.table).await?;
+        // Find the channel from router firstly.
+        let channel = self.cached_router.route(&request.table).await?;
 
         // Read from remote.
         let table_ident = request.table.clone();
         let projected_schema = request.read_request.projected_schema.clone();
-
-        let channel = self.channel_pool.get(&endpoint).await?;
         let mut rpc_client = RemoteEngineServiceClient::<Channel>::new(channel);
         let request_pb = proto::remote_engine::ReadRequest::try_from(request)
             .map_err(|e| Box::new(e) as _)
@@ -58,10 +51,21 @@ impl Client {
             .await
             .context(Rpc {
                 table_ident: table_ident.clone(),
-                msg: format!("read from remote failed, endpoint:{:?}", endpoint),
-            })?;
+                msg: "read from remote failed",
+            });
 
-        let response = result.into_inner();
+        let response = match result {
+            Ok(response) => response,
+
+            Err(e) => {
+                // If occurred error, we simply evict the corresponding channel now.
+                // TODO: evict according to the type of error.
+                self.cached_router.evict(&table_ident).await;
+                return Err(e);
+            }
+        };
+
+        let response = response.into_inner();
         let remote_read_record_batch_stream =
             ClientReadRecordBatchStream::new(table_ident, response, projected_schema);
 
@@ -69,13 +73,12 @@ impl Client {
     }
 
     pub async fn write(&self, request: WriteRequest) -> Result<usize> {
-        // Find the endpoint from router firstly.
-        let endpoint = self.route(&request.table).await?;
+        // Find the channel from router firstly.
+        let channel = self.cached_router.route(&request.table).await?;
 
         // Write to remote.
         let table_ident = request.table.clone();
 
-        let channel = self.channel_pool.get(&endpoint).await?;
         let request_pb = proto::remote_engine::WriteRequest::try_from(request)
             .map_err(|e| Box::new(e) as _)
             .context(ConvertWriteRequest {
@@ -88,10 +91,21 @@ impl Client {
             .await
             .context(Rpc {
                 table_ident: table_ident.clone(),
-                msg: format!("write to remote failed, endpoint:{:?}", endpoint),
-            })?;
+                msg: "write to remote failed",
+            });
 
-        let response = result.into_inner();
+        let response = match result {
+            Ok(response) => response,
+
+            Err(e) => {
+                // If occurred error, we simply evict the corresponding channel now.
+                // TODO: evict according to the type of error.
+                self.cached_router.evict(&table_ident).await;
+                return Err(e);
+            }
+        };
+
+        let response = response.into_inner();
         if let Some(header) = response.header && !status_code::is_ok(header.code) {
             Server {
                 table_ident: table_ident.clone(),
@@ -101,42 +115,6 @@ impl Client {
         } else {
             Ok(response.affected_rows as usize)
         }
-    }
-
-    async fn route(&self, table_ident: &TableIdentifier) -> Result<Endpoint> {
-        let schema = &table_ident.schema;
-        let table = table_ident.table.clone();
-        let route_request = storage::RouteRequest {
-            metrics: vec![table],
-        };
-        let route_infos =
-            self.router
-                .route(schema, route_request)
-                .await
-                .context(RouteWithCause {
-                    table_ident: table_ident.clone(),
-                })?;
-
-        if route_infos.is_empty() {
-            return RouteNoCause {
-                table_ident: table_ident.clone(),
-                msg: "route infos is empty",
-            }
-            .fail();
-        }
-
-        // Get channel from pool.
-        let endpoint = route_infos
-            .first()
-            .unwrap()
-            .endpoint
-            .clone()
-            .context(RouteNoCause {
-                table_ident: table_ident.clone(),
-                msg: "no endpoint in route info",
-            })?;
-
-        Ok(Endpoint::from(endpoint))
     }
 }
 

--- a/remote_engine_client/src/config.rs
+++ b/remote_engine_client/src/config.rs
@@ -12,10 +12,12 @@ use serde_derive::Deserialize;
 pub struct Config {
     pub connect_timeout: ReadableDuration,
     pub channel_pool_max_size: usize,
+    pub channel_pool_lock_partition_num: usize,
     pub channel_keep_alive_while_idle: bool,
     pub channel_keep_alive_timeout: ReadableDuration,
     pub channel_keep_alive_interval: ReadableDuration,
-    pub route_cache_size: usize,
+    pub route_cache_max_size: usize,
+    pub route_cache_lock_partition_num: usize,
 }
 
 impl Default for Config {
@@ -23,10 +25,12 @@ impl Default for Config {
         Self {
             connect_timeout: ReadableDuration::from_str("3s").unwrap(),
             channel_pool_max_size: 128,
+            channel_pool_lock_partition_num: 16,
             channel_keep_alive_interval: ReadableDuration::from_str("600s").unwrap(),
             channel_keep_alive_timeout: ReadableDuration::from_str("3s").unwrap(),
             channel_keep_alive_while_idle: true,
-            route_cache_size: 128,
+            route_cache_max_size: 128,
+            route_cache_lock_partition_num: 16,
         }
     }
 }

--- a/remote_engine_client/src/config.rs
+++ b/remote_engine_client/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub channel_keep_alive_while_idle: bool,
     pub channel_keep_alive_timeout: ReadableDuration,
     pub channel_keep_alive_interval: ReadableDuration,
+    pub route_cache_size: usize,
 }
 
 impl Default for Config {
@@ -25,6 +26,7 @@ impl Default for Config {
             channel_keep_alive_interval: ReadableDuration::from_str("600s").unwrap(),
             channel_keep_alive_timeout: ReadableDuration::from_str("3s").unwrap(),
             channel_keep_alive_while_idle: true,
+            route_cache_size: 128,
         }
     }
 }

--- a/remote_engine_client/src/config.rs
+++ b/remote_engine_client/src/config.rs
@@ -11,26 +11,26 @@ use serde_derive::Deserialize;
 #[serde(default)]
 pub struct Config {
     pub connect_timeout: ReadableDuration,
-    pub channel_pool_max_size: usize,
-    pub channel_pool_lock_partition_num: usize,
+    pub channel_pool_max_size_per_partition: usize,
+    pub channel_pool_partition_num: usize,
     pub channel_keep_alive_while_idle: bool,
     pub channel_keep_alive_timeout: ReadableDuration,
     pub channel_keep_alive_interval: ReadableDuration,
-    pub route_cache_max_size: usize,
-    pub route_cache_lock_partition_num: usize,
+    pub route_cache_max_size_per_partition: usize,
+    pub route_cache_partition_num: usize,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             connect_timeout: ReadableDuration::from_str("3s").unwrap(),
-            channel_pool_max_size: 128,
-            channel_pool_lock_partition_num: 16,
+            channel_pool_max_size_per_partition: 16,
+            channel_pool_partition_num: 16,
             channel_keep_alive_interval: ReadableDuration::from_str("600s").unwrap(),
             channel_keep_alive_timeout: ReadableDuration::from_str("3s").unwrap(),
             channel_keep_alive_while_idle: true,
-            route_cache_max_size: 128,
-            route_cache_lock_partition_num: 16,
+            route_cache_max_size_per_partition: 16,
+            route_cache_partition_num: 16,
         }
     }
 }

--- a/remote_engine_client/src/lib.rs
+++ b/remote_engine_client/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Remote table engine implementation
 
+mod cached_router;
 mod channel;
 mod client;
 pub mod config;

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -74,7 +74,7 @@ pub enum Error {
 
 define_result!(Error);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct TableIdentifier {
     pub catalog: String,
     pub schema: String,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #
Part of #492 

# Rationale for this change
 Now, we do route work in each request, that make performance too bad.
So, this pr add a cached router in remote engine client. 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Add cached router for remote engine client.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
