### PR TITLE
feat: disable do_snapshot when recover table data

### DIFF
--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -224,7 +224,8 @@ impl Instance {
                     request.cluster_version,
                     request.table_id.as_u64(),
                 ),
-                true,
+                // Recover table data don't do snapshot.
+                false,
             )
             .await
             .context(ReadMetaUpdate {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -224,7 +224,7 @@ impl Instance {
                     request.cluster_version,
                     request.table_id.as_u64(),
                 ),
-                // Recover table data don't do snapshot.
+                // Avoid snapshotting when recover table data.
                 false,
             )
             .await


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Since the read-only partition table and table(follower role) need to be opened in multi servers, the server cannot do snapshot of the manifest when the table is opened.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
* Disable `do_snapshot` when recover table data.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
