### PR TITLE
feat: use arrow-ipc to communicate between remote server and client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ name = "arrow_ext"
 version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
- "uncover",
+ "snafu 0.6.10",
 ]
 
 [[package]]
@@ -4821,6 +4821,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 name = "remote_engine_client"
 version = "1.0.0-alpha02"
 dependencies = [
+ "arrow_ext 1.0.0-alpha02",
  "async-trait",
  "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=6e12241032e01d00e130b65118dfafc0794a3102)",
  "clru",
@@ -5281,6 +5282,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "analytic_engine",
  "arrow",
+ "arrow_ext 1.0.0-alpha02",
  "async-trait",
  "bytes 1.2.1",
  "catalog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "arena",
  "arrow",
  "arrow2",
+ "arrow_ext 1.0.0-alpha02",
  "base64 0.13.0",
  "clap 3.2.23",
  "common_types 1.0.0-alpha02",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "snafu 0.6.10",
+ "zstd 0.12.1+zstd.1.5.2",
 ]
 
 [[package]]
@@ -458,6 +459,7 @@ dependencies = [
  "table_kv",
  "tokio 1.24.1",
  "wal",
+ "zstd 0.12.1+zstd.1.5.2",
 ]
 
 [[package]]
@@ -3739,7 +3741,7 @@ dependencies = [
  "spin",
  "tokio-codec",
  "uuid 0.7.4",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -3965,7 +3967,7 @@ dependencies = [
  "snap",
  "thrift 0.16.0",
  "tokio 1.24.1",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -7250,7 +7252,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c947d2adc84ff9a59f2e3c03b81aa4128acf28d6ad7d56273f7e8af14e47bea"
+dependencies = [
+ "zstd-safe 6.0.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -7258,6 +7269,16 @@ name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ tonic = "0.8.1"
 tokio = { version = "1.24", features = ["full"] }
 wal = { path = "wal" }
 message_queue = { path = "components/message_queue" }
+zstd = { version = "0.12", default-features = false }
 
 [workspace.dependencies.ceresdbproto]
 git = "https://github.com/CeresDB/ceresdbproto.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ path = "src/bin/ceresdb-server.rs"
 
 [workspace.dependencies]
 arrow = { version = "23.0.0", features = ["prettyprint"] }
+arrow_ipc = { version = "23.0.0" }
 arrow_ext = { path = "components/arrow_ext" }
 analytic_engine = { path = "analytic_engine" }
 arena = { path = "components/arena" }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -35,6 +35,7 @@ table_engine = { workspace = true }
 table_kv = { workspace = true }
 tokio = { workspace = true }
 wal = { workspace = true }
+zstd = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -15,6 +15,7 @@ analytic_engine = { workspace = true }
 arena = { workspace = true }
 arrow = { workspace = true }
 arrow2 = { version = "0.12.0", features = [ "io_parquet" ] }
+arrow_ext = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }
 common_types = { workspace = true }

--- a/benchmarks/src/bin/ipc.rs
+++ b/benchmarks/src/bin/ipc.rs
@@ -1,0 +1,63 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::{sync::Arc, time::Instant};
+
+use arrow::{
+    array::{Int32Array, StringArray},
+    datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
+};
+use arrow_ext::ipc;
+use common_util::{avro, time::InstantExt};
+
+fn create_batch(rows: usize) -> RecordBatch {
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Utf8, false),
+    ]);
+
+    let a = Int32Array::from_iter_values(0..rows as i32);
+    let b = StringArray::from_iter_values((0..rows).map(|i| i.to_string()));
+
+    RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap()
+}
+
+pub fn main() {
+    let arrow_batch = create_batch(102400);
+
+    // Arrow IPC
+    {
+        let batch = common_types::record_batch::RecordBatch::try_from(arrow_batch.clone()).unwrap();
+        let compression = ipc::Compression::Zstd;
+
+        let begin = Instant::now();
+        let bytes =
+            ipc::encode_record_batch(&batch.into_arrow_record_batch(), compression).unwrap();
+        println!("Arrow IPC encoded size:{}", bytes.len());
+
+        let decode_batch = ipc::decode_record_batch(bytes, compression).unwrap();
+        let _ = common_types::record_batch::RecordBatch::try_from(decode_batch).unwrap();
+
+        let cost = begin.saturating_elapsed();
+        println!("Arrow IPC encode/decode cost:{}ms", cost.as_millis());
+    }
+
+    // Avro
+    {
+        let record_schema =
+            common_types::schema::RecordSchema::try_from(arrow_batch.schema()).unwrap();
+        let batch = common_types::record_batch::RecordBatch::try_from(arrow_batch).unwrap();
+
+        let begin = Instant::now();
+        let bytes = avro::record_batch_to_avro_rows(&batch).unwrap();
+        println!(
+            "Avro encoded size:{}",
+            bytes.iter().map(|row| row.len()).sum::<usize>()
+        );
+
+        let _decode_batch = avro::avro_rows_to_record_batch(bytes, record_schema);
+
+        let cost = begin.saturating_elapsed();
+        println!("Avro encode/decode cost:{}ms", cost.as_millis());
+    }
+}

--- a/common_types/src/lib.rs
+++ b/common_types/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hash;
 pub mod projected_schema;
 #[cfg(feature = "arrow")]
 pub mod record_batch;
+pub mod remote_engine;
 pub mod request_id;
 #[cfg(feature = "arrow")]
 pub mod row;
@@ -29,6 +30,8 @@ pub const MAX_SEQUENCE_NUMBER: u64 = u64::MAX;
 /// Minimum sequence number, all sequence number should greater than this, so
 /// sequence number should starts from 1.
 pub const MIN_SEQUENCE_NUMBER: u64 = 0;
+
+pub use remote_engine::Version as RemoteEngineVersion;
 
 #[cfg(any(test, feature = "test"))]
 pub mod tests;

--- a/common_types/src/remote_engine.rs
+++ b/common_types/src/remote_engine.rs
@@ -1,0 +1,36 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Common type for remote engine rpc service
+
+use snafu::{Backtrace, Snafu};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Unknown version, value:{}.\nBacktrace:\n{}", version, backtrace))]
+    UnknownVersion { version: u32, backtrace: Backtrace },
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub enum Version {
+    ArrowIPCWithZstd,
+}
+
+impl TryFrom<u32> for Version {
+    type Error = Error;
+
+    fn try_from(version: u32) -> Result<Self> {
+        match version {
+            0 => Ok(Self::ArrowIPCWithZstd),
+            _ => UnknownVersion { version }.fail(),
+        }
+    }
+}
+
+impl Version {
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Self::ArrowIPCWithZstd => 0,
+        }
+    }
+}

--- a/components/arrow_ext/Cargo.toml
+++ b/components/arrow_ext/Cargo.toml
@@ -9,10 +9,7 @@ workspace = true
 
 [package.edition]
 workspace = true
-[dependencies.uncover]
-git = "https://github.com/matklad/uncover.git"
-rev = "1d0770d997e29731b287e9e11e4ffbbea5f456da"
 
 [dependencies]
 arrow = { workspace = true }
-
+snafu = { workspace = true }

--- a/components/arrow_ext/Cargo.toml
+++ b/components/arrow_ext/Cargo.toml
@@ -13,3 +13,4 @@ workspace = true
 [dependencies]
 arrow = { workspace = true }
 snafu = { workspace = true }
+zstd = { workspace = true }

--- a/components/arrow_ext/src/ipc.rs
+++ b/components/arrow_ext/src/ipc.rs
@@ -19,20 +19,49 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Zstd decode error, err:{}.\nBacktrace:\n{}", source, backtrace))]
+    ZstdError {
+        source: std::io::Error,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display("Failed to decode record batch.\nBacktrace:\n{}", backtrace))]
     Decode { backtrace: Backtrace },
 }
 
 type Result<T> = std::result::Result<T, Error>;
 
-pub fn encode_record_batch(batch: &RecordBatch) -> Result<Vec<u8>> {
+#[derive(Copy, Clone)]
+pub enum Compression {
+    None,
+    Zstd,
+}
+
+// https://facebook.github.io/zstd/zstd_manual.html
+// The lower the level, the faster the speed (at the cost of compression).
+const ZSTD_LEVEL: i32 = 3;
+
+pub fn encode_record_batch(batch: &RecordBatch, compression: Compression) -> Result<Vec<u8>> {
     let buffer: Vec<u8> = Vec::new();
     let mut stream_writer = StreamWriter::try_new(buffer, &batch.schema()).context(ArrowError)?;
     stream_writer.write(batch).context(ArrowError)?;
-    stream_writer.into_inner().context(ArrowError)
+    stream_writer
+        .into_inner()
+        .context(ArrowError)
+        .and_then(|bytes| match compression {
+            Compression::None => Ok(bytes),
+            Compression::Zstd => {
+                zstd::stream::encode_all(Cursor::new(bytes), ZSTD_LEVEL).context(ZstdError)
+            }
+        })
 }
 
-pub fn decode_record_batch(bytes: Vec<u8>) -> Result<RecordBatch> {
+pub fn decode_record_batch(bytes: Vec<u8>, compression: Compression) -> Result<RecordBatch> {
+    let bytes = match compression {
+        Compression::None => bytes,
+        Compression::Zstd => zstd::stream::decode_all(Cursor::new(bytes)).context(ZstdError)?,
+    };
+
     let mut stream_reader = StreamReader::try_new(Cursor::new(bytes), None).context(ArrowError)?;
     stream_reader.next().context(Decode)?.context(ArrowError)
 }
@@ -63,8 +92,9 @@ mod tests {
     #[test]
     fn test_ipc_encode_decode() {
         let batch = create_batch(1024);
-        let bytes = encode_record_batch(&batch).unwrap();
-
-        assert_eq!(batch, decode_record_batch(bytes).unwrap());
+        for compression in &[Compression::None, Compression::Zstd] {
+            let bytes = encode_record_batch(&batch, *compression).unwrap();
+            assert_eq!(batch, decode_record_batch(bytes, *compression).unwrap());
+        }
     }
 }

--- a/components/arrow_ext/src/ipc.rs
+++ b/components/arrow_ext/src/ipc.rs
@@ -1,0 +1,38 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Utilities for `RecordBatch` serialization using Arrow IPC
+
+use std::io::Cursor;
+
+use arrow::{
+    ipc::{reader::StreamReader, writer::StreamWriter},
+    record_batch::RecordBatch,
+};
+use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+
+#[derive(Snafu, Debug)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("Arror error, err:{}.\nBacktrace:\n{}", source, backtrace))]
+    ArrowError {
+        source: arrow::error::ArrowError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to decode record batch.\nBacktrace:\n{}", backtrace))]
+    Decode { backtrace: Backtrace },
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub fn encode_record_batch(batch: &RecordBatch) -> Result<Vec<u8>> {
+    let buffer: Vec<u8> = Vec::new();
+    let mut stream_writer = StreamWriter::try_new(buffer, &batch.schema()).context(ArrowError)?;
+    stream_writer.write(batch).context(ArrowError)?;
+    stream_writer.into_inner().context(ArrowError)
+}
+
+pub fn decode_record_batch(bytes: Vec<u8>) -> Result<RecordBatch> {
+    let mut stream_reader = StreamReader::try_new(Cursor::new(bytes), None).context(ArrowError)?;
+    stream_reader.next().context(Decode)?.context(ArrowError)
+}

--- a/components/arrow_ext/src/lib.rs
+++ b/components/arrow_ext/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 pub mod display;
+pub mod ipc;
 pub mod operation;

--- a/proto/protos/remote_engine.proto
+++ b/proto/protos/remote_engine.proto
@@ -54,7 +54,7 @@ message ReadResponse {
   ResponseHeader header = 1;
   // Version of row encoding method
   uint32 version = 2;
-  repeated bytes rows = 3;
+  bytes rows = 3;
 }
 
 message RowGroup {

--- a/remote_engine_client/Cargo.toml
+++ b/remote_engine_client/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 workspace = true
 
 [dependencies]
+arrow_ext = { workspace = true }
 async-trait = { workspace = true }
 ceresdbproto = { workspace = true }
 clru = { workspace = true }

--- a/remote_engine_client/src/client.rs
+++ b/remote_engine_client/src/client.rs
@@ -178,7 +178,8 @@ impl Stream for ClientReadRecordBatchStream {
                     }.fail()));
                 }
 
-                let record_batch = ipc::decode_record_batch(response.rows)
+                // TODO(chenxiang): read compression from config
+                let record_batch = ipc::decode_record_batch(response.rows, ipc::Compression::Zstd)
                     .map_err(|e| Box::new(e) as _)
                     .context(ConvertReadResponse {
                         msg: "decode record batch failed",

--- a/remote_engine_client/src/lib.rs
+++ b/remote_engine_client/src/lib.rs
@@ -55,12 +55,14 @@ pub mod error {
         },
 
         #[snafu(display(
-            "Failed to convert request or response, table, msg:{}, err:{}",
+            "Failed to convert request or response, table, msg:{}, version:{}, err:{}",
             msg,
+            version,
             source
         ))]
         ConvertReadResponse {
             msg: String,
+            version: u32,
             source: Box<dyn std::error::Error + Send + Sync>,
         },
 
@@ -108,6 +110,11 @@ pub mod error {
         RouteNoCause {
             table_ident: TableIdentifier,
             msg: String,
+        },
+
+        #[snafu(display("Failed to convert version, source:{}", source))]
+        ConvertVersion {
+            source: common_types::remote_engine::Error,
         },
     }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 analytic_engine = { workspace = true }
 arrow = { workspace = true }
+arrow_ext = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 catalog = { workspace = true }

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -143,7 +143,7 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
                         .map_err(|e| Box::new(e) as _)
                         .context(ErrWithCause {
                             code: StatusCode::Internal,
-                            msg: "fail to convert record batch to avro",
+                            msg: "encode record batch failed",
                         }) {
                             Err(e) => ReadResponse {
                                 header: Some(error::build_err_header(e)),

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -8,7 +8,6 @@ use arrow_ext::ipc;
 use async_trait::async_trait;
 use catalog::manager::ManagerRef;
 use common_types::record_batch::RecordBatch;
-use common_util::avro;
 use futures::stream::{self, BoxStream, StreamExt};
 use log::error;
 use proto::remote_engine::{

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use arrow_ext::ipc;
 use async_trait::async_trait;
 use catalog::manager::ManagerRef;
 use common_types::record_batch::RecordBatch;
@@ -137,22 +138,23 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
             Ok(stream) => {
                 let new_stream: Self::ReadStream = Box::pin(stream.map(|res| match res {
                     Ok(record_batch) => {
-                        let resp = match avro::record_batch_to_avro_rows(&record_batch)
-                            .map_err(|e| Box::new(e) as _)
-                            .context(ErrWithCause {
-                                code: StatusCode::Internal,
-                                msg: "fail to convert record batch to avro",
-                            }) {
-                            Err(e) => ReadResponse {
-                                header: Some(error::build_err_header(e)),
-                                ..Default::default()
-                            },
-                            Ok(rows) => ReadResponse {
-                                header: Some(build_ok_header()),
-                                version: ENCODE_ROWS_WITH_AVRO,
-                                rows,
-                            },
-                        };
+                        let resp =
+                            match ipc::encode_record_batch(&record_batch.into_arrow_record_batch())
+                                .map_err(|e| Box::new(e) as _)
+                                .context(ErrWithCause {
+                                    code: StatusCode::Internal,
+                                    msg: "fail to convert record batch to avro",
+                                }) {
+                                Err(e) => ReadResponse {
+                                    header: Some(error::build_err_header(e)),
+                                    ..Default::default()
+                                },
+                                Ok(rows) => ReadResponse {
+                                    header: Some(build_ok_header()),
+                                    version: ENCODE_ROWS_WITH_AVRO,
+                                    rows,
+                                },
+                            };
 
                         Ok(resp)
                     }

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use arrow_ext::ipc;
 use async_trait::async_trait;
 use catalog::manager::ManagerRef;
-use common_types::record_batch::RecordBatch;
+use common_types::{record_batch::RecordBatch, RemoteEngineVersion};
 use futures::stream::{self, BoxStream, StreamExt};
 use log::error;
 use proto::remote_engine::{
@@ -34,7 +34,6 @@ use crate::{
 pub(crate) mod error;
 
 const STREAM_QUERY_CHANNEL_LEN: usize = 20;
-const ENCODE_ROWS_WITH_AVRO: u32 = 0;
 
 #[derive(Clone)]
 pub struct RemoteEngineServiceImpl<Q: QueryExecutor + 'static> {
@@ -137,7 +136,6 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
             Ok(stream) => {
                 let new_stream: Self::ReadStream = Box::pin(stream.map(|res| match res {
                     Ok(record_batch) => {
-                        // TODO(chenxiang): read compression from config
                         let resp = match ipc::encode_record_batch(
                             &record_batch.into_arrow_record_batch(),
                             ipc::Compression::Zstd,
@@ -153,7 +151,7 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
                             },
                             Ok(rows) => ReadResponse {
                                 header: Some(build_ok_header()),
-                                version: ENCODE_ROWS_WITH_AVRO,
+                                version: RemoteEngineVersion::ArrowIPCWithZstd.as_u32(),
                                 rows,
                             },
                         };


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
In current implementation, remote service communication bewteen ceresdb using
avro to serialize RecordBatch. For arrow ecosystem, there is a designated serialization method -- [Arrow IPC](https://github.com/apache/arrow/blob/master/docs/source/format/Columnar.rst#serialization-and-interprocess-communication-ipc)

Some benchmark:
```
cd benchmarks && cargo run --bin ipc -r
Arrow IPC encoded size:1348496
Arrow IPC encode/decode cost:1ms
Avro encoded size:904634
Avro encode/decode cost:284ms
```
Encoded bytes using Arrow IPC will take more space  1348496/904634 = 1.4, but it's more much less time.

After zstd compression, IPC is better than avro in both size and speed.
```
Arrow IPC encoded size:780181
Arrow IPC encode/decode cost:8ms
Avro encoded size:904634
Avro encode/decode cost:287ms
```
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Replace avro with arrow ipc for remote service communication
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

New UT `test_ipc_encode_decode`

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

