### PR TITLE
refactor: make storage format more elegant

### DIFF
--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -615,7 +615,7 @@ mod tests {
             file::{FileMeta, FilePurgeQueue, SstMetaData},
             manager::{tests::LevelsControllerMockBuilder, LevelsController},
         },
-        table_options::StorageFormatOptions,
+        table_options::StorageFormat,
     };
 
     fn build_sst_meta_data(time_range: TimeRange) -> SstMetaData {
@@ -625,8 +625,8 @@ mod tests {
             time_range,
             max_sequence: 200,
             schema: build_schema(),
-            storage_format_opts: Default::default(),
             bloom_filter: Default::default(),
+            collapsible_cols_idx: Vec::new(),
         }
     }
 
@@ -772,7 +772,7 @@ mod tests {
                     row_num: 0,
                     time_range: TimeRange::empty(),
                     max_seq: 0,
-                    storage_format_opts: StorageFormatOptions::default(),
+                    storage_format: StorageFormat::default(),
                 };
                 let queue = FilePurgeQueue::new(1, 1.into(), tx.clone());
                 FileHandle::new(file_meta, queue)

--- a/analytic_engine/src/context.rs
+++ b/analytic_engine/src/context.rs
@@ -6,7 +6,7 @@ use std::{fmt, sync::Arc};
 
 use table_engine::engine::EngineRuntimes;
 
-use crate::{sst::meta_cache::MetaCacheRef, Config};
+use crate::{sst::meta_data::cache::MetaCacheRef, Config};
 
 /// Context for instance open
 pub struct OpenContext {

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     sst::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef},
         file::FilePurger,
-        meta_cache::MetaCacheRef,
+        meta_data::cache::MetaCacheRef,
     },
     table::data::TableDataRef,
     wal_synchronizer::WalSynchronizer,

--- a/analytic_engine/src/row_iter/record_batch_stream.rs
+++ b/analytic_engine/src/row_iter/record_batch_stream.rs
@@ -293,7 +293,12 @@ pub async fn stream_from_sst_file(
     let path = sst_util::new_sst_file_path(space_id, table_id, sst_file.id());
 
     let mut sst_reader = sst_factory
-        .new_sst_reader(sst_reader_options, &path, store_picker)
+        .new_sst_reader(
+            sst_reader_options,
+            &path,
+            sst_file.storage_format(),
+            store_picker,
+        )
         .with_context(|| SstReaderNotFound {
             options: sst_reader_options.clone(),
         })?;

--- a/analytic_engine/src/row_iter/record_batch_stream.rs
+++ b/analytic_engine/src/row_iter/record_batch_stream.rs
@@ -303,7 +303,7 @@ pub async fn stream_from_sst_file(
             options: sst_reader_options.clone(),
         })?;
     let meta = sst_reader.meta_data().await.context(ReadSstMeta)?;
-    let max_seq = meta.max_sequence;
+    let max_seq = meta.max_sequence();
     let sst_stream = sst_reader.read().await.context(ReadSstData)?;
 
     let stream = Box::new(sst_stream.map(move |v| {

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -41,7 +41,7 @@ use crate::{
     },
     sst::{
         factory::{FactoryImpl, ObjectStorePicker, ObjectStorePickerRef, ReadFrequency},
-        meta_cache::{MetaCache, MetaCacheRef},
+        meta_data::cache::{MetaCache, MetaCacheRef},
     },
     storage_options::{ObjectStoreOptions, StorageOptions},
     Config, ObkvWalConfig, WalStorageConfig,

--- a/analytic_engine/src/sst/builder.rs
+++ b/analytic_engine/src/sst/builder.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use common_types::{record_batch::RecordBatchWithKey, request_id::RequestId};
 use futures::Stream;
 
-use crate::sst::file::SstMetaData;
+use crate::{sst::file::SstMetaData, table_options::StorageFormat};
 
 pub mod error {
     use common_util::define_result;
@@ -60,6 +60,7 @@ pub type RecordBatchStream = Box<dyn Stream<Item = RecordBatchStreamItem> + Send
 pub struct SstInfo {
     pub file_size: usize,
     pub row_num: usize,
+    pub storage_format: StorageFormat,
 }
 
 /// The builder for sst.

--- a/analytic_engine/src/sst/builder.rs
+++ b/analytic_engine/src/sst/builder.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use common_types::{record_batch::RecordBatchWithKey, request_id::RequestId};
 use futures::Stream;
 
-use crate::{sst::file::SstMetaData, table_options::StorageFormat};
+use crate::{sst::meta_data::SstMetaData, table_options::StorageFormat};
 
 pub mod error {
     use common_util::define_result;
@@ -44,6 +44,9 @@ pub mod error {
         ReadData {
             source: Box<dyn std::error::Error + Send + Sync>,
         },
+
+        #[snafu(display("Other kind of error, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
+        OtherNoCause { msg: String, backtrace: Backtrace },
     }
 
     define_result!(Error);

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -12,7 +12,7 @@ use table_engine::predicate::PredicateRef;
 use crate::{
     sst::{
         builder::SstBuilder,
-        meta_cache::MetaCacheRef,
+        meta_data::cache::MetaCacheRef,
         parquet::{builder::ParquetSstBuilder, AsyncParquetReader, ThreadedReader},
         reader::SstReader,
     },

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -16,7 +16,7 @@ use crate::{
         parquet::{builder::ParquetSstBuilder, AsyncParquetReader, ThreadedReader},
         reader::SstReader,
     },
-    table_options::Compression,
+    table_options::{Compression, StorageFormat, StorageFormatHint},
 };
 
 /// Pick suitable object store for different scenes.
@@ -47,6 +47,7 @@ pub trait Factory: Send + Sync + Debug {
         &self,
         options: &SstReaderOptions,
         path: &'a Path,
+        storage_format: StorageFormat,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Option<Box<dyn SstReader + Send + 'a>>;
 
@@ -56,12 +57,6 @@ pub trait Factory: Send + Sync + Debug {
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Option<Box<dyn SstBuilder + Send + 'a>>;
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum SstType {
-    Auto,
-    Parquet,
 }
 
 /// The frequency of query execution may decide some behavior in the sst reader,
@@ -91,7 +86,7 @@ pub struct SstReaderOptions {
 
 #[derive(Debug, Clone)]
 pub struct SstBuilderOptions {
-    pub sst_type: SstType,
+    pub storage_format_hint: StorageFormatHint,
     pub num_rows_per_row_group: usize,
     pub compression: Compression,
 }
@@ -104,11 +99,13 @@ impl Factory for FactoryImpl {
         &self,
         options: &SstReaderOptions,
         path: &'a Path,
+        storage_format: StorageFormat,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Option<Box<dyn SstReader + Send + 'a>> {
         // TODO: Currently, we only have one sst format, and we have to choose right
         // reader for sst according to its real format in the future.
-        let reader = AsyncParquetReader::new(path, store_picker, options);
+        let hybrid_encoding = matches!(storage_format, StorageFormat::Hybrid);
+        let reader = AsyncParquetReader::new(path, hybrid_encoding, store_picker, options);
         let reader = ThreadedReader::new(
             reader,
             options.runtime.clone(),
@@ -123,13 +120,17 @@ impl Factory for FactoryImpl {
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Option<Box<dyn SstBuilder + Send + 'a>> {
-        match options.sst_type {
-            SstType::Parquet | SstType::Auto => Some(Box::new(ParquetSstBuilder::new(
-                path,
-                store_picker,
-                options,
-            ))),
-        }
+        let hybrid_encoding = match options.storage_format_hint {
+            StorageFormatHint::Specific(format) => matches!(format, StorageFormat::Hybrid),
+            StorageFormatHint::Auto => false,
+        };
+
+        Some(Box::new(ParquetSstBuilder::new(
+            path,
+            hybrid_encoding,
+            store_picker,
+            options,
+        )))
     }
 }
 

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -122,6 +122,7 @@ impl Factory for FactoryImpl {
     ) -> Option<Box<dyn SstBuilder + Send + 'a>> {
         let hybrid_encoding = match options.storage_format_hint {
             StorageFormatHint::Specific(format) => matches!(format, StorageFormat::Hybrid),
+            // `Auto` is mapped to columnar parquet format now, may change in future.
             StorageFormatHint::Auto => false,
         };
 

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -4,9 +4,7 @@
 
 use std::{
     borrow::Borrow,
-    cmp,
     collections::{BTreeMap, HashSet},
-    convert::TryFrom,
     fmt,
     fmt::Debug,
     hash::{Hash, Hasher},
@@ -17,8 +15,6 @@ use std::{
 };
 
 use common_types::{
-    bytes::Bytes,
-    schema::Schema,
     time::{TimeRange, Timestamp},
     SequenceNumber,
 };
@@ -27,53 +23,20 @@ use common_util::{
     metric::Meter,
     runtime::{JoinHandle, Runtime},
 };
-use ethbloom::Bloom;
 use log::{debug, error, info};
 use object_store::ObjectStoreRef;
-use proto::{common as common_pb, sst as sst_pb};
-use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+use snafu::{ResultExt, Snafu};
 use table_engine::table::TableId;
 use tokio::sync::{
     mpsc::{self, UnboundedReceiver, UnboundedSender},
     Mutex,
 };
 
-use crate::{
-    space::SpaceId,
-    sst::{
-        factory::{FactoryRef, ObjectStorePickerRef, SstReaderOptions},
-        manager::FileId,
-        reader,
-    },
-    table::sst_util,
-    table_options::StorageFormat,
-};
+use crate::{space::SpaceId, sst::manager::FileId, table::sst_util, table_options::StorageFormat};
 
 /// Error of sst file.
 #[derive(Debug, Snafu)]
 pub enum Error {
-    #[snafu(display("Time range is not found.\nBacktrace\n:{}", backtrace))]
-    TimeRangeNotFound { backtrace: Backtrace },
-
-    #[snafu(display("Table schema is not found.\nBacktrace\n:{}", backtrace))]
-    TableSchemaNotFound { backtrace: Backtrace },
-
-    #[snafu(display("Storage format options are not found.\nBacktrace\n:{}", backtrace))]
-    StorageFormatOptionsNotFound { backtrace: Backtrace },
-
-    #[snafu(display(
-        "Bloom filter should be 256 byte, current:{}.\nBacktrace\n:{}",
-        size,
-        backtrace
-    ))]
-    InvalidBloomFilterSize { size: usize, backtrace: Backtrace },
-
-    #[snafu(display("Failed to convert time range, err:{}", source))]
-    ConvertTimeRange { source: common_types::time::Error },
-
-    #[snafu(display("Failed to convert table schema, err:{}", source))]
-    ConvertTableSchema { source: common_types::schema::Error },
-
     #[snafu(display("Failed to join purger, err:{}", source))]
     StopPurger { source: common_util::runtime::Error },
 }
@@ -436,127 +399,6 @@ impl FileMeta {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct BloomFilter {
-    // Two level vector means
-    // 1. row group
-    // 2. column
-    filters: Vec<Vec<Bloom>>,
-}
-
-impl BloomFilter {
-    pub fn new(filters: Vec<Vec<Bloom>>) -> Self {
-        Self { filters }
-    }
-
-    #[inline]
-    pub fn filters(&self) -> &[Vec<Bloom>] {
-        &self.filters
-    }
-}
-
-impl From<BloomFilter> for sst_pb::SstBloomFilter {
-    fn from(bloom_filter: BloomFilter) -> Self {
-        let row_group_filters = bloom_filter
-            .filters
-            .iter()
-            .map(|row_group_filter| {
-                let column_filters = row_group_filter
-                    .iter()
-                    .map(|column_filter| column_filter.data().to_vec())
-                    .collect::<Vec<_>>();
-                sst_pb::sst_bloom_filter::RowGroupFilter { column_filters }
-            })
-            .collect::<Vec<_>>();
-
-        sst_pb::SstBloomFilter { row_group_filters }
-    }
-}
-
-impl TryFrom<sst_pb::SstBloomFilter> for BloomFilter {
-    type Error = Error;
-
-    fn try_from(src: sst_pb::SstBloomFilter) -> Result<Self> {
-        let filters = src
-            .row_group_filters
-            .into_iter()
-            .map(|row_group_filter| {
-                row_group_filter
-                    .column_filters
-                    .into_iter()
-                    .map(|encoded_bytes| {
-                        let size = encoded_bytes.len();
-                        let bs: [u8; 256] = encoded_bytes
-                            .try_into()
-                            .ok()
-                            .context(InvalidBloomFilterSize { size })?;
-
-                        Ok(Bloom::from(bs))
-                    })
-                    .collect::<Result<Vec<_>>>()
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        Ok(BloomFilter { filters })
-    }
-}
-
-/// Meta data of a sst file
-#[derive(Debug, Clone, PartialEq)]
-pub struct SstMetaData {
-    pub min_key: Bytes,
-    pub max_key: Bytes,
-    /// Time Range of the sst
-    pub time_range: TimeRange,
-    /// Max sequence number in the sst
-    pub max_sequence: SequenceNumber,
-    pub schema: Schema,
-    pub bloom_filter: Option<BloomFilter>,
-    pub collapsible_cols_idx: Vec<u32>,
-}
-
-pub type SstMetaDataRef = Arc<SstMetaData>;
-
-impl From<SstMetaData> for sst_pb::SstMetaData {
-    fn from(src: SstMetaData) -> Self {
-        sst_pb::SstMetaData {
-            min_key: src.min_key.to_vec(),
-            max_key: src.max_key.to_vec(),
-            max_sequence: src.max_sequence,
-            time_range: Some(src.time_range.into()),
-            schema: Some(common_pb::TableSchema::from(&src.schema)),
-            bloom_filter: src.bloom_filter.map(|v| v.into()),
-            collapsible_cols_idx: src.collapsible_cols_idx,
-        }
-    }
-}
-
-impl TryFrom<sst_pb::SstMetaData> for SstMetaData {
-    type Error = Error;
-
-    fn try_from(src: sst_pb::SstMetaData) -> Result<Self> {
-        let time_range = {
-            let time_range = src.time_range.context(TimeRangeNotFound)?;
-            TimeRange::try_from(time_range).context(ConvertTimeRange)?
-        };
-        let schema = {
-            let schema = src.schema.context(TableSchemaNotFound)?;
-            Schema::try_from(schema).context(ConvertTableSchema)?
-        };
-        let bloom_filter = src.bloom_filter.map(BloomFilter::try_from).transpose()?;
-
-        Ok(Self {
-            min_key: src.min_key.into(),
-            max_key: src.max_key.into(),
-            time_range,
-            max_sequence: src.max_sequence,
-            schema,
-            bloom_filter,
-            collapsible_cols_idx: src.collapsible_cols_idx,
-        })
-    }
-}
-
 // Queue to store files to be deleted for a table.
 #[derive(Clone)]
 pub struct FilePurgeQueue {
@@ -702,73 +544,6 @@ impl FilePurger {
     }
 }
 
-/// A utility reader to fetch meta data of multiple sst files.
-pub struct SstMetaReader {
-    pub space_id: SpaceId,
-    pub table_id: TableId,
-    pub factory: FactoryRef,
-    pub read_opts: SstReaderOptions,
-    pub store_picker: ObjectStorePickerRef,
-}
-
-impl SstMetaReader {
-    /// Fetch meta data of the `files` from object store.
-    pub async fn fetch_metas(&self, files: &[FileHandle]) -> reader::Result<Vec<SstMetaData>> {
-        let mut sst_metas = Vec::with_capacity(files.len());
-        for f in files {
-            let path = sst_util::new_sst_file_path(self.space_id, self.table_id, f.id());
-            let mut reader = self
-                .factory
-                .new_sst_reader(
-                    &self.read_opts,
-                    &path,
-                    f.storage_format(),
-                    &self.store_picker,
-                )
-                .context(reader::OtherNoCause {
-                    msg: format!("no sst reader found for the file:{:?}", path),
-                })?;
-            let meta_data = reader.meta_data().await?;
-            sst_metas.push(meta_data.clone());
-        }
-
-        Ok(sst_metas)
-    }
-}
-
-/// Merge sst meta of given `sst_metas`, panic if `sst_metas` is empty.
-///
-/// The size and row_num of the merged meta is initialized to 0.
-pub fn merge_sst_meta(sst_metas: &[SstMetaData], schema: Schema) -> SstMetaData {
-    let mut min_key = &sst_metas[0].min_key;
-    let mut max_key = &sst_metas[0].max_key;
-    let mut time_range_start = sst_metas[0].time_range.inclusive_start();
-    let mut time_range_end = sst_metas[0].time_range.exclusive_end();
-    let mut max_sequence = sst_metas[0].max_sequence;
-
-    if sst_metas.len() > 1 {
-        for file in &sst_metas[1..] {
-            min_key = cmp::min(&file.min_key, min_key);
-            max_key = cmp::max(&file.max_key, max_key);
-            time_range_start = cmp::min(file.time_range.inclusive_start(), time_range_start);
-            time_range_end = cmp::max(file.time_range.exclusive_end(), time_range_end);
-            max_sequence = cmp::max(file.max_sequence, max_sequence);
-        }
-    }
-
-    SstMetaData {
-        min_key: min_key.clone(),
-        max_key: max_key.clone(),
-        time_range: TimeRange::new(time_range_start, time_range_end).unwrap(),
-        max_sequence,
-        schema,
-        // bloom filter will be rebuilt when write sst, so use default here.
-        bloom_filter: None,
-        // collapsible cols will be rebuilt when write sst, so use empty one here.
-        collapsible_cols_idx: Vec::new(),
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -782,45 +557,6 @@ pub mod tests {
             FilePurger {
                 sender,
                 handle: Mutex::new(None),
-            }
-        }
-    }
-
-    #[must_use]
-    pub struct SstMetaDataMocker {
-        schema: Schema,
-        time_range: TimeRange,
-        max_sequence: SequenceNumber,
-    }
-
-    impl SstMetaDataMocker {
-        pub fn new(schema: Schema) -> Self {
-            Self {
-                schema,
-                time_range: TimeRange::min_to_max(),
-                max_sequence: 1,
-            }
-        }
-
-        pub fn time_range(mut self, range: TimeRange) -> Self {
-            self.time_range = range;
-            self
-        }
-
-        pub fn max_sequence(mut self, max_sequence: SequenceNumber) -> Self {
-            self.max_sequence = max_sequence;
-            self
-        }
-
-        pub fn build(&self) -> SstMetaData {
-            SstMetaData {
-                min_key: Bytes::new(),
-                max_key: Bytes::new(),
-                time_range: self.time_range,
-                max_sequence: self.max_sequence,
-                schema: self.schema.clone(),
-                bloom_filter: Default::default(),
-                collapsible_cols_idx: Vec::new(),
             }
         }
     }

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -125,8 +125,9 @@ pub mod tests {
 
     use crate::{
         sst::{
-            file::{FileMeta, FilePurgeQueue, SstMetaData},
+            file::{FileMeta, FilePurgeQueue},
             manager::{FileId, LevelsController},
+            meta_data::SstMetaData,
         },
         table_options::StorageFormat,
     };
@@ -154,8 +155,8 @@ pub mod tests {
                         id: id as FileId,
                         size: 0,
                         row_num: 0,
-                        time_range: sst_meta.time_range,
-                        max_seq: sst_meta.max_sequence,
+                        time_range: sst_meta.time_range(),
+                        max_seq: sst_meta.max_sequence(),
                         storage_format: StorageFormat::Columnar,
                     },
                 );

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -123,9 +123,12 @@ pub mod tests {
     use table_engine::table::TableId;
     use tokio::sync::mpsc;
 
-    use crate::sst::{
-        file::{FileMeta, FilePurgeQueue, SstMetaData},
-        manager::{FileId, LevelsController},
+    use crate::{
+        sst::{
+            file::{FileMeta, FilePurgeQueue, SstMetaData},
+            manager::{FileId, LevelsController},
+        },
+        table_options::StorageFormat,
     };
 
     #[must_use]
@@ -153,7 +156,7 @@ pub mod tests {
                         row_num: 0,
                         time_range: sst_meta.time_range,
                         max_seq: sst_meta.max_sequence,
-                        storage_format_opts: sst_meta.storage_format_opts,
+                        storage_format: StorageFormat::Columnar,
                     },
                 );
             }

--- a/analytic_engine/src/sst/meta_data/mod.rs
+++ b/analytic_engine/src/sst/meta_data/mod.rs
@@ -1,0 +1,166 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+pub mod cache;
+
+use std::sync::Arc;
+
+use common_types::{schema::Schema, time::TimeRange, SequenceNumber};
+use common_util::define_result;
+use proto::sst as sst_pb;
+use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+use table_engine::table::TableId;
+
+use crate::{
+    space::SpaceId,
+    sst::{
+        factory::{FactoryRef, ObjectStorePickerRef, SstReaderOptions},
+        file::FileHandle,
+        parquet::{
+            self, encoding,
+            meta_data::{ParquetMetaData, ParquetMetaDataRef},
+        },
+        reader,
+    },
+    table::sst_util,
+};
+
+/// Error of sst file.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display(
+        "Key value metadata in parquet is not found.\nBacktrace\n:{}",
+        backtrace
+    ))]
+    KvMetaDataNotFound { backtrace: Backtrace },
+
+    #[snafu(display("Metadata in proto struct is not found.\nBacktrace\n:{}", backtrace))]
+    MetaDataNotFound { backtrace: Backtrace },
+
+    #[snafu(display("Empty custom metadata in parquet.\nBacktrace\n:{}", backtrace))]
+    EmptyCustomMetaData { backtrace: Backtrace },
+
+    #[snafu(display("Failed to decode custom metadata in parquet, err:{}", source))]
+    DecodeCustomMetaData { source: encoding::Error },
+
+    #[snafu(display("Failed to build sst reader.\nBacktrace:\n:{}", backtrace))]
+    BuildSstReader { backtrace: Backtrace },
+
+    #[snafu(display("Failed to read meta data from reader, err:{}", source))]
+    ReadMetaData { source: reader::Error },
+
+    #[snafu(display("Failed to convert parquet meta data, err:{}", source))]
+    ConvertParquetMetaData { source: parquet::meta_data::Error },
+}
+
+define_result!(Error);
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum SstMetaData {
+    Parquet(ParquetMetaDataRef),
+}
+
+impl SstMetaData {
+    #[inline]
+    pub fn schema(&self) -> &Schema {
+        match self {
+            Self::Parquet(v) => &v.schema,
+        }
+    }
+
+    #[inline]
+    pub fn time_range(&self) -> TimeRange {
+        match self {
+            Self::Parquet(v) => v.time_range,
+        }
+    }
+
+    #[inline]
+    pub fn max_sequence(&self) -> SequenceNumber {
+        match self {
+            Self::Parquet(v) => v.max_sequence,
+        }
+    }
+
+    #[inline]
+    pub fn as_parquet(&self) -> Option<ParquetMetaDataRef> {
+        match self {
+            Self::Parquet(v) => Some(v.clone()),
+        }
+    }
+}
+
+impl From<SstMetaData> for sst_pb::SstMetaData {
+    fn from(src: SstMetaData) -> Self {
+        match src {
+            SstMetaData::Parquet(meta_data) => {
+                let meta_data = sst_pb::ParquetMetaData::from(meta_data.as_ref().to_owned());
+                sst_pb::SstMetaData {
+                    meta_data: Some(sst_pb::sst_meta_data::MetaData::Parquet(meta_data)),
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<sst_pb::SstMetaData> for SstMetaData {
+    type Error = Error;
+
+    fn try_from(src: sst_pb::SstMetaData) -> Result<Self> {
+        let meta_data = src.meta_data.context(MetaDataNotFound)?;
+        match meta_data {
+            sst_pb::sst_meta_data::MetaData::Parquet(meta_data) => {
+                let parquet_meta_data =
+                    ParquetMetaData::try_from(meta_data).context(ConvertParquetMetaData)?;
+
+                Ok(Self::Parquet(Arc::new(parquet_meta_data)))
+            }
+        }
+    }
+}
+
+/// A utility reader to fetch meta data of multiple sst files.
+pub struct SstMetaReader {
+    pub space_id: SpaceId,
+    pub table_id: TableId,
+    pub factory: FactoryRef,
+    pub read_opts: SstReaderOptions,
+    pub store_picker: ObjectStorePickerRef,
+}
+
+impl SstMetaReader {
+    /// Fetch meta data of the `files` from object store.
+    pub async fn fetch_metas(&self, files: &[FileHandle]) -> Result<Vec<SstMetaData>> {
+        let mut sst_metas = Vec::with_capacity(files.len());
+        for f in files {
+            let path = sst_util::new_sst_file_path(self.space_id, self.table_id, f.id());
+            let mut reader = self
+                .factory
+                .new_sst_reader(
+                    &self.read_opts,
+                    &path,
+                    f.storage_format(),
+                    &self.store_picker,
+                )
+                .context(BuildSstReader)?;
+            let meta_data = reader.meta_data().await.context(ReadMetaData)?;
+            sst_metas.push(meta_data.clone());
+        }
+
+        Ok(sst_metas)
+    }
+}
+
+/// Merge multiple sst meta data into the one.
+///
+/// Panic if the metas is empty.
+pub fn merge_sst_meta<'a, I>(metas: I, schema: Schema) -> SstMetaData
+where
+    I: Iterator<Item = &'a SstMetaData>,
+{
+    let parquet_metas = metas.map(|v| match v {
+        SstMetaData::Parquet(meta_data) => meta_data.as_ref(),
+    });
+
+    let parquet_meta_data = parquet::meta_data::merge_sst_meta(parquet_metas, schema);
+    SstMetaData::Parquet(Arc::new(parquet_meta_data))
+}

--- a/analytic_engine/src/sst/mod.rs
+++ b/analytic_engine/src/sst/mod.rs
@@ -6,7 +6,7 @@ pub mod builder;
 pub mod factory;
 pub mod file;
 pub mod manager;
-pub mod meta_cache;
+pub mod meta_data;
 pub mod metrics;
 pub mod parquet;
 pub mod reader;

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -1,0 +1,209 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// MetaData for SST based on parquet.
+
+use std::{cmp, fmt, sync::Arc};
+
+use bytes::Bytes;
+use common_types::{schema::Schema, time::TimeRange, SequenceNumber};
+use common_util::define_result;
+use ethbloom::Bloom;
+use proto::{common as common_pb, sst as sst_pb};
+use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+
+/// Error of sst file.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Time range is not found.\nBacktrace\n:{}", backtrace))]
+    TimeRangeNotFound { backtrace: Backtrace },
+
+    #[snafu(display("Table schema is not found.\nBacktrace\n:{}", backtrace))]
+    TableSchemaNotFound { backtrace: Backtrace },
+
+    #[snafu(display(
+        "Bloom filter should be 256 byte, current:{}.\nBacktrace\n:{}",
+        size,
+        backtrace
+    ))]
+    InvalidBloomFilterSize { size: usize, backtrace: Backtrace },
+
+    #[snafu(display("Failed to convert time range, err:{}", source))]
+    ConvertTimeRange { source: common_types::time::Error },
+
+    #[snafu(display("Failed to convert table schema, err:{}", source))]
+    ConvertTableSchema { source: common_types::schema::Error },
+}
+
+define_result!(Error);
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BloomFilter {
+    // Two level vector means
+    // 1. row group
+    // 2. column
+    filters: Vec<Vec<Bloom>>,
+}
+
+impl BloomFilter {
+    pub fn new(filters: Vec<Vec<Bloom>>) -> Self {
+        Self { filters }
+    }
+
+    #[inline]
+    pub fn filters(&self) -> &[Vec<Bloom>] {
+        &self.filters
+    }
+}
+
+impl From<BloomFilter> for sst_pb::SstBloomFilter {
+    fn from(bloom_filter: BloomFilter) -> Self {
+        let row_group_filters = bloom_filter
+            .filters
+            .iter()
+            .map(|row_group_filter| {
+                let column_filters = row_group_filter
+                    .iter()
+                    .map(|column_filter| column_filter.data().to_vec())
+                    .collect::<Vec<_>>();
+                sst_pb::sst_bloom_filter::RowGroupFilter { column_filters }
+            })
+            .collect::<Vec<_>>();
+
+        sst_pb::SstBloomFilter { row_group_filters }
+    }
+}
+
+impl TryFrom<sst_pb::SstBloomFilter> for BloomFilter {
+    type Error = Error;
+
+    fn try_from(src: sst_pb::SstBloomFilter) -> Result<Self> {
+        let filters = src
+            .row_group_filters
+            .into_iter()
+            .map(|row_group_filter| {
+                row_group_filter
+                    .column_filters
+                    .into_iter()
+                    .map(|encoded_bytes| {
+                        let size = encoded_bytes.len();
+                        let bs: [u8; 256] = encoded_bytes
+                            .try_into()
+                            .ok()
+                            .context(InvalidBloomFilterSize { size })?;
+
+                        Ok(Bloom::from(bs))
+                    })
+                    .collect::<Result<Vec<_>>>()
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(BloomFilter { filters })
+    }
+}
+
+/// Meta data of a sst file
+#[derive(Clone, PartialEq)]
+pub struct ParquetMetaData {
+    pub min_key: Bytes,
+    pub max_key: Bytes,
+    /// Time Range of the sst
+    pub time_range: TimeRange,
+    /// Max sequence number in the sst
+    pub max_sequence: SequenceNumber,
+    pub schema: Schema,
+    pub bloom_filter: Option<BloomFilter>,
+    pub collapsible_cols_idx: Vec<u32>,
+}
+
+pub type ParquetMetaDataRef = Arc<ParquetMetaData>;
+
+impl fmt::Debug for ParquetMetaData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ParquetMetaData")
+            .field("min_key", &self.min_key)
+            .field("max_key", &self.max_key)
+            .field("time_range", &self.time_range)
+            .field("max_sequence", &self.max_sequence)
+            .field("schema", &self.schema)
+            // Avoid the messy output from bloom filter.
+            .field("has_bloom_filter", &self.bloom_filter.is_some())
+            .field("collapsible_cols_idx", &self.collapsible_cols_idx)
+            .finish()
+    }
+}
+
+impl From<ParquetMetaData> for sst_pb::ParquetMetaData {
+    fn from(src: ParquetMetaData) -> Self {
+        sst_pb::ParquetMetaData {
+            min_key: src.min_key.to_vec(),
+            max_key: src.max_key.to_vec(),
+            max_sequence: src.max_sequence,
+            time_range: Some(src.time_range.into()),
+            schema: Some(common_pb::TableSchema::from(&src.schema)),
+            bloom_filter: src.bloom_filter.map(|v| v.into()),
+            collapsible_cols_idx: src.collapsible_cols_idx,
+        }
+    }
+}
+
+impl TryFrom<sst_pb::ParquetMetaData> for ParquetMetaData {
+    type Error = Error;
+
+    fn try_from(src: sst_pb::ParquetMetaData) -> Result<Self> {
+        let time_range = {
+            let time_range = src.time_range.context(TimeRangeNotFound)?;
+            TimeRange::try_from(time_range).context(ConvertTimeRange)?
+        };
+        let schema = {
+            let schema = src.schema.context(TableSchemaNotFound)?;
+            Schema::try_from(schema).context(ConvertTableSchema)?
+        };
+        let bloom_filter = src.bloom_filter.map(BloomFilter::try_from).transpose()?;
+
+        Ok(Self {
+            min_key: src.min_key.into(),
+            max_key: src.max_key.into(),
+            time_range,
+            max_sequence: src.max_sequence,
+            schema,
+            bloom_filter,
+            collapsible_cols_idx: src.collapsible_cols_idx,
+        })
+    }
+}
+
+/// Merge meta data of given `metas`, panic if `metas` is empty.
+///
+/// The size and row_num of the merged meta is initialized to 0.
+// TODO: add unit test for this method.
+pub fn merge_sst_meta<'a, I>(mut metas: I, schema: Schema) -> ParquetMetaData
+where
+    I: Iterator<Item = &'a ParquetMetaData>,
+{
+    let first_meta = metas.next().unwrap();
+    let mut min_key = &first_meta.min_key;
+    let mut max_key = &first_meta.max_key;
+    let mut time_range_start = first_meta.time_range.inclusive_start();
+    let mut time_range_end = first_meta.time_range.exclusive_end();
+    let mut max_sequence = first_meta.max_sequence;
+
+    for file in metas {
+        min_key = cmp::min(&file.min_key, min_key);
+        max_key = cmp::max(&file.max_key, max_key);
+        time_range_start = cmp::min(file.time_range.inclusive_start(), time_range_start);
+        time_range_end = cmp::max(file.time_range.exclusive_end(), time_range_end);
+        max_sequence = cmp::max(file.max_sequence, max_sequence);
+    }
+
+    ParquetMetaData {
+        min_key: min_key.clone(),
+        max_key: max_key.clone(),
+        time_range: TimeRange::new(time_range_start, time_range_end).unwrap(),
+        max_sequence,
+        schema,
+        // bloom filter will be rebuilt when write sst, so use default here.
+        bloom_filter: None,
+        // collapsible cols will be rebuilt when write sst, so use empty one here.
+        collapsible_cols_idx: Vec::new(),
+    }
+}

--- a/analytic_engine/src/sst/parquet/mod.rs
+++ b/analytic_engine/src/sst/parquet/mod.rs
@@ -6,6 +6,7 @@ pub mod async_reader;
 pub mod builder;
 pub mod encoding;
 mod hybrid;
+pub mod meta_data;
 pub(crate) mod row_group_filter;
 
 pub use async_reader::{Reader as AsyncParquetReader, ThreadedReader};

--- a/analytic_engine/src/sst/reader.rs
+++ b/analytic_engine/src/sst/reader.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use common_types::record_batch::RecordBatchWithKey;
 use futures::Stream;
 
-use crate::sst::file::SstMetaData;
+use crate::sst::meta_data::SstMetaData;
 
 pub mod error {
     use common_util::define_result;
@@ -82,7 +82,7 @@ pub use error::*;
 
 #[async_trait]
 pub trait SstReader {
-    async fn meta_data(&mut self) -> Result<&SstMetaData>;
+    async fn meta_data(&mut self) -> Result<SstMetaData>;
 
     async fn read(
         &mut self,

--- a/analytic_engine/src/table/version_edit.rs
+++ b/analytic_engine/src/table/version_edit.rs
@@ -12,7 +12,7 @@ use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use crate::{
     sst::{file::FileMeta, manager::FileId},
     table::data::MemTableId,
-    table_options::StorageFormatOptions,
+    table_options::StorageFormat,
 };
 
 #[derive(Debug, Snafu)]
@@ -58,9 +58,7 @@ impl From<AddFile> for meta_pb::AddFileMeta {
             max_seq: v.file.max_seq,
             size: v.file.size,
             row_num: v.file.row_num,
-            storage_format: analytic_common_pb::StorageFormat::from(
-                v.file.storage_format_opts.format,
-            ) as i32,
+            storage_format: analytic_common_pb::StorageFormat::from(v.file.storage_format) as i32,
         }
     }
 }
@@ -86,7 +84,7 @@ impl TryFrom<meta_pb::AddFileMeta> for AddFile {
                 row_num: src.row_num,
                 time_range,
                 max_seq: src.max_seq,
-                storage_format_opts: StorageFormatOptions::new(storage_format.into()),
+                storage_format: StorageFormat::from(storage_format),
             },
         };
 
@@ -182,7 +180,7 @@ pub mod tests {
                     row_num: 0,
                     time_range: self.time_range,
                     max_seq: self.max_seq,
-                    storage_format_opts: StorageFormatOptions::default(),
+                    storage_format: StorageFormat::default(),
                 },
             }
         }

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -20,7 +20,7 @@ use analytic_engine::{
             FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
             SstReaderOptions,
         },
-        meta_cache::MetaCacheRef,
+        meta_data::cache::MetaCacheRef,
     },
     table::{
         sst_util,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -19,7 +19,7 @@ use analytic_engine::{
             SstReaderOptions,
         },
         file::{FileHandle, FilePurgeQueue, Request},
-        meta_cache::MetaCacheRef,
+        meta_data::cache::MetaCacheRef,
     },
     table::sst_util,
 };

--- a/benchmarks/src/parquet_bench.rs
+++ b/benchmarks/src/parquet_bench.rs
@@ -4,7 +4,7 @@
 
 use std::{io::Cursor, sync::Arc, time::Instant};
 
-use analytic_engine::sst::meta_cache::MetaCacheRef;
+use analytic_engine::sst::meta_data::cache::MetaCacheRef;
 use common_types::schema::Schema;
 use common_util::runtime::Runtime;
 use futures::StreamExt;

--- a/benchmarks/src/scan_memtable_bench.rs
+++ b/benchmarks/src/scan_memtable_bench.rs
@@ -10,7 +10,7 @@ use analytic_engine::{
         skiplist::factory::SkiplistMemTableFactory,
         MemTableRef, ScanContext, ScanRequest,
     },
-    sst::meta_cache::MetaCacheRef,
+    sst::meta_data::cache::MetaCacheRef,
 };
 use arena::NoopCollector;
 use common_types::projected_schema::ProjectedSchema;

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -4,9 +4,12 @@
 
 use std::{cmp, sync::Arc, time::Instant};
 
-use analytic_engine::sst::{
-    factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
-    meta_cache::{MetaCache, MetaCacheRef},
+use analytic_engine::{
+    sst::{
+        factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
+        meta_cache::{MetaCache, MetaCacheRef},
+    },
+    table_options::StorageFormat,
 };
 use common_types::{projected_schema::ProjectedSchema, schema::Schema};
 use common_util::runtime::Runtime;
@@ -80,7 +83,12 @@ impl SstBench {
 
         self.runtime.block_on(async {
             let mut sst_reader = sst_factory
-                .new_sst_reader(&self.sst_reader_options, &sst_path, &store_picker)
+                .new_sst_reader(
+                    &self.sst_reader_options,
+                    &sst_path,
+                    StorageFormat::Columnar,
+                    &store_picker,
+                )
                 .unwrap();
             let begin_instant = Instant::now();
             let mut sst_stream = sst_reader.read().await.unwrap();

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -7,7 +7,7 @@ use std::{cmp, sync::Arc, time::Instant};
 use analytic_engine::{
     sst::{
         factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
-        meta_cache::{MetaCache, MetaCacheRef},
+        meta_data::cache::{MetaCache, MetaCacheRef},
     },
     table_options::StorageFormat,
 };

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -18,8 +18,9 @@ use analytic_engine::{
             Factory, FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
             SstBuilderOptions, SstReaderOptions,
         },
-        file::{self, FilePurgeQueue, SstMetaData, SstMetaReader},
+        file::FilePurgeQueue,
         manager::FileId,
+        meta_data::{self, SstMetaData, SstMetaReader},
     },
     table::sst_util,
     table_options::{Compression, StorageFormat, StorageFormatHint},
@@ -92,7 +93,7 @@ pub async fn rebuild_sst(config: RebuildSstConfig, runtime: Arc<Runtime>) {
 
     let sst_meta = util::meta_from_sst(&store, &input_path, &None).await;
 
-    let projected_schema = ProjectedSchema::no_projection(sst_meta.schema.clone());
+    let projected_schema = ProjectedSchema::no_projection(sst_meta.schema().clone());
     let sst_reader_options = SstReaderOptions {
         read_batch_row_num: config.read_batch_row_num,
         reverse: false,
@@ -253,7 +254,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
             store_picker: store_picker.clone(),
         };
         let sst_metas = meta_reader.fetch_metas(&file_handles).await.unwrap();
-        file::merge_sst_meta(&sst_metas, schema)
+        meta_data::merge_sst_meta(sst_metas.iter(), schema)
     };
     let output_sst_config = SstConfig {
         sst_meta,

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -9,9 +9,9 @@ use analytic_engine::{
     space::SpaceId,
     sst::{
         factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
-        file::{FileHandle, FileMeta, FilePurgeQueue, SstMetaData},
+        file::{FileHandle, FileMeta, FilePurgeQueue},
         manager::FileId,
-        meta_cache::MetaCacheRef,
+        meta_data::{cache::MetaCacheRef, SstMetaData},
         parquet::encoding,
     },
     table::sst_util,
@@ -63,7 +63,8 @@ pub async fn meta_from_sst(
     let metadata = footer::parse_metadata(&chunk_reader).unwrap();
     let kv_metas = metadata.file_metadata().key_value_metadata().unwrap();
 
-    encoding::decode_sst_meta_data(&kv_metas[0]).unwrap()
+    let parquet_meta_data = encoding::decode_sst_meta_data(&kv_metas[0]).unwrap();
+    SstMetaData::Parquet(Arc::new(parquet_meta_data))
 }
 
 pub async fn schema_from_sst(
@@ -73,7 +74,7 @@ pub async fn schema_from_sst(
 ) -> Schema {
     let sst_meta = meta_from_sst(store, sst_path, meta_cache).await;
 
-    sst_meta.schema
+    sst_meta.schema().clone()
 }
 
 pub fn projected_schema_by_number(
@@ -158,8 +159,8 @@ pub async fn file_handles_from_ssts(
             id: *file_id,
             size: 0,
             row_num: 0,
-            time_range: sst_meta.time_range,
-            max_seq: sst_meta.max_sequence,
+            time_range: sst_meta.time_range(),
+            max_seq: sst_meta.max_sequence(),
             storage_format: StorageFormat::Columnar,
         };
 

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -15,6 +15,7 @@ use analytic_engine::{
         parquet::encoding,
     },
     table::sst_util,
+    table_options::StorageFormat,
 };
 use common_types::{
     bytes::{BufMut, SafeBufMut},
@@ -110,7 +111,12 @@ pub async fn load_sst_to_memtable(
     let sst_factory = FactoryImpl;
     let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
     let mut sst_reader = sst_factory
-        .new_sst_reader(&sst_reader_options, sst_path, &store_picker)
+        .new_sst_reader(
+            &sst_reader_options,
+            sst_path,
+            StorageFormat::Columnar,
+            &store_picker,
+        )
         .unwrap();
 
     let mut sst_stream = sst_reader.read().await.unwrap();
@@ -154,7 +160,7 @@ pub async fn file_handles_from_ssts(
             row_num: 0,
             time_range: sst_meta.time_range,
             max_seq: sst_meta.max_sequence,
-            storage_format_opts: sst_meta.storage_format_opts,
+            storage_format: StorageFormat::Columnar,
         };
 
         let handle = FileHandle::new(file_meta, purge_queue.clone());

--- a/components/parquet_ext/src/lib.rs
+++ b/components/parquet_ext/src/lib.rs
@@ -7,6 +7,5 @@ pub mod tests;
 
 use std::sync::Arc;
 
-use parquet::file::metadata::ParquetMetaData;
-
+pub use parquet::file::metadata::ParquetMetaData;
 pub type ParquetMetaDataRef = Arc<ParquetMetaData>;

--- a/proto/protos/analytic_common.proto
+++ b/proto/protos/analytic_common.proto
@@ -30,7 +30,8 @@ enum UpdateMode {
 
 message StorageFormatHint {
   oneof hint {
-    // The value of the auto is meaningless.
+    // Auto means the storage format is automatically determined by CeresDB and
+    // its value have no specific meaning.
     int32 auto = 1;
     StorageFormat specific = 2;
   }

--- a/proto/protos/analytic_common.proto
+++ b/proto/protos/analytic_common.proto
@@ -20,7 +20,7 @@ message TableOptions {
   // If sampling_segment_duration is true, then the segment duration
   // is still unknown.
   bool sampling_segment_duration = 11;
-  StorageFormat storage_format = 12;
+  StorageFormatHint storage_format_hint = 12;
 }
 
 enum UpdateMode {
@@ -28,9 +28,12 @@ enum UpdateMode {
   Append = 1;
 }
 
-message StorageFormatOptions {
-  StorageFormat format = 1;
-  repeated uint32 collapsible_cols_idx = 2;
+message StorageFormatHint {
+  oneof hint {
+    // The value of the auto is meaningless.
+    int32 auto = 1;
+    StorageFormat specific = 2;
+  }
 }
 
 enum StorageFormat {

--- a/proto/protos/sst.proto
+++ b/proto/protos/sst.proto
@@ -15,6 +15,7 @@ message SstBloomFilter {
   repeated RowGroupFilter row_group_filters = 1;
 }
 
+/// Used by ssts encoded by parquet, incuding columar&hybrid storage formats.
 message SstMetaData {
   // Min key in the sst
   bytes min_key = 1;
@@ -25,6 +26,6 @@ message SstMetaData {
   // The time range of the sst
   common.TimeRange time_range = 4;
   common.TableSchema schema = 5;
-  analytic_common.StorageFormatOptions storage_format_opts = 6;
-  SstBloomFilter bloom_filter = 7;
+  SstBloomFilter bloom_filter = 6;
+  repeated uint32 collapsible_cols_idx = 7;
 }

--- a/proto/protos/sst.proto
+++ b/proto/protos/sst.proto
@@ -15,8 +15,14 @@ message SstBloomFilter {
   repeated RowGroupFilter row_group_filters = 1;
 }
 
-/// Used by ssts encoded by parquet, incuding columar&hybrid storage formats.
 message SstMetaData {
+  oneof MetaData {
+    ParquetMetaData parquet = 1;
+  }
+}
+
+/// Used by ssts encoded by parquet, incuding columar&hybrid storage formats.
+message ParquetMetaData {
   // Min key in the sst
   bytes min_key = 1;
   // Max key in the sst

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -82,7 +82,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         read_batch_row_num: 8192,
         reverse: false,
         frequency: ReadFrequency::Once,
-        projected_schema: ProjectedSchema::no_projection(sst_meta.schema.clone()),
+        projected_schema: ProjectedSchema::no_projection(sst_meta.schema().clone()),
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
         runtime,

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -7,9 +7,9 @@ use std::{error::Error, sync::Arc};
 use analytic_engine::{
     sst::factory::{
         Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstBuilderOptions,
-        SstReaderOptions, SstType,
+        SstReaderOptions,
     },
-    table_options::{Compression, StorageFormat, StorageFormatOptions},
+    table_options::{Compression, StorageFormat, StorageFormatHint},
 };
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -45,7 +45,11 @@ struct Args {
 
     /// Storage format(values: columnar/hybrid)
     #[clap(short, long, default_value = "columnar")]
-    format: String,
+    input_format: String,
+
+    /// Storage format(values: columnar/hybrid)
+    #[clap(short, long, default_value = "columnar")]
+    output_format: String,
 }
 
 fn new_runtime(thread_num: usize) -> Runtime {
@@ -72,7 +76,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let storage = LocalFileSystem::new_with_prefix(args.store_path).expect("invalid path");
     let store = Arc::new(storage) as _;
     let input_path = Path::from(args.input);
-    let mut sst_meta = sst_util::meta_from_sst(&store, &input_path).await;
+    let sst_meta = sst_util::meta_from_sst(&store, &input_path).await;
     let factory = FactoryImpl;
     let reader_opts = SstReaderOptions {
         read_batch_row_num: 8192,
@@ -86,12 +90,16 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         num_rows_per_row_group: 8192,
     };
     let store_picker: ObjectStorePickerRef = Arc::new(store);
+    let input_format = StorageFormat::try_from(args.input_format.as_str())
+        .with_context(|| format!("invalid input storage format:{}", args.input_format))?;
     let mut reader = factory
-        .new_sst_reader(&reader_opts, &input_path, &store_picker)
+        .new_sst_reader(&reader_opts, &input_path, input_format, &store_picker)
         .expect("no sst reader found");
 
+    let output_format_hint = StorageFormatHint::try_from(args.output_format.as_str())
+        .with_context(|| format!("invalid storage format:{}", args.output_format))?;
     let builder_opts = SstBuilderOptions {
-        sst_type: SstType::Parquet,
+        storage_format_hint: output_format_hint,
         num_rows_per_row_group: args.batch_size,
         compression: Compression::parse_from(&args.compression)
             .with_context(|| format!("invalid compression:{}", args.compression))?,
@@ -100,10 +108,6 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let mut builder = factory
         .new_sst_builder(&builder_opts, &output, &store_picker)
         .expect("no sst builder found");
-    sst_meta.storage_format_opts = StorageFormatOptions::new(
-        StorageFormat::try_from(args.format.as_str())
-            .with_context(|| format!("invalid storage format:{}", args.format))?,
-    );
     let sst_stream = reader
         .read()
         .await

--- a/tools/src/sst_util.rs
+++ b/tools/src/sst_util.rs
@@ -1,6 +1,8 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use analytic_engine::sst::{file::SstMetaData, parquet::encoding};
+use std::sync::Arc;
+
+use analytic_engine::sst::{meta_data::SstMetaData, parquet::encoding};
 use object_store::{ObjectStoreRef, Path};
 use parquet::file::footer;
 
@@ -11,5 +13,6 @@ pub async fn meta_from_sst(store: &ObjectStoreRef, sst_path: &Path) -> SstMetaDa
     let metadata = footer::parse_metadata(&chunk_reader).unwrap();
     let kv_metas = metadata.file_metadata().key_value_metadata().unwrap();
 
-    encoding::decode_sst_meta_data(&kv_metas[0]).unwrap()
+    let parquet_meta_data = encoding::decode_sst_meta_data(&kv_metas[0]).unwrap();
+    SstMetaData::Parquet(Arc::new(parquet_meta_data))
 }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #402 

# Rationale for this change
 Currently, the storage format has been misused for many places. This PR will address this problem.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Remove `SsType` from the `TableData`;
- Add `StorageFormatHint` in the table options;
- Remove `StorageFormatOptions` from the `SstMetaData`;

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
`storage_format` has been replaced with `storage_format_hint` in the table options.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
