### PR TITLE
refactor: separate object store from async reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,7 +4009,9 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "arrow_ext 1.0.0-alpha02",
+ "async-trait",
  "bytes 1.2.1",
+ "common_util",
  "datafusion",
  "datafusion-expr",
  "log",

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -23,7 +23,7 @@ use crate::{
         builder::SstBuilder,
         meta_data::cache::MetaCacheRef,
         parquet::{
-            async_reader::AsyncFileReader, builder::ParquetSstBuilder, AsyncParquetReader,
+            async_reader::AsyncFileChunkReader, builder::ParquetSstBuilder, AsyncParquetReader,
             ThreadedReader,
         },
         reader::SstReader,
@@ -48,7 +48,7 @@ impl FileReaderOnObjectStore {
 }
 
 #[async_trait]
-impl AsyncFileReader for FileReaderOnObjectStore {
+impl AsyncFileChunkReader for FileReaderOnObjectStore {
     async fn file_size(&self) -> GenericResult<usize> {
         // check cached filed_size first
         {

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -12,7 +12,7 @@ use table_engine::predicate::PredicateRef;
 use crate::{
     sst::{
         builder::SstBuilder,
-        file_reader::FileReaderOnObjectStore,
+        file_reader::FileChunkReaderOnObjectStore,
         meta_data::cache::MetaCacheRef,
         parquet::{builder::ParquetSstBuilder, AsyncParquetReader, ThreadedReader},
         reader::SstReader,
@@ -107,7 +107,7 @@ impl Factory for FactoryImpl {
         // reader for sst according to its real format in the future.
         let hybrid_encoding = matches!(storage_format, StorageFormat::Hybrid);
         let store = store_picker.pick_by_freq(options.frequency).clone();
-        let file_reader = FileReaderOnObjectStore::new(path.clone(), store);
+        let file_reader = FileChunkReaderOnObjectStore::new(path.clone(), store);
         let parquet_reader =
             AsyncParquetReader::new(path, hybrid_encoding, Arc::new(file_reader), options);
         let reader = ThreadedReader::new(

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -2,10 +2,19 @@
 
 //! Factory for different kinds sst builder and reader.
 
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::Debug,
+    ops::Range,
+    sync::{Arc, RwLock},
+};
 
+use async_trait::async_trait;
+use bytes::Bytes;
 use common_types::projected_schema::ProjectedSchema;
-use common_util::runtime::Runtime;
+use common_util::{
+    error::{GenericError, GenericResult},
+    runtime::Runtime,
+};
 use object_store::{ObjectStoreRef, Path};
 use table_engine::predicate::PredicateRef;
 
@@ -13,11 +22,66 @@ use crate::{
     sst::{
         builder::SstBuilder,
         meta_data::cache::MetaCacheRef,
-        parquet::{builder::ParquetSstBuilder, AsyncParquetReader, ThreadedReader},
+        parquet::{
+            async_reader::AsyncFileReader, builder::ParquetSstBuilder, AsyncParquetReader,
+            ThreadedReader,
+        },
         reader::SstReader,
     },
     table_options::{Compression, StorageFormat, StorageFormatHint},
 };
+
+pub struct FileReaderOnObjectStore {
+    path: Path,
+    store: ObjectStoreRef,
+    cached_file_size: RwLock<Option<usize>>,
+}
+
+impl FileReaderOnObjectStore {
+    pub fn new(path: Path, store: ObjectStoreRef) -> Self {
+        Self {
+            path,
+            store,
+            cached_file_size: RwLock::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncFileReader for FileReaderOnObjectStore {
+    async fn file_size(&self) -> GenericResult<usize> {
+        // check cached filed_size first
+        {
+            let file_size = self.cached_file_size.read().unwrap();
+            if let Some(s) = file_size.as_ref() {
+                return Ok(*s);
+            }
+        }
+
+        // fetch the size from the underlying store
+        let head = self
+            .store
+            .head(&self.path)
+            .await
+            .map_err(|e| Box::new(e) as GenericError)?;
+        *self.cached_file_size.write().unwrap() = Some(head.size);
+        Ok(head.size)
+    }
+
+    async fn get_byte_range(&self, range: Range<usize>) -> GenericResult<Bytes> {
+        self.store
+            .get_range(&self.path, range)
+            .await
+            .map_err(|e| Box::new(e) as _)
+    }
+
+    async fn get_byte_ranges(&self, ranges: &[Range<usize>]) -> GenericResult<Vec<Bytes>> {
+        self.store
+            .get_ranges(&self.path, ranges)
+            .await
+            .map_err(|e| Box::new(e) as _)
+    }
+}
 
 /// Pick suitable object store for different scenes.
 pub trait ObjectStorePicker: Send + Sync + Debug {
@@ -105,9 +169,12 @@ impl Factory for FactoryImpl {
         // TODO: Currently, we only have one sst format, and we have to choose right
         // reader for sst according to its real format in the future.
         let hybrid_encoding = matches!(storage_format, StorageFormat::Hybrid);
-        let reader = AsyncParquetReader::new(path, hybrid_encoding, store_picker, options);
+        let store = store_picker.pick_by_freq(options.frequency).clone();
+        let file_reader = FileReaderOnObjectStore::new(path.clone(), store);
+        let parquet_reader =
+            AsyncParquetReader::new(path, hybrid_encoding, Arc::new(file_reader), options);
         let reader = ThreadedReader::new(
-            reader,
+            parquet_reader,
             options.runtime.clone(),
             options.background_read_parallelism,
         );

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -2,86 +2,23 @@
 
 //! Factory for different kinds sst builder and reader.
 
-use std::{
-    fmt::Debug,
-    ops::Range,
-    sync::{Arc, RwLock},
-};
+use std::{fmt::Debug, sync::Arc};
 
-use async_trait::async_trait;
-use bytes::Bytes;
 use common_types::projected_schema::ProjectedSchema;
-use common_util::{
-    error::{GenericError, GenericResult},
-    runtime::Runtime,
-};
+use common_util::runtime::Runtime;
 use object_store::{ObjectStoreRef, Path};
 use table_engine::predicate::PredicateRef;
 
 use crate::{
     sst::{
         builder::SstBuilder,
+        file_reader::FileReaderOnObjectStore,
         meta_data::cache::MetaCacheRef,
-        parquet::{
-            async_reader::AsyncFileChunkReader, builder::ParquetSstBuilder, AsyncParquetReader,
-            ThreadedReader,
-        },
+        parquet::{builder::ParquetSstBuilder, AsyncParquetReader, ThreadedReader},
         reader::SstReader,
     },
     table_options::{Compression, StorageFormat, StorageFormatHint},
 };
-
-pub struct FileReaderOnObjectStore {
-    path: Path,
-    store: ObjectStoreRef,
-    cached_file_size: RwLock<Option<usize>>,
-}
-
-impl FileReaderOnObjectStore {
-    pub fn new(path: Path, store: ObjectStoreRef) -> Self {
-        Self {
-            path,
-            store,
-            cached_file_size: RwLock::new(None),
-        }
-    }
-}
-
-#[async_trait]
-impl AsyncFileChunkReader for FileReaderOnObjectStore {
-    async fn file_size(&self) -> GenericResult<usize> {
-        // check cached filed_size first
-        {
-            let file_size = self.cached_file_size.read().unwrap();
-            if let Some(s) = file_size.as_ref() {
-                return Ok(*s);
-            }
-        }
-
-        // fetch the size from the underlying store
-        let head = self
-            .store
-            .head(&self.path)
-            .await
-            .map_err(|e| Box::new(e) as GenericError)?;
-        *self.cached_file_size.write().unwrap() = Some(head.size);
-        Ok(head.size)
-    }
-
-    async fn get_byte_range(&self, range: Range<usize>) -> GenericResult<Bytes> {
-        self.store
-            .get_range(&self.path, range)
-            .await
-            .map_err(|e| Box::new(e) as _)
-    }
-
-    async fn get_byte_ranges(&self, ranges: &[Range<usize>]) -> GenericResult<Vec<Bytes>> {
-        self.store
-            .get_ranges(&self.path, ranges)
-            .await
-            .map_err(|e| Box::new(e) as _)
-    }
-}
 
 /// Pick suitable object store for different scenes.
 pub trait ObjectStorePicker: Send + Sync + Debug {

--- a/analytic_engine/src/sst/file_reader.rs
+++ b/analytic_engine/src/sst/file_reader.rs
@@ -1,0 +1,74 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    ops::Range,
+    sync::{Arc, RwLock},
+};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use common_util::error::{GenericError, GenericResult};
+use object_store::{ObjectStoreRef, Path};
+
+pub type AsyncFileReaderRef = Arc<dyn AsyncFileChunkReader>;
+
+#[async_trait]
+pub trait AsyncFileChunkReader: Send + Sync {
+    async fn file_size(&self) -> GenericResult<usize>;
+
+    async fn get_byte_range(&self, range: Range<usize>) -> GenericResult<Bytes>;
+
+    async fn get_byte_ranges(&self, ranges: &[Range<usize>]) -> GenericResult<Vec<Bytes>>;
+}
+
+pub struct FileReaderOnObjectStore {
+    path: Path,
+    store: ObjectStoreRef,
+    cached_file_size: RwLock<Option<usize>>,
+}
+
+impl FileReaderOnObjectStore {
+    pub fn new(path: Path, store: ObjectStoreRef) -> Self {
+        Self {
+            path,
+            store,
+            cached_file_size: RwLock::new(None),
+        }
+    }
+}
+
+#[async_trait]
+impl AsyncFileChunkReader for FileReaderOnObjectStore {
+    async fn file_size(&self) -> GenericResult<usize> {
+        // check cached filed_size first
+        {
+            let file_size = self.cached_file_size.read().unwrap();
+            if let Some(s) = file_size.as_ref() {
+                return Ok(*s);
+            }
+        }
+
+        // fetch the size from the underlying store
+        let head = self
+            .store
+            .head(&self.path)
+            .await
+            .map_err(|e| Box::new(e) as GenericError)?;
+        *self.cached_file_size.write().unwrap() = Some(head.size);
+        Ok(head.size)
+    }
+
+    async fn get_byte_range(&self, range: Range<usize>) -> GenericResult<Bytes> {
+        self.store
+            .get_range(&self.path, range)
+            .await
+            .map_err(|e| Box::new(e) as _)
+    }
+
+    async fn get_byte_ranges(&self, ranges: &[Range<usize>]) -> GenericResult<Vec<Bytes>> {
+        self.store
+            .get_ranges(&self.path, ranges)
+            .await
+            .map_err(|e| Box::new(e) as _)
+    }
+}

--- a/analytic_engine/src/sst/file_reader.rs
+++ b/analytic_engine/src/sst/file_reader.rs
@@ -10,10 +10,10 @@ use bytes::Bytes;
 use common_util::error::{GenericError, GenericResult};
 use object_store::{ObjectStoreRef, Path};
 
-pub type AsyncFileReaderRef = Arc<dyn AsyncFileChunkReader>;
+pub type FileChunkReaderRef = Arc<dyn FileChunkReader>;
 
 #[async_trait]
-pub trait AsyncFileChunkReader: Send + Sync {
+pub trait FileChunkReader: Send + Sync {
     async fn file_size(&self) -> GenericResult<usize>;
 
     async fn get_byte_range(&self, range: Range<usize>) -> GenericResult<Bytes>;
@@ -21,13 +21,14 @@ pub trait AsyncFileChunkReader: Send + Sync {
     async fn get_byte_ranges(&self, ranges: &[Range<usize>]) -> GenericResult<Vec<Bytes>>;
 }
 
-pub struct FileReaderOnObjectStore {
+/// A [`FileChunkReader`] implementation based on [`ObjectStore`].
+pub struct FileChunkReaderOnObjectStore {
     path: Path,
     store: ObjectStoreRef,
     cached_file_size: RwLock<Option<usize>>,
 }
 
-impl FileReaderOnObjectStore {
+impl FileChunkReaderOnObjectStore {
     pub fn new(path: Path, store: ObjectStoreRef) -> Self {
         Self {
             path,
@@ -38,7 +39,7 @@ impl FileReaderOnObjectStore {
 }
 
 #[async_trait]
-impl AsyncFileChunkReader for FileReaderOnObjectStore {
+impl FileChunkReader for FileChunkReaderOnObjectStore {
     async fn file_size(&self) -> GenericResult<usize> {
         // check cached filed_size first
         {

--- a/analytic_engine/src/sst/mod.rs
+++ b/analytic_engine/src/sst/mod.rs
@@ -5,6 +5,7 @@
 pub mod builder;
 pub mod factory;
 pub mod file;
+pub mod file_reader;
 pub mod manager;
 pub mod meta_data;
 pub mod metrics;

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -38,7 +38,7 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::sst::{
     factory::{ReadFrequency, SstReaderOptions},
-    file_reader::AsyncFileReaderRef,
+    file_reader::FileChunkReaderRef,
     meta_data::{
         cache::{MetaCacheRef, MetaData},
         SstMetaData,
@@ -55,7 +55,7 @@ use crate::sst::{
 type SendableRecordBatchStream = Pin<Box<dyn Stream<Item = Result<ArrowRecordBatch>> + Send>>;
 
 struct ChunkReaderAdapter {
-    file_reader: AsyncFileReaderRef,
+    file_reader: FileChunkReaderRef,
 }
 
 #[async_trait]
@@ -69,7 +69,7 @@ pub struct Reader<'a> {
     /// The path where the data is persisted.
     path: &'a Path,
     hybrid_encoding: bool,
-    file_reader: AsyncFileReaderRef,
+    file_reader: FileChunkReaderRef,
     projected_schema: ProjectedSchema,
     meta_cache: Option<MetaCacheRef>,
     predicate: PredicateRef,
@@ -89,7 +89,7 @@ impl<'a> Reader<'a> {
     pub fn new(
         path: &'a Path,
         hybrid_encoding: bool,
-        file_reader: AsyncFileReaderRef,
+        file_reader: FileChunkReaderRef,
         options: &SstReaderOptions,
     ) -> Self {
         let batch_size = options.read_batch_row_num;
@@ -367,13 +367,13 @@ impl fmt::Debug for ReaderMetrics {
 }
 
 struct ParquetFileReaderAdapter {
-    file_reader: AsyncFileReaderRef,
+    file_reader: FileChunkReaderRef,
     meta_data: MetaData,
     metrics: ReaderMetrics,
 }
 
 impl ParquetFileReaderAdapter {
-    fn new(file_reader: AsyncFileReaderRef, meta_data: MetaData) -> Self {
+    fn new(file_reader: FileChunkReaderRef, meta_data: MetaData) -> Self {
         Self {
             file_reader,
             meta_data,

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -290,7 +290,7 @@ mod tests {
         row_iter::tests::build_record_batch_with_key,
         sst::{
             factory::{Factory, FactoryImpl, ReadFrequency, SstBuilderOptions, SstReaderOptions},
-            file_reader::FileReaderOnObjectStore,
+            file_reader::FileChunkReaderOnObjectStore,
             parquet::AsyncParquetReader,
             reader::{tests::check_stream, SstReader},
         },
@@ -386,7 +386,7 @@ mod tests {
             };
 
             let mut reader: Box<dyn SstReader + Send> = {
-                let file_reader = FileReaderOnObjectStore::new(
+                let file_reader = FileChunkReaderOnObjectStore::new(
                     sst_file_path.clone(),
                     store_picker.default_store().clone(),
                 );

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -289,7 +289,10 @@ mod tests {
     use crate::{
         row_iter::tests::build_record_batch_with_key,
         sst::{
-            factory::{Factory, FactoryImpl, ReadFrequency, SstBuilderOptions, SstReaderOptions},
+            factory::{
+                Factory, FactoryImpl, FileReaderOnObjectStore, ReadFrequency, SstBuilderOptions,
+                SstReaderOptions,
+            },
             parquet::AsyncParquetReader,
             reader::{tests::check_stream, SstReader},
         },
@@ -385,10 +388,14 @@ mod tests {
             };
 
             let mut reader: Box<dyn SstReader + Send> = {
+                let file_reader = FileReaderOnObjectStore::new(
+                    sst_file_path.clone(),
+                    store_picker.default_store().clone(),
+                );
                 let mut reader = AsyncParquetReader::new(
                     &sst_file_path,
                     false,
-                    &store_picker,
+                    Arc::new(file_reader),
                     &sst_reader_options,
                 );
                 let mut sst_meta_readback = reader

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -289,10 +289,8 @@ mod tests {
     use crate::{
         row_iter::tests::build_record_batch_with_key,
         sst::{
-            factory::{
-                Factory, FactoryImpl, FileReaderOnObjectStore, ReadFrequency, SstBuilderOptions,
-                SstReaderOptions,
-            },
+            factory::{Factory, FactoryImpl, ReadFrequency, SstBuilderOptions, SstReaderOptions},
+            file_reader::FileReaderOnObjectStore,
             parquet::AsyncParquetReader,
             reader::{tests::check_stream, SstReader},
         },

--- a/components/parquet_ext/Cargo.toml
+++ b/components/parquet_ext/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 [dependencies]
 arrow = { workspace = true }
 arrow_ext = { workspace = true }
+async-trait = { workspace = true }
 bytes = { workspace = true }
+common_util = { workspace = true }
 datafusion = { workspace = true }
 datafusion-expr = { workspace = true }
 log = { workspace = true }

--- a/components/parquet_ext/src/lib.rs
+++ b/components/parquet_ext/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+pub mod meta_data;
 pub mod prune;
 pub mod reverse_reader;
 #[cfg(test)]

--- a/components/parquet_ext/src/meta_data.rs
+++ b/components/parquet_ext/src/meta_data.rs
@@ -1,0 +1,67 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::ops::Range;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use common_util::error::GenericResult;
+use parquet::{
+    errors::{ParquetError, Result},
+    file::{footer, metadata::ParquetMetaData},
+};
+
+#[async_trait]
+pub trait ChunkReader: Sync + Send {
+    async fn get_bytes(&self, range: Range<usize>) -> GenericResult<Bytes>;
+}
+
+/// Fetch and parse [`ParquetMetadata`] from the file reader.
+///
+/// Referring to: https://github.com/apache/arrow-datafusion/blob/ac2e5d15e5452e83c835d793a95335e87bf35569/datafusion/core/src/datasource/file_format/parquet.rs#L390-L449
+pub async fn fetch_parquet_metadata(
+    file_size: usize,
+    file_reader: &dyn ChunkReader,
+) -> Result<ParquetMetaData> {
+    const FOOTER_LEN: usize = 8;
+
+    if file_size < FOOTER_LEN {
+        let err_msg = format!("file size of {} is less than footer", file_size);
+        return Err(ParquetError::General(err_msg));
+    }
+
+    let footer_start = file_size - FOOTER_LEN;
+
+    let footer_bytes = file_reader
+        .get_bytes(footer_start..file_size)
+        .await
+        .map_err(|e| {
+            let err_msg = format!("failed to get footer bytes, err:{}", e);
+            ParquetError::General(err_msg)
+        })?;
+
+    assert_eq!(footer_bytes.len(), FOOTER_LEN);
+    let mut footer = [0; FOOTER_LEN];
+    footer.copy_from_slice(&footer_bytes);
+
+    let metadata_len = footer::decode_footer(&footer)?;
+
+    if file_size < metadata_len + FOOTER_LEN {
+        let err_msg = format!(
+            "file size of {} is smaller than footer + metadata {}",
+            file_size,
+            metadata_len + FOOTER_LEN
+        );
+        return Err(ParquetError::General(err_msg));
+    }
+
+    let metadata_start = file_size - metadata_len - FOOTER_LEN;
+    let metadata_bytes = file_reader
+        .get_bytes(metadata_start..footer_start)
+        .await
+        .map_err(|e| {
+            let err_msg = format!("failed to get metadata bytes, err:{}", e);
+            ParquetError::General(err_msg)
+        })?;
+
+    footer::decode_metadata(&metadata_bytes)
+}

--- a/integration_tests/cases/local/03_dml/case_insensitive.result
+++ b/integration_tests/cases/local/03_dml/case_insensitive.result
@@ -56,7 +56,7 @@ Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to cr
 SHOW CREATE TABLE case_insensitive_table1;
 
 Table,Create Table,
-String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`tsid` uint64 NOT NULL, `ts` timestamp NOT NULL, `value1` double, PRIMARY KEY(tsid,ts), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`tsid` uint64 NOT NULL, `ts` timestamp NOT NULL, `value1` double, PRIMARY KEY(tsid,ts), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 SHOW CREATE TABLE CASE_INSENSITIVE_TABLE1;
@@ -66,7 +66,7 @@ Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to cr
 SHOW CREATE TABLE `case_insensitive_table1`;
 
 Table,Create Table,
-String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`tsid` uint64 NOT NULL, `ts` timestamp NOT NULL, `value1` double, PRIMARY KEY(tsid,ts), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"case_insensitive_table1")),String(StringBytes(b"CREATE TABLE `case_insensitive_table1` (`tsid` uint64 NOT NULL, `ts` timestamp NOT NULL, `value1` double, PRIMARY KEY(tsid,ts), TIMESTAMP KEY(ts)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 SHOW CREATE TABLE `CASE_INSENSITIVE_TABLE1`;

--- a/integration_tests/cases/local/05_ddl/create_tables.result
+++ b/integration_tests/cases/local/05_ddl/create_tables.result
@@ -92,7 +92,7 @@ String(StringBytes(b"a")),String(StringBytes(b"int")),Boolean(false),Boolean(tru
 show create table `05_create_tables_t4`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t4")),String(StringBytes(b"CREATE TABLE `05_create_tables_t4` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t4")),String(StringBytes(b"CREATE TABLE `05_create_tables_t4` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `05_create_tables_t5`(c1 int, t timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
@@ -110,7 +110,7 @@ String(StringBytes(b"c1")),String(StringBytes(b"int")),Boolean(false),Boolean(tr
 show create table `05_create_tables_t5`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t5")),String(StringBytes(b"CREATE TABLE `05_create_tables_t5` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t5")),String(StringBytes(b"CREATE TABLE `05_create_tables_t5` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `05_create_tables_t6`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY, t2 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
@@ -132,7 +132,7 @@ String(StringBytes(b"c1")),String(StringBytes(b"int")),Boolean(false),Boolean(tr
 show create table `05_create_tables_t7`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t7")),String(StringBytes(b"CREATE TABLE `05_create_tables_t7` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `c1` int COMMENT 'id', PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t7")),String(StringBytes(b"CREATE TABLE `05_create_tables_t7` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `c1` int COMMENT 'id', PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `05_create_tables_t8`(c1 int, t1 timestamp NOT NULL TIMESTAMP KEY) ENGINE = Analytic;
@@ -142,7 +142,7 @@ affected_rows: 0
 show create table `05_create_tables_t8`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t8")),String(StringBytes(b"CREATE TABLE `05_create_tables_t8` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t8`;
@@ -184,7 +184,7 @@ affected_rows: 0
 show create table `05_create_tables_t9`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t9")),String(StringBytes(b"CREATE TABLE `05_create_tables_t9` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, `c2` bigint DEFAULT 0, `c3` uint32 DEFAULT 1 + 1, `c4` string DEFAULT 'xxx', `c5` uint32 DEFAULT c3 * 2 + 1, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t9")),String(StringBytes(b"CREATE TABLE `05_create_tables_t9` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, `c2` bigint DEFAULT 0, `c3` uint32 DEFAULT 1 + 1, `c4` string DEFAULT 'xxx', `c5` uint32 DEFAULT c3 * 2 + 1, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t9`;
@@ -198,7 +198,7 @@ affected_rows: 0
 show create table `05_create_tables_t10`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t10")),String(StringBytes(b"CREATE TABLE `05_create_tables_t10` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t10")),String(StringBytes(b"CREATE TABLE `05_create_tables_t10` (`tsid` uint64 NOT NULL, `t1` timestamp NOT NULL, `c1` int, PRIMARY KEY(tsid,t1), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t10`;
@@ -212,7 +212,7 @@ affected_rows: 0
 show create table `05_create_tables_t11`;
 
 Table,Create Table,
-String(StringBytes(b"05_create_tables_t11")),String(StringBytes(b"CREATE TABLE `05_create_tables_t11` (`t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, `c1` int, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"05_create_tables_t11")),String(StringBytes(b"CREATE TABLE `05_create_tables_t11` (`t1` timestamp NOT NULL, `tsid` uint64 NOT NULL, `c1` int, PRIMARY KEY(t1,tsid), TIMESTAMP KEY(t1)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 drop table `05_create_tables_t11`;

--- a/integration_tests/cases/local/06_show/show_create_table.result
+++ b/integration_tests/cases/local/06_show/show_create_table.result
@@ -17,7 +17,7 @@ affected_rows: 0
 SHOW CREATE TABLE `06_show_a`;
 
 Table,Create Table,
-String(StringBytes(b"06_show_a")),String(StringBytes(b"CREATE TABLE `06_show_a` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` bigint, `b` int DEFAULT 3, `c` string DEFAULT 'x', `d` smallint, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"06_show_a")),String(StringBytes(b"CREATE TABLE `06_show_a` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` bigint, `b` int DEFAULT 3, `c` string DEFAULT 'x', `d` smallint, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `06_show_b` (a bigint, b int null default null, c string, d smallint null, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE = Analytic;
@@ -27,7 +27,7 @@ affected_rows: 0
 SHOW CREATE TABLE `06_show_b`;
 
 Table,Create Table,
-String(StringBytes(b"06_show_b")),String(StringBytes(b"CREATE TABLE `06_show_b` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` bigint, `b` int DEFAULT NULL, `c` string, `d` smallint, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"06_show_b")),String(StringBytes(b"CREATE TABLE `06_show_b` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` bigint, `b` int DEFAULT NULL, `c` string, `d` smallint, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 CREATE TABLE `06_show_c` (a int, t timestamp NOT NULL, TIMESTAMP KEY(t)) ENGINE = Analytic;
@@ -37,7 +37,7 @@ affected_rows: 0
 SHOW CREATE TABLE `06_show_c`;
 
 Table,Create Table,
-String(StringBytes(b"06_show_c")),String(StringBytes(b"CREATE TABLE `06_show_c` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='COLUMNAR', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
+String(StringBytes(b"06_show_c")),String(StringBytes(b"CREATE TABLE `06_show_c` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `a` int, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')")),
 
 
 DROP TABLE `06_show_a`;


### PR DESCRIPTION
# Which issue does this PR close?

Prepare for #495

# Rationale for this change
 In order to control how to decode our custom sst file, the object store must be separated from the Parquet SST async reader because the api of object store has no flexibility to introduce another footer after the original file content.

(Actually, this is a similar with #503, which is reverted by #536, and we need to move on to the custom storage format which needs this PR.)

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Separate the ObjectStore from the parquet sst async reader.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
