### PR TITLE
chore: change the prefix of sub partition table name to "__"

### DIFF
--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -232,7 +232,7 @@ impl TryFrom<meta_pb::PartitionInfo> for PartitionInfo {
 }
 
 pub fn format_sub_partition_table_name(table_name: &str, partition_name: &str) -> String {
-    format!("____{}_{}", table_name, partition_name)
+    format!("__{}_{}", table_name, partition_name)
 }
 
 /// Encoder for partition info with version control.

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -10,6 +10,7 @@ use proto::{meta_update as meta_pb, meta_update::partition_info::PartitionInfoEn
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 
 const DEFAULT_PARTITION_INFO_ENCODING_VERSION: u8 = 0;
+const PARTITION_TABLE_PREFIX: &str = "__";
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -232,7 +233,10 @@ impl TryFrom<meta_pb::PartitionInfo> for PartitionInfo {
 }
 
 pub fn format_sub_partition_table_name(table_name: &str, partition_name: &str) -> String {
-    format!("__{}_{}", table_name, partition_name)
+    format!(
+        "{}{}_{}",
+        PARTITION_TABLE_PREFIX, table_name, partition_name
+    )
 }
 
 /// Encoder for partition info with version control.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 At present, the prefix of  sub partition table name is "____",  which is too long.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Change the prefix of sub partition table name to "__".
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
