### PR TITLE
feat: pass partition info to ceresmeta when create table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3#d393d4753ae0619d4609eef50c7fb2dd4b061df3"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f#9430fe7d321955878ca06c431b115d73640f5d8f"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1024,7 +1024,7 @@ name = "cluster"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "log",
@@ -3195,7 +3195,7 @@ name = "meta_client"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "futures 0.3.21",
@@ -4828,7 +4828,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow_ext 1.0.0-alpha02",
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "clru",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -4963,7 +4963,7 @@ name = "router"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "cluster",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -5292,7 +5292,7 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "cluster",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -5631,7 +5631,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "datafusion",
@@ -5887,7 +5887,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
+ "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=6cc1754ffc31ddfe0710972c94f8fe5acd61af98#6cc1754ffc31ddfe0710972c94f8fe5acd61af98"
+source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d#9bffa8aa977f5cb1ce1534ca37184e873e34549d"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1024,7 +1024,7 @@ name = "cluster"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=6cc1754ffc31ddfe0710972c94f8fe5acd61af98)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "log",
@@ -3195,7 +3195,7 @@ name = "meta_client"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=6cc1754ffc31ddfe0710972c94f8fe5acd61af98)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "futures 0.3.21",
@@ -3207,6 +3207,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "snafu 0.6.10",
+ "table_engine",
  "tokio 1.24.1",
  "tonic",
  "url 2.2.2",
@@ -4827,7 +4828,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow_ext 1.0.0-alpha02",
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=6cc1754ffc31ddfe0710972c94f8fe5acd61af98)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
  "clru",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -4962,7 +4963,7 @@ name = "router"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=6cc1754ffc31ddfe0710972c94f8fe5acd61af98)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
  "cluster",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -5291,7 +5292,7 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=6cc1754ffc31ddfe0710972c94f8fe5acd61af98)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
  "cluster",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -5630,7 +5631,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=6cc1754ffc31ddfe0710972c94f8fe5acd61af98)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "datafusion",
@@ -5886,6 +5887,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "async-trait",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "0.1.0"
-source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d#9bffa8aa977f5cb1ce1534ca37184e873e34549d"
+source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3#d393d4753ae0619d4609eef50c7fb2dd4b061df3"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1024,7 +1024,7 @@ name = "cluster"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "log",
@@ -3195,7 +3195,7 @@ name = "meta_client"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "futures 0.3.21",
@@ -4828,7 +4828,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow_ext 1.0.0-alpha02",
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
  "clru",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -4963,7 +4963,7 @@ name = "router"
 version = "1.0.0-alpha02"
 dependencies = [
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
  "cluster",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -5292,7 +5292,7 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
  "cluster",
  "common_types 1.0.0-alpha02",
  "common_util",
@@ -5631,7 +5631,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "catalog",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "datafusion",
@@ -5887,7 +5887,7 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "async-trait",
- "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9bffa8aa977f5cb1ce1534ca37184e873e34549d)",
+ "ceresdbproto 0.1.0 (git+https://github.com/chunshao90/ceresdbproto.git?rev=d393d4753ae0619d4609eef50c7fb2dd4b061df3)",
  "common_types 1.0.0-alpha02",
  "common_util",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ message_queue = { path = "components/message_queue" }
 zstd = { version = "0.12", default-features = false }
 
 [workspace.dependencies.ceresdbproto]
-git = "https://github.com/chunshao90/ceresdbproto.git"
-rev = "d393d4753ae0619d4609eef50c7fb2dd4b061df3"
+git = "https://github.com/CeresDB/ceresdbproto.git"
+rev = "9430fe7d321955878ca06c431b115d73640f5d8f"
 
 [workspace.dependencies.datafusion]
 git = "https://github.com/CeresDB/arrow-datafusion.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ zstd = { version = "0.12", default-features = false }
 
 [workspace.dependencies.ceresdbproto]
 git = "https://github.com/chunshao90/ceresdbproto.git"
-rev = "9bffa8aa977f5cb1ce1534ca37184e873e34549d"
+rev = "d393d4753ae0619d4609eef50c7fb2dd4b061df3"
 
 [workspace.dependencies.datafusion]
 git = "https://github.com/CeresDB/arrow-datafusion.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ message_queue = { path = "components/message_queue" }
 zstd = { version = "0.12", default-features = false }
 
 [workspace.dependencies.ceresdbproto]
-git = "https://github.com/CeresDB/ceresdbproto.git"
-rev = "6cc1754ffc31ddfe0710972c94f8fe5acd61af98"
+git = "https://github.com/chunshao90/ceresdbproto.git"
+rev = "9bffa8aa977f5cb1ce1534ca37184e873e34549d"
 
 [workspace.dependencies.datafusion]
 git = "https://github.com/CeresDB/arrow-datafusion.git"

--- a/analytic_engine/src/meta/details.rs
+++ b/analytic_engine/src/meta/details.rs
@@ -1191,7 +1191,7 @@ mod tests {
             let default_version = 0;
             let partition_info = Some(PartitionInfo::Hash(HashPartitionInfo {
                 version: default_version,
-                partition_definitions: vec![PartitionDefinition {
+                definitions: vec![PartitionDefinition {
                     name: "p0".to_string(),
                     origin_name: Some("region0".to_string()),
                 }],

--- a/interpreters/src/show_create.rs
+++ b/interpreters/src/show_create.rs
@@ -127,14 +127,14 @@ impl ShowCreateInterpreter {
                     res += format!(
                         " PARTITION BY LINEAR HASH({}) PARTITIONS {}",
                         expr,
-                        v.partition_definitions.len()
+                        v.definitions.len()
                     )
                     .as_str()
                 } else {
                     res += format!(
                         " PARTITION BY HASH({}) PARTITIONS {}",
                         expr,
-                        v.partition_definitions.len()
+                        v.definitions.len()
                     )
                     .as_str()
                 }
@@ -145,14 +145,14 @@ impl ShowCreateInterpreter {
                     res += format!(
                         " PARTITION BY LINEAR KEY({}) PARTITIONS {}",
                         rendered_partition_key,
-                        v.partition_definitions.len()
+                        v.definitions.len()
                     )
                     .as_str()
                 } else {
                     res += format!(
                         " PARTITION BY KEY({}) PARTITIONS {}",
                         rendered_partition_key,
-                        v.partition_definitions.len()
+                        v.definitions.len()
                     )
                     .as_str()
                 }
@@ -197,7 +197,7 @@ mod test {
         let expr = col("col1").add(col("col2"));
         let partition_info = PartitionInfo::Hash(HashPartitionInfo {
             version: 0,
-            partition_definitions: vec![
+            definitions: vec![
                 PartitionDefinition {
                     name: "p0".to_string(),
                     origin_name: None,
@@ -223,7 +223,7 @@ mod test {
         let partition_key_col_name = "col1";
         let partition_info = PartitionInfo::Key(KeyPartitionInfo {
             version: 0,
-            partition_definitions: vec![
+            definitions: vec![
                 PartitionDefinition {
                     name: "p0".to_string(),
                     origin_name: None,

--- a/meta_client/Cargo.toml
+++ b/meta_client/Cargo.toml
@@ -24,6 +24,7 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
+table_engine =  { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 url = "2.2"

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -11,6 +11,7 @@ use common_types::{
 use common_util::config::ReadableDuration;
 use serde_derive::Deserialize;
 use snafu::OptionExt;
+use table_engine::partition::PartitionInfo;
 
 use crate::{Error, MissingShardInfo, MissingTableInfo, Result};
 pub type ClusterNodesRef = Arc<Vec<NodeShard>>;
@@ -35,6 +36,7 @@ pub struct AllocSchemaIdResponse {
 #[derive(Clone, Debug)]
 pub struct PartitionTableInfo {
     pub sub_table_names: Vec<String>,
+    pub partition_info: PartitionInfo,
 }
 
 #[derive(Clone, Debug)]
@@ -46,7 +48,6 @@ pub struct CreateTableRequest {
     pub create_if_not_exist: bool,
     pub options: HashMap<String, String>,
     pub partition_table_info: Option<PartitionTableInfo>,
-    pub encoded_partition_info: Vec<u8>,
 }
 
 #[derive(Clone, Debug)]
@@ -311,6 +312,7 @@ impl From<CreateTableRequest> for meta_service_pb::CreateTableRequest {
         let partition_table_info =
             req.partition_table_info
                 .map(|v| meta_service_pb::PartitionTableInfo {
+                    partition_info: Some(v.partition_info.into()),
                     sub_table_names: v.sub_table_names,
                 });
         Self {
@@ -321,7 +323,6 @@ impl From<CreateTableRequest> for meta_service_pb::CreateTableRequest {
             engine: req.engine,
             create_if_not_exist: req.create_if_not_exist,
             options: req.options,
-            encoded_partition_info: req.encoded_partition_info,
             partition_table_info,
         }
     }
@@ -350,6 +351,7 @@ impl From<DropTableRequest> for meta_service_pb::DropTableRequest {
         let partition_table_info =
             req.partition_table_info
                 .map(|v| meta_service_pb::PartitionTableInfo {
+                    partition_info: Some(v.partition_info.into()),
                     sub_table_names: v.sub_table_names,
                 });
         Self {

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -327,7 +327,7 @@ async fn handle_create_table_on_shard(
             ),
         })?;
 
-    let partition_info = match request.partition_info {
+    let partition_info = match table.partition_info {
         Some(v) => Some(
             PartitionInfo::try_from(v.clone())
                 .map_err(|e| Box::new(e) as _)

--- a/sql/src/partition.rs
+++ b/sql/src/partition.rs
@@ -48,7 +48,7 @@ impl PartitionParser {
 
             Ok(HashPartitionInfo {
                 version: DEFAULT_PARTITION_VERSION,
-                definitions: definitions,
+                definitions,
                 expr,
                 linear,
             })
@@ -71,7 +71,7 @@ impl PartitionParser {
 
         Ok(KeyPartitionInfo {
             version: DEFAULT_PARTITION_VERSION,
-            definitions: definitions,
+            definitions,
             partition_key,
             linear,
         })

--- a/sql/src/partition.rs
+++ b/sql/src/partition.rs
@@ -48,7 +48,7 @@ impl PartitionParser {
 
             Ok(HashPartitionInfo {
                 version: DEFAULT_PARTITION_VERSION,
-                partition_definitions: definitions,
+                definitions: definitions,
                 expr,
                 linear,
             })
@@ -71,7 +71,7 @@ impl PartitionParser {
 
         Ok(KeyPartitionInfo {
             version: DEFAULT_PARTITION_VERSION,
-            partition_definitions: definitions,
+            definitions: definitions,
             partition_key,
             linear,
         })

--- a/table_engine/Cargo.toml
+++ b/table_engine/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 # In alphabetical order
 arrow = { workspace = true }
 async-trait = { workspace = true }
+ceresdbproto = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }
 datafusion = { workspace = true }

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -105,6 +105,7 @@ pub struct KeyPartitionInfo {
     pub linear: bool,
 }
 
+// TODO: remove PartitionInfo from proto, see https://github.com/CeresDB/ceresdb/issues/571
 impl From<PartitionDefinition> for meta_pb::PartitionDefinition {
     fn from(definition: PartitionDefinition) -> Self {
         Self {
@@ -197,13 +198,13 @@ impl From<PartitionInfo> for meta_pb::PartitionInfo {
             PartitionInfo::Hash(v) => {
                 let hash_partition_info = meta_pb::HashPartitionInfo::from(v);
                 meta_pb::PartitionInfo {
-                    partition_info_enum: Some(PartitionInfoEnum::Hash(hash_partition_info)),
+                    partition_info_enum: Some(PartitionInfoEnumProto::Hash(hash_partition_info)),
                 }
             }
             PartitionInfo::Key(v) => {
                 let key_partition_info = meta_pb::KeyPartitionInfo::from(v);
                 meta_pb::PartitionInfo {
-                    partition_info_enum: Some(PartitionInfoEnum::Key(key_partition_info)),
+                    partition_info_enum: Some(PartitionInfoEnumProto::Key(key_partition_info)),
                 }
             }
         }
@@ -215,6 +216,135 @@ impl TryFrom<meta_pb::PartitionInfo> for PartitionInfo {
 
     fn try_from(
         partition_info_pb: meta_pb::PartitionInfo,
+    ) -> std::result::Result<Self, Self::Error> {
+        match partition_info_pb.partition_info_enum {
+            Some(partition_info_enum) => match partition_info_enum {
+                PartitionInfoEnumProto::Hash(v) => {
+                    let hash_partition_info = HashPartitionInfo::from(v);
+                    Ok(Self::Hash(hash_partition_info))
+                }
+                PartitionInfoEnumProto::Key(v) => {
+                    let key_partition_info = KeyPartitionInfo::from(v);
+                    Ok(Self::Key(key_partition_info))
+                }
+            },
+            None => Err(Error::EmptyPartitionInfo {}),
+        }
+    }
+}
+
+impl From<PartitionDefinition> for ceresdbproto::cluster::PartitionDefinition {
+    fn from(definition: PartitionDefinition) -> Self {
+        Self {
+            name: definition.name,
+            origin_name: definition
+                .origin_name
+                .map(ceresdbproto::cluster::partition_definition::OriginName::Origin),
+        }
+    }
+}
+
+impl From<ceresdbproto::cluster::PartitionDefinition> for PartitionDefinition {
+    fn from(pb: ceresdbproto::cluster::PartitionDefinition) -> Self {
+        let mut origin_name = None;
+        if let Some(v) = pb.origin_name {
+            match v {
+                ceresdbproto::cluster::partition_definition::OriginName::Origin(name) => {
+                    origin_name = Some(name)
+                }
+            }
+        }
+        Self {
+            name: pb.name,
+            origin_name,
+        }
+    }
+}
+
+impl From<ceresdbproto::cluster::HashPartitionInfo> for HashPartitionInfo {
+    fn from(partition_info_pb: ceresdbproto::cluster::HashPartitionInfo) -> Self {
+        HashPartitionInfo {
+            version: partition_info_pb.version,
+            partition_definitions: partition_info_pb
+                .partition_definitions
+                .into_iter()
+                .map(|v| v.into())
+                .collect(),
+            expr: Bytes::from(partition_info_pb.expr),
+            linear: partition_info_pb.linear,
+        }
+    }
+}
+
+impl From<HashPartitionInfo> for ceresdbproto::cluster::HashPartitionInfo {
+    fn from(partition_info: HashPartitionInfo) -> Self {
+        ceresdbproto::cluster::HashPartitionInfo {
+            version: partition_info.version,
+            partition_definitions: partition_info
+                .partition_definitions
+                .into_iter()
+                .map(|v| v.into())
+                .collect(),
+            expr: Bytes::into(partition_info.expr),
+            linear: partition_info.linear,
+        }
+    }
+}
+
+impl From<ceresdbproto::cluster::KeyPartitionInfo> for KeyPartitionInfo {
+    fn from(partition_info_pb: ceresdbproto::cluster::KeyPartitionInfo) -> Self {
+        KeyPartitionInfo {
+            version: partition_info_pb.version,
+            partition_definitions: partition_info_pb
+                .partition_definitions
+                .into_iter()
+                .map(|v| v.into())
+                .collect(),
+            partition_key: partition_info_pb.partition_key,
+            linear: partition_info_pb.linear,
+        }
+    }
+}
+
+impl From<KeyPartitionInfo> for ceresdbproto::cluster::KeyPartitionInfo {
+    fn from(partition_info: KeyPartitionInfo) -> Self {
+        ceresdbproto::cluster::KeyPartitionInfo {
+            version: partition_info.version,
+            partition_definitions: partition_info
+                .partition_definitions
+                .into_iter()
+                .map(|v| v.into())
+                .collect(),
+            partition_key: partition_info.partition_key,
+            linear: partition_info.linear,
+        }
+    }
+}
+
+impl From<PartitionInfo> for ceresdbproto::cluster::PartitionInfo {
+    fn from(partition_info: PartitionInfo) -> Self {
+        match partition_info {
+            PartitionInfo::Hash(v) => {
+                let hash_partition_info = ceresdbproto::cluster::HashPartitionInfo::from(v);
+                ceresdbproto::cluster::PartitionInfo {
+                    partition_info_enum: Some(PartitionInfoEnum::Hash(hash_partition_info)),
+                }
+            }
+            PartitionInfo::Key(v) => {
+                let key_partition_info = ceresdbproto::cluster::KeyPartitionInfo::from(v);
+                ceresdbproto::cluster::PartitionInfo {
+                    partition_info_enum: Some(PartitionInfoEnum::Key(key_partition_info)),
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<ceresdbproto::cluster::PartitionInfo> for PartitionInfo {
+    type Error = Error;
+
+    fn try_from(
+        partition_info_pb: ceresdbproto::cluster::PartitionInfo,
     ) -> std::result::Result<Self, Self::Error> {
         match partition_info_pb.partition_info_enum {
             Some(partition_info_enum) => match partition_info_enum {
@@ -237,91 +367,4 @@ pub fn format_sub_partition_table_name(table_name: &str, partition_name: &str) -
         "{}{}_{}",
         PARTITION_TABLE_PREFIX, table_name, partition_name
     )
-}
-
-/// Encoder for partition info with version control.
-pub struct PartitionInfoEncoder {
-    version: u8,
-}
-
-impl Default for PartitionInfoEncoder {
-    fn default() -> Self {
-        Self::new(DEFAULT_PARTITION_INFO_ENCODING_VERSION)
-    }
-}
-
-impl PartitionInfoEncoder {
-    fn new(version: u8) -> Self {
-        Self { version }
-    }
-
-    pub fn encode(&self, partition_info: PartitionInfo) -> Result<Vec<u8>> {
-        let pb_partition_info = meta_pb::PartitionInfo::from(partition_info);
-        let mut buf = Vec::with_capacity(1 + pb_partition_info.encoded_len() as usize);
-        buf.push(self.version);
-
-        pb_partition_info
-            .encode(&mut buf)
-            .context(EncodePartitionInfoToPb)?;
-
-        Ok(buf)
-    }
-
-    pub fn decode(&self, buf: &[u8]) -> Result<Option<PartitionInfo>> {
-        if buf.is_empty() {
-            return Ok(None);
-        }
-
-        self.ensure_version(buf[0])?;
-
-        let pb_partition_info =
-            meta_pb::PartitionInfo::decode(&buf[1..]).context(DecodePartitionInfoToPb { buf })?;
-
-        Ok(Some(PartitionInfo::try_from(pb_partition_info)?))
-    }
-
-    fn ensure_version(&self, version: u8) -> Result<()> {
-        ensure!(
-            self.version == version,
-            InvalidPartitionInfoEncodingVersion { version }
-        );
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::partition::{
-        rule::key::DEFAULT_PARTITION_VERSION, KeyPartitionInfo, PartitionDefinition, PartitionInfo,
-        PartitionInfoEncoder,
-    };
-
-    #[test]
-    fn test_partition_info_encoder() {
-        let partition_info = PartitionInfo::Key(KeyPartitionInfo {
-            version: DEFAULT_PARTITION_VERSION,
-            partition_definitions: vec![
-                PartitionDefinition {
-                    name: "p0".to_string(),
-                    origin_name: Some("partition_0".to_string()),
-                },
-                PartitionDefinition {
-                    name: "p1".to_string(),
-                    origin_name: None,
-                },
-            ],
-            partition_key: vec!["col1".to_string(), "col2".to_string(), "col3".to_string()],
-            linear: false,
-        });
-        let partition_info_encoder = PartitionInfoEncoder::default();
-        let encode_partition_info = partition_info_encoder
-            .encode(partition_info.clone())
-            .unwrap();
-        let decode_partition_info = partition_info_encoder
-            .decode(&encode_partition_info)
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(decode_partition_info, partition_info);
-    }
 }

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -77,8 +77,8 @@ pub enum PartitionInfo {
 impl PartitionInfo {
     pub fn get_definitions(&self) -> Vec<PartitionDefinition> {
         match self {
-            Self::Hash(v) => v.partition_definitions.clone(),
-            Self::Key(v) => v.partition_definitions.clone(),
+            Self::Hash(v) => v.definitions.clone(),
+            Self::Key(v) => v.definitions.clone(),
         }
     }
 }
@@ -92,7 +92,7 @@ pub struct PartitionDefinition {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HashPartitionInfo {
     pub version: i32,
-    pub partition_definitions: Vec<PartitionDefinition>,
+    pub definitions: Vec<PartitionDefinition>,
     pub expr: Bytes,
     pub linear: bool,
 }
@@ -100,7 +100,7 @@ pub struct HashPartitionInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeyPartitionInfo {
     pub version: i32,
-    pub partition_definitions: Vec<PartitionDefinition>,
+    pub definitions: Vec<PartitionDefinition>,
     pub partition_key: Vec<String>,
     pub linear: bool,
 }
@@ -136,7 +136,7 @@ impl From<meta_pb::HashPartitionInfo> for HashPartitionInfo {
     fn from(partition_info_pb: meta_pb::HashPartitionInfo) -> Self {
         HashPartitionInfo {
             version: partition_info_pb.version,
-            partition_definitions: partition_info_pb
+            definitions: partition_info_pb
                 .partition_definitions
                 .into_iter()
                 .map(|v| v.into())
@@ -152,7 +152,7 @@ impl From<HashPartitionInfo> for meta_pb::HashPartitionInfo {
         meta_pb::HashPartitionInfo {
             version: partition_info.version,
             partition_definitions: partition_info
-                .partition_definitions
+                .definitions
                 .into_iter()
                 .map(|v| v.into())
                 .collect(),
@@ -166,7 +166,7 @@ impl From<meta_pb::KeyPartitionInfo> for KeyPartitionInfo {
     fn from(partition_info_pb: meta_pb::KeyPartitionInfo) -> Self {
         KeyPartitionInfo {
             version: partition_info_pb.version,
-            partition_definitions: partition_info_pb
+            definitions: partition_info_pb
                 .partition_definitions
                 .into_iter()
                 .map(|v| v.into())
@@ -182,7 +182,7 @@ impl From<KeyPartitionInfo> for meta_pb::KeyPartitionInfo {
         meta_pb::KeyPartitionInfo {
             version: partition_info.version,
             partition_definitions: partition_info
-                .partition_definitions
+                .definitions
                 .into_iter()
                 .map(|v| v.into())
                 .collect(),
@@ -265,8 +265,8 @@ impl From<ceresdbproto::cluster::HashPartitionInfo> for HashPartitionInfo {
     fn from(partition_info_pb: ceresdbproto::cluster::HashPartitionInfo) -> Self {
         HashPartitionInfo {
             version: partition_info_pb.version,
-            partition_definitions: partition_info_pb
-                .partition_definitions
+            definitions: partition_info_pb
+                .definitions
                 .into_iter()
                 .map(|v| v.into())
                 .collect(),
@@ -280,8 +280,8 @@ impl From<HashPartitionInfo> for ceresdbproto::cluster::HashPartitionInfo {
     fn from(partition_info: HashPartitionInfo) -> Self {
         ceresdbproto::cluster::HashPartitionInfo {
             version: partition_info.version,
-            partition_definitions: partition_info
-                .partition_definitions
+            definitions: partition_info
+                .definitions
                 .into_iter()
                 .map(|v| v.into())
                 .collect(),
@@ -295,8 +295,8 @@ impl From<ceresdbproto::cluster::KeyPartitionInfo> for KeyPartitionInfo {
     fn from(partition_info_pb: ceresdbproto::cluster::KeyPartitionInfo) -> Self {
         KeyPartitionInfo {
             version: partition_info_pb.version,
-            partition_definitions: partition_info_pb
-                .partition_definitions
+            definitions: partition_info_pb
+                .definitions
                 .into_iter()
                 .map(|v| v.into())
                 .collect(),
@@ -310,8 +310,8 @@ impl From<KeyPartitionInfo> for ceresdbproto::cluster::KeyPartitionInfo {
     fn from(partition_info: KeyPartitionInfo) -> Self {
         ceresdbproto::cluster::KeyPartitionInfo {
             version: partition_info.version,
-            partition_definitions: partition_info
-                .partition_definitions
+            definitions: partition_info
+                .definitions
                 .into_iter()
                 .map(|v| v.into())
                 .collect(),

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -4,12 +4,11 @@
 
 pub mod rule;
 
+use ceresdbproto::cluster::partition_info::Info;
 use common_types::bytes::Bytes;
-use prost::Message;
 use proto::{meta_update as meta_pb, meta_update::partition_info::PartitionInfoEnum};
-use snafu::{ensure, Backtrace, ResultExt, Snafu};
+use snafu::{Backtrace, Snafu};
 
-const DEFAULT_PARTITION_INFO_ENCODING_VERSION: u8 = 0;
 const PARTITION_TABLE_PREFIX: &str = "__";
 
 #[derive(Debug, Snafu)]
@@ -198,13 +197,13 @@ impl From<PartitionInfo> for meta_pb::PartitionInfo {
             PartitionInfo::Hash(v) => {
                 let hash_partition_info = meta_pb::HashPartitionInfo::from(v);
                 meta_pb::PartitionInfo {
-                    partition_info_enum: Some(PartitionInfoEnumProto::Hash(hash_partition_info)),
+                    partition_info_enum: Some(PartitionInfoEnum::Hash(hash_partition_info)),
                 }
             }
             PartitionInfo::Key(v) => {
                 let key_partition_info = meta_pb::KeyPartitionInfo::from(v);
                 meta_pb::PartitionInfo {
-                    partition_info_enum: Some(PartitionInfoEnumProto::Key(key_partition_info)),
+                    partition_info_enum: Some(PartitionInfoEnum::Key(key_partition_info)),
                 }
             }
         }
@@ -219,11 +218,11 @@ impl TryFrom<meta_pb::PartitionInfo> for PartitionInfo {
     ) -> std::result::Result<Self, Self::Error> {
         match partition_info_pb.partition_info_enum {
             Some(partition_info_enum) => match partition_info_enum {
-                PartitionInfoEnumProto::Hash(v) => {
+                PartitionInfoEnum::Hash(v) => {
                     let hash_partition_info = HashPartitionInfo::from(v);
                     Ok(Self::Hash(hash_partition_info))
                 }
-                PartitionInfoEnumProto::Key(v) => {
+                PartitionInfoEnum::Key(v) => {
                     let key_partition_info = KeyPartitionInfo::from(v);
                     Ok(Self::Key(key_partition_info))
                 }
@@ -327,13 +326,13 @@ impl From<PartitionInfo> for ceresdbproto::cluster::PartitionInfo {
             PartitionInfo::Hash(v) => {
                 let hash_partition_info = ceresdbproto::cluster::HashPartitionInfo::from(v);
                 ceresdbproto::cluster::PartitionInfo {
-                    partition_info_enum: Some(PartitionInfoEnum::Hash(hash_partition_info)),
+                    info: Some(Info::Hash(hash_partition_info)),
                 }
             }
             PartitionInfo::Key(v) => {
                 let key_partition_info = ceresdbproto::cluster::KeyPartitionInfo::from(v);
                 ceresdbproto::cluster::PartitionInfo {
-                    partition_info_enum: Some(PartitionInfoEnum::Key(key_partition_info)),
+                    info: Some(Info::Key(key_partition_info)),
                 }
             }
         }
@@ -346,13 +345,13 @@ impl TryFrom<ceresdbproto::cluster::PartitionInfo> for PartitionInfo {
     fn try_from(
         partition_info_pb: ceresdbproto::cluster::PartitionInfo,
     ) -> std::result::Result<Self, Self::Error> {
-        match partition_info_pb.partition_info_enum {
-            Some(partition_info_enum) => match partition_info_enum {
-                PartitionInfoEnum::Hash(v) => {
+        match partition_info_pb.info {
+            Some(info) => match info {
+                Info::Hash(v) => {
                     let hash_partition_info = HashPartitionInfo::from(v);
                     Ok(Self::Hash(hash_partition_info))
                 }
-                PartitionInfoEnum::Key(v) => {
+                Info::Key(v) => {
                     let key_partition_info = KeyPartitionInfo::from(v);
                     Ok(Self::Key(key_partition_info))
                 }

--- a/table_engine/src/partition/rule/df_adapter/mod.rs
+++ b/table_engine/src/partition/rule/df_adapter/mod.rs
@@ -94,7 +94,7 @@ mod tests {
         let valid_filters_2 = vec![filter1, filter2, filter3, filter4];
         let ket_partition = KeyPartitionInfo {
             version: DEFAULT_PARTITION_VERSION,
-            partition_definitions: vec![PartitionDefinition::default(); partition_num],
+            definitions: vec![PartitionDefinition::default(); partition_num],
             partition_key: vec!["col1".to_string(), "col2".to_string(), "col3".to_string()],
             linear: false,
         };
@@ -139,7 +139,7 @@ mod tests {
         let invalid_filters_2 = vec![filter1, filter2, filter4];
         let ket_partition = KeyPartitionInfo {
             version: DEFAULT_PARTITION_VERSION,
-            partition_definitions: vec![PartitionDefinition::default(); partition_num],
+            definitions: vec![PartitionDefinition::default(); partition_num],
             partition_key: vec!["col1".to_string(), "col2".to_string(), "col3".to_string()],
             linear: false,
         };
@@ -170,7 +170,7 @@ mod tests {
         let partition_num = 16;
         let ket_partition = KeyPartitionInfo {
             version: DEFAULT_PARTITION_VERSION,
-            partition_definitions: vec![PartitionDefinition::default(); partition_num],
+            definitions: vec![PartitionDefinition::default(); partition_num],
             partition_key: vec!["col1".to_string(), "col2".to_string(), "col3".to_string()],
             linear: false,
         };

--- a/table_engine/src/partition/rule/df_adapter/mod.rs
+++ b/table_engine/src/partition/rule/df_adapter/mod.rs
@@ -113,7 +113,7 @@ mod tests {
         ];
         let partition_key_refs = partition_keys.iter().collect::<Vec<_>>();
         let mut buf = BytesMut::new();
-        let expected = compute_partition(&partition_key_refs, partition_num as u64, &mut buf);
+        let expected = compute_partition(&partition_key_refs, partition_num, &mut buf);
 
         assert_eq!(partitions[0], expected);
 
@@ -233,8 +233,8 @@ mod tests {
         let partition_keys_2 = test_datums[1].clone();
         let partition_key_refs_2 = partition_keys_2.iter().collect::<Vec<_>>();
         let mut buf = BytesMut::new();
-        let expected_1 = compute_partition(&partition_key_refs_1, partition_num as u64, &mut buf);
-        let expected_2 = compute_partition(&partition_key_refs_2, partition_num as u64, &mut buf);
+        let expected_1 = compute_partition(&partition_key_refs_1, partition_num, &mut buf);
+        let expected_2 = compute_partition(&partition_key_refs_2, partition_num, &mut buf);
         let expecteds = vec![expected_1, expected_2];
 
         assert_eq!(partitions, expecteds);

--- a/table_engine/src/partition/rule/factory.rs
+++ b/table_engine/src/partition/rule/factory.rs
@@ -5,9 +5,11 @@
 use common_types::schema::Schema;
 use snafu::{ensure, OptionExt};
 
-use super::{key::KeyRule, ColumnWithType};
 use crate::partition::{
-    rule::{key::DEFAULT_PARTITION_VERSION, PartitionRuleRef},
+    rule::{
+        key::{KeyRule, DEFAULT_PARTITION_VERSION},
+        ColumnWithType, PartitionRuleRef,
+    },
     BuildPartitionRule, KeyPartitionInfo, PartitionInfo, Result,
 };
 
@@ -55,7 +57,7 @@ impl PartitionRuleFactory {
 
         Ok(Box::new(KeyRule {
             typed_key_columns,
-            partition_num: key_info.definitions.len() as u64,
+            partition_num: key_info.definitions.len(),
         }))
     }
 }

--- a/table_engine/src/partition/rule/factory.rs
+++ b/table_engine/src/partition/rule/factory.rs
@@ -55,7 +55,7 @@ impl PartitionRuleFactory {
 
         Ok(Box::new(KeyRule {
             typed_key_columns,
-            partition_num: key_info.partition_definitions.len() as u64,
+            partition_num: key_info.definitions.len() as u64,
         }))
     }
 }

--- a/table_engine/src/partition/rule/key.rs
+++ b/table_engine/src/partition/rule/key.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_PARTITION_VERSION: i32 = 0;
 
 pub struct KeyRule {
     pub typed_key_columns: Vec<ColumnWithType>,
-    pub partition_num: u64,
+    pub partition_num: usize,
 }
 
 impl KeyRule {
@@ -241,7 +241,7 @@ fn expand_partition_keys_group(
 // Compute partition
 pub(crate) fn compute_partition(
     partition_keys: &[&Datum],
-    partition_num: u64,
+    partition_num: usize,
     buf: &mut BytesMut,
 ) -> usize {
     buf.clear();
@@ -249,7 +249,7 @@ pub(crate) fn compute_partition(
         .iter()
         .for_each(|datum| buf.put_slice(&datum.to_bytes()));
 
-    (hash64(buf) % partition_num) as usize
+    (hash64(buf) % (partition_num as u64)) as usize
 }
 
 #[cfg(test)]
@@ -288,7 +288,7 @@ mod tests {
         buf.put_slice(&datums[2].to_bytes());
         buf.put_slice(&datums[3].to_bytes());
         buf.put_slice(&datums[4].to_bytes());
-        let expected = (hash64(&buf) % partition_num) as usize;
+        let expected = (hash64(&buf) % (partition_num as u64)) as usize;
 
         assert_eq!(actual, expected);
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #
Refer to #572 

# Rationale for this change
 In order to support the case where the partition table is opened by multiple machines in a non-cloud environment, store the partition info of PartitionTable in ceresmeta.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
* Pass partition info to ceresmeta.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Manual testing.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
