### PR TITLE
feat: detect sst header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,7 +4009,9 @@ version = "1.0.0-alpha02"
 dependencies = [
  "arrow",
  "arrow_ext 1.0.0-alpha02",
+ "async-trait",
  "bytes 1.2.1",
+ "common_util",
  "datafusion",
  "datafusion-expr",
  "log",

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -44,7 +44,7 @@ use crate::{
     space::SpaceAndTable,
     sst::{
         builder::RecordBatchStream,
-        factory::{self, ReadFrequency, SstBuilderOptions, SstReaderOptions},
+        factory::{self, ReadFrequency, SstBuildOptions, SstReadOptions},
         file::FileMeta,
         meta_data::{self, SstMetaData, SstMetaReader},
         parquet::meta_data::ParquetMetaData,
@@ -617,7 +617,7 @@ impl Instance {
         let mut sst_handlers = Vec::with_capacity(time_ranges.len());
         let mut file_ids = Vec::with_capacity(time_ranges.len());
 
-        let sst_builder_options = SstBuilderOptions {
+        let sst_builder_options = SstBuildOptions {
             storage_format_hint: table_data.table_options().storage_format_hint,
             num_rows_per_row_group: table_data.table_options().num_rows_per_row_group,
             compression: table_data.table_options().compression,
@@ -760,7 +760,7 @@ impl Instance {
         let sst_file_path = table_data.set_sst_file_path(file_id);
 
         let storage_format_hint = table_data.table_options().storage_format_hint;
-        let sst_builder_options = SstBuilderOptions {
+        let sst_builder_options = SstBuildOptions {
             storage_format_hint,
             num_rows_per_row_group: table_data.table_options().num_rows_per_row_group,
             compression: table_data.table_options().compression,
@@ -924,7 +924,7 @@ impl SpaceStore {
         let schema = table_data.schema();
         let table_options = table_data.table_options();
         let projected_schema = ProjectedSchema::no_projection(schema.clone());
-        let sst_reader_options = SstReaderOptions {
+        let sst_read_options = SstReadOptions {
             read_batch_row_num: table_options.num_rows_per_row_group,
             reverse: false,
             frequency: ReadFrequency::Once,
@@ -950,7 +950,7 @@ impl SpaceStore {
                 projected_schema,
                 predicate: Arc::new(Predicate::empty()),
                 sst_factory: &self.sst_factory,
-                sst_reader_options: sst_reader_options.clone(),
+                sst_read_options: sst_read_options.clone(),
                 store_picker: self.store_picker(),
                 merge_iter_options: iter_options.clone(),
                 need_dedup: table_options.need_dedup(),
@@ -979,7 +979,7 @@ impl SpaceStore {
                 space_id: table_data.space_id,
                 table_id: table_data.id,
                 factory: self.sst_factory.clone(),
-                read_opts: sst_reader_options,
+                read_opts: sst_read_options,
                 store_picker: self.store_picker.clone(),
             };
             let sst_metas = meta_reader
@@ -994,7 +994,7 @@ impl SpaceStore {
         let sst_file_path = table_data.set_sst_file_path(file_id);
 
         let storage_format_hint = table_data.table_options().storage_format_hint;
-        let sst_builder_options = SstBuilderOptions {
+        let sst_builder_options = SstBuildOptions {
             storage_format_hint,
             num_rows_per_row_group: table_options.num_rows_per_row_group,
             compression: table_options.compression,

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -656,6 +656,7 @@ impl Instance {
                         &sst_file_path,
                         store.store_picker(),
                     )
+                    .await
                     .context(InvalidSstStorageFormat {
                         storage_format_hint,
                     })?;
@@ -772,6 +773,7 @@ impl Instance {
                 &sst_file_path,
                 self.space_store.store_picker(),
             )
+            .await
             .context(InvalidSstStorageFormat {
                 storage_format_hint,
             })?;
@@ -1000,6 +1002,7 @@ impl SpaceStore {
         let mut sst_builder = self
             .sst_factory
             .new_sst_builder(&sst_builder_options, &sst_file_path, self.store_picker())
+            .await
             .context(InvalidSstStorageFormat {
                 storage_format_hint,
             })?;

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -34,7 +34,7 @@ use crate::{
         IterOptions, RecordBatchWithKeyIterator,
     },
     space::SpaceAndTable,
-    sst::factory::{ReadFrequency, SstReaderOptions},
+    sst::factory::{ReadFrequency, SstReadOptions},
     table::{
         data::TableData,
         version::{ReadView, TableVersion},
@@ -152,7 +152,7 @@ impl Instance {
         // Current visible sequence
         let sequence = table_data.last_sequence();
         let projected_schema = request.projected_schema.clone();
-        let sst_reader_options = SstReaderOptions {
+        let sst_read_options = SstReadOptions {
             read_batch_row_num: table_options.num_rows_per_row_group,
             reverse: request.order.is_in_desc_order(),
             frequency: ReadFrequency::Frequent,
@@ -179,7 +179,7 @@ impl Instance {
                 projected_schema: projected_schema.clone(),
                 predicate: request.predicate.clone(),
                 sst_factory: &self.space_store.sst_factory,
-                sst_reader_options: sst_reader_options.clone(),
+                sst_read_options: sst_read_options.clone(),
                 store_picker: self.space_store.store_picker(),
                 merge_iter_options: iter_options.clone(),
                 need_dedup: table_options.need_dedup(),
@@ -215,7 +215,7 @@ impl Instance {
 
         assert!(request.order.is_out_of_order());
 
-        let sst_reader_options = SstReaderOptions {
+        let sst_read_options = SstReadOptions {
             read_batch_row_num: table_options.num_rows_per_row_group,
             // no need to read in order so just read in asc order by default.
             reverse: false,
@@ -241,7 +241,7 @@ impl Instance {
                 table_id: table_data.id,
                 projected_schema: projected_schema.clone(),
                 predicate: request.predicate.clone(),
-                sst_reader_options: sst_reader_options.clone(),
+                sst_read_options: sst_read_options.clone(),
                 sst_factory: &self.space_store.sst_factory,
                 store_picker: self.space_store.store_picker(),
             };

--- a/analytic_engine/src/row_iter/chain.rs
+++ b/analytic_engine/src/row_iter/chain.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     space::SpaceId,
     sst::{
-        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReaderOptions},
+        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReadOptions},
         file::FileHandle,
     },
     table::version::{MemTableVec, SamplingMemTable},
@@ -58,7 +58,7 @@ pub struct ChainConfig<'a> {
     /// Predicate of the query.
     pub predicate: PredicateRef,
 
-    pub sst_reader_options: SstReaderOptions,
+    pub sst_read_options: SstReadOptions,
     /// Sst factory
     pub sst_factory: &'a SstFactoryRef,
     /// Store picker for persisting sst.
@@ -145,7 +145,7 @@ impl<'a> Builder<'a> {
                     self.config.table_id,
                     sst,
                     self.config.sst_factory,
-                    &self.config.sst_reader_options,
+                    &self.config.sst_read_options,
                     self.config.store_picker,
                 )
                 .await

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     space::SpaceId,
     sst::{
-        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReaderOptions},
+        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReadOptions},
         file::FileHandle,
         manager::{FileId, MAX_LEVEL},
     },
@@ -96,7 +96,7 @@ pub struct MergeConfig<'a> {
     /// The predicate of the query.
     pub predicate: PredicateRef,
 
-    pub sst_reader_options: SstReaderOptions,
+    pub sst_read_options: SstReadOptions,
     /// Sst factory
     pub sst_factory: &'a SstFactoryRef,
     /// Store picker for persisting sst.
@@ -210,7 +210,7 @@ impl<'a> MergeBuilder<'a> {
                     self.config.table_id,
                     f,
                     self.config.sst_factory,
-                    &self.config.sst_reader_options,
+                    &self.config.sst_read_options,
                     self.config.store_picker,
                 )
                 .await

--- a/analytic_engine/src/row_iter/record_batch_stream.rs
+++ b/analytic_engine/src/row_iter/record_batch_stream.rs
@@ -320,6 +320,7 @@ pub async fn stream_from_sst_file(
             sst_file.storage_format(),
             store_picker,
         )
+        .await
         .with_context(|| SstReaderNotFound {
             options: sst_reader_options.clone(),
         })?;

--- a/analytic_engine/src/sst/builder.rs
+++ b/analytic_engine/src/sst/builder.rs
@@ -66,13 +66,13 @@ pub struct SstInfo {
     pub storage_format: StorageFormat,
 }
 
-/// The builder for sst.
+/// The writer for sst.
 ///
-/// The caller provides a stream of [RecordBatch] and the builder takes
+/// The caller provides a stream of [RecordBatch] and the writer takes
 /// responsibilities for persisting the records.
 #[async_trait]
-pub trait SstBuilder {
-    async fn build(
+pub trait SstWriter {
+    async fn write(
         &mut self,
         request_id: RequestId,
         meta: &SstMetaData,

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -13,7 +13,7 @@ use table_engine::predicate::PredicateRef;
 
 use crate::{
     sst::{
-        builder::SstBuilder,
+        builder::SstWriter,
         header,
         header::HeaderParser,
         meta_data::cache::MetaCacheRef,
@@ -67,12 +67,12 @@ pub trait Factory: Send + Sync + Debug {
         store_picker: &'a ObjectStorePickerRef,
     ) -> Result<Box<dyn SstReader + Send + 'a>>;
 
-    async fn create_builder<'a>(
+    async fn create_writer<'a>(
         &self,
         options: &SstBuildOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
-    ) -> Result<Box<dyn SstBuilder + Send + 'a>>;
+    ) -> Result<Box<dyn SstWriter + Send + 'a>>;
 }
 
 /// The frequency of query execution may decide some behavior in the sst reader,
@@ -149,12 +149,12 @@ impl Factory for FactoryImpl {
         }
     }
 
-    async fn create_builder<'a>(
+    async fn create_writer<'a>(
         &self,
         options: &SstBuildOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
-    ) -> Result<Box<dyn SstBuilder + Send + 'a>> {
+    ) -> Result<Box<dyn SstWriter + Send + 'a>> {
         let hybrid_encoding = match options.storage_format_hint {
             StorageFormatHint::Specific(format) => matches!(format, StorageFormat::Hybrid),
             // `Auto` is mapped to columnar parquet format now, may change in future.

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -62,14 +62,14 @@ pub trait Factory: Send + Sync + Debug {
     async fn create_reader<'a>(
         &self,
         path: &'a Path,
-        options: &SstReaderOptions,
-        hint: SstReaderHint,
+        options: &SstReadOptions,
+        hint: SstReadHint,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Result<Box<dyn SstReader + Send + 'a>>;
 
     async fn create_builder<'a>(
         &self,
-        options: &SstBuilderOptions,
+        options: &SstBuildOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Result<Box<dyn SstBuilder + Send + 'a>>;
@@ -84,7 +84,7 @@ pub enum ReadFrequency {
 }
 
 #[derive(Clone, Copy, Debug, Default)]
-pub struct SstReaderHint {
+pub struct SstReadHint {
     /// Hint for the size of the sst file. It may avoid some io if provided.
     pub file_size: Option<usize>,
     /// Hint for the storage format of the sst file. It may avoid some io if
@@ -93,7 +93,7 @@ pub struct SstReaderHint {
 }
 
 #[derive(Debug, Clone)]
-pub struct SstReaderOptions {
+pub struct SstReadOptions {
     pub read_batch_row_num: usize,
     pub reverse: bool,
     pub frequency: ReadFrequency,
@@ -110,7 +110,7 @@ pub struct SstReaderOptions {
 }
 
 #[derive(Debug, Clone)]
-pub struct SstBuilderOptions {
+pub struct SstBuildOptions {
     pub storage_format_hint: StorageFormatHint,
     pub num_rows_per_row_group: usize,
     pub compression: Compression,
@@ -124,8 +124,8 @@ impl Factory for FactoryImpl {
     async fn create_reader<'a>(
         &self,
         path: &'a Path,
-        options: &SstReaderOptions,
-        hint: SstReaderHint,
+        options: &SstReadOptions,
+        hint: SstReadHint,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Result<Box<dyn SstReader + Send + 'a>> {
         let storage_format = match hint.file_format {
@@ -151,7 +151,7 @@ impl Factory for FactoryImpl {
 
     async fn create_builder<'a>(
         &self,
-        options: &SstBuilderOptions,
+        options: &SstBuildOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Result<Box<dyn SstBuilder + Send + 'a>> {

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -69,7 +69,7 @@ pub trait Factory: Send + Sync + Debug {
 
     async fn create_writer<'a>(
         &self,
-        options: &SstBuildOptions,
+        options: &SstWriteOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Result<Box<dyn SstWriter + Send + 'a>>;
@@ -110,7 +110,7 @@ pub struct SstReadOptions {
 }
 
 #[derive(Debug, Clone)]
-pub struct SstBuildOptions {
+pub struct SstWriteOptions {
     pub storage_format_hint: StorageFormatHint,
     pub num_rows_per_row_group: usize,
     pub compression: Compression,
@@ -151,7 +151,7 @@ impl Factory for FactoryImpl {
 
     async fn create_writer<'a>(
         &self,
-        options: &SstBuildOptions,
+        options: &SstWriteOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Result<Box<dyn SstWriter + Send + 'a>> {

--- a/analytic_engine/src/sst/header.rs
+++ b/analytic_engine/src/sst/header.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// The header parser for one sst.
+
+use bytes::Bytes;
+use common_util::define_result;
+use object_store::{ObjectStoreRef, Path};
+use parquet::data_type::AsBytes;
+use snafu::{Backtrace, ResultExt, Snafu};
+
+use crate::table_options::StorageFormat;
+
+/// Error of sst file.
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("Failed to read header bytes, err:{}", source,))]
+    ReadHeaderBytes {
+        source: object_store::ObjectStoreError,
+    },
+    #[snafu(display(
+        "Unknown header, header value:{:?}.\nBacktrace:\n{}",
+        header_value,
+        backtrace
+    ))]
+    UnknownHeader {
+        header_value: Bytes,
+        backtrace: Backtrace,
+    },
+}
+
+define_result!(Error);
+
+/// A parser for decoding the header of SST.
+///
+/// Assume that every SST shares the same encoding format:
+///
+/// +------------+----------------------+
+/// | 4B(header) |       Payload        |
+/// +------------+----------------------+
+pub struct HeaderParser<'a> {
+    path: &'a Path,
+    store: &'a ObjectStoreRef,
+}
+
+impl<'a> HeaderParser<'a> {
+    const HEADER_LEN: usize = 4;
+    const PARQUET: &'static [u8] = b"PAR1";
+
+    pub fn new(path: &'a Path, store: &'a ObjectStoreRef) -> HeaderParser<'a> {
+        Self { path, store }
+    }
+
+    pub async fn parse(&self) -> Result<StorageFormat> {
+        let header_value = self
+            .store
+            .get_range(self.path, 0..Self::HEADER_LEN)
+            .await
+            .context(ReadHeaderBytes)?;
+
+        match header_value.as_bytes() {
+            Self::PARQUET => Ok(StorageFormat::Columnar),
+            _ => UnknownHeader { header_value }.fail(),
+        }
+    }
+}

--- a/analytic_engine/src/sst/header.rs
+++ b/analytic_engine/src/sst/header.rs
@@ -16,6 +16,7 @@ pub enum Error {
     ReadHeaderBytes {
         source: object_store::ObjectStoreError,
     },
+
     #[snafu(display(
         "Unknown header, header value:{:?}.\nBacktrace:\n{}",
         header_value,
@@ -49,6 +50,7 @@ impl<'a> HeaderParser<'a> {
         Self { path, store }
     }
 
+    /// Detect the storage format by parsing header of the sst.
     pub async fn parse(&self) -> Result<StorageFormat> {
         let header_value = self
             .store

--- a/analytic_engine/src/sst/header.rs
+++ b/analytic_engine/src/sst/header.rs
@@ -10,7 +10,6 @@ use snafu::{Backtrace, ResultExt, Snafu};
 
 use crate::table_options::StorageFormat;
 
-/// Error of sst file.
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("Failed to read header bytes, err:{}", source,))]

--- a/analytic_engine/src/sst/meta_data/mod.rs
+++ b/analytic_engine/src/sst/meta_data/mod.rs
@@ -141,6 +141,7 @@ impl SstMetaReader {
                     f.storage_format(),
                     &self.store_picker,
                 )
+                .await
                 .context(BuildSstReader)?;
             let meta_data = reader.meta_data().await.context(ReadMetaData)?;
             sst_metas.push(meta_data.clone());

--- a/analytic_engine/src/sst/meta_data/mod.rs
+++ b/analytic_engine/src/sst/meta_data/mod.rs
@@ -10,12 +10,12 @@ use proto::sst as sst_pb;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::table::TableId;
 
-use super::factory::SstReaderHint;
+use super::factory::SstReadHint;
 use crate::{
     space::SpaceId,
     sst::{
         factory,
-        factory::{FactoryRef, ObjectStorePickerRef, SstReaderOptions},
+        factory::{FactoryRef, ObjectStorePickerRef, SstReadOptions},
         file::FileHandle,
         parquet::{
             self, encoding,
@@ -125,7 +125,7 @@ pub struct SstMetaReader {
     pub space_id: SpaceId,
     pub table_id: TableId,
     pub factory: FactoryRef,
-    pub read_opts: SstReaderOptions,
+    pub read_opts: SstReadOptions,
     pub store_picker: ObjectStorePickerRef,
 }
 
@@ -135,7 +135,7 @@ impl SstMetaReader {
         let mut sst_metas = Vec::with_capacity(files.len());
         for f in files {
             let path = sst_util::new_sst_file_path(self.space_id, self.table_id, f.id());
-            let read_hint = SstReaderHint {
+            let read_hint = SstReadHint {
                 file_size: Some(f.size() as usize),
                 file_format: Some(f.storage_format()),
             };

--- a/analytic_engine/src/sst/mod.rs
+++ b/analytic_engine/src/sst/mod.rs
@@ -5,6 +5,7 @@
 pub mod builder;
 pub mod factory;
 pub mod file;
+pub mod header;
 pub mod manager;
 pub mod meta_data;
 pub mod metrics;

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -57,7 +57,7 @@ pub struct Reader<'a> {
     path: &'a Path,
     /// The storage where the data is persist.
     store: &'a ObjectStoreRef,
-    /// The hint for the sst file size. One io will be avoided if provided.
+    /// The hint for the sst file size.
     file_size_hint: Option<usize>,
     projected_schema: ProjectedSchema,
     meta_cache: Option<MetaCacheRef>,

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -36,7 +36,7 @@ use table_engine::predicate::PredicateRef;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 use crate::sst::{
-    factory::{ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
+    factory::{ObjectStorePickerRef, ReadFrequency, SstReadOptions},
     meta_data::{
         cache::{MetaCacheRef, MetaData},
         SstMetaData,
@@ -77,7 +77,7 @@ pub struct Reader<'a> {
 impl<'a> Reader<'a> {
     pub fn new(
         path: &'a Path,
-        options: &SstReaderOptions,
+        options: &SstReadOptions,
         file_size_hint: Option<usize>,
         store_picker: &'a ObjectStorePickerRef,
     ) -> Self {

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -362,7 +362,7 @@ mod tests {
             }));
 
             let mut builder = sst_factory
-                .new_sst_builder(&sst_builder_options, &sst_file_path, &store_picker)
+                .create_builder(&sst_builder_options, &sst_file_path, &store_picker)
                 .await
                 .unwrap();
             let sst_info = builder

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -22,7 +22,7 @@ use crate::{
             self, EncodeRecordBatch, OtherNoCause, PollRecordBatch, RecordBatchStream, Result,
             SstInfo, SstWriter, Storage,
         },
-        factory::{ObjectStorePickerRef, SstBuildOptions},
+        factory::{ObjectStorePickerRef, SstWriteOptions},
         meta_data::SstMetaData,
         parquet::{
             encoding::ParquetEncoder,
@@ -50,7 +50,7 @@ impl<'a> ParquetSstBuilder<'a> {
         path: &'a Path,
         hybrid_encoding: bool,
         store_picker: &'a ObjectStorePickerRef,
-        options: &SstBuildOptions,
+        options: &SstWriteOptions,
     ) -> Self {
         let store = store_picker.default_store();
         Self {
@@ -289,7 +289,7 @@ mod tests {
     use crate::{
         row_iter::tests::build_record_batch_with_key,
         sst::{
-            factory::{Factory, FactoryImpl, ReadFrequency, SstBuildOptions, SstReadOptions},
+            factory::{Factory, FactoryImpl, ReadFrequency, SstReadOptions, SstWriteOptions},
             parquet::AsyncParquetReader,
             reader::{tests::check_stream, SstReader},
         },
@@ -315,7 +315,7 @@ mod tests {
     ) {
         runtime.block_on(async {
             let sst_factory = FactoryImpl;
-            let sst_builder_options = SstBuildOptions {
+            let sst_write_options = SstWriteOptions {
                 storage_format_hint: StorageFormatHint::Auto,
                 num_rows_per_row_group,
                 compression: table_options::Compression::Uncompressed,
@@ -362,7 +362,7 @@ mod tests {
             }));
 
             let mut writer = sst_factory
-                .create_writer(&sst_builder_options, &sst_file_path, &store_picker)
+                .create_writer(&sst_write_options, &sst_file_path, &store_picker)
                 .await
                 .unwrap();
             let sst_info = writer

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -363,6 +363,7 @@ mod tests {
 
             let mut builder = sst_factory
                 .new_sst_builder(&sst_builder_options, &sst_file_path, &store_picker)
+                .await
                 .unwrap();
             let sst_info = builder
                 .build(RequestId::next_id(), &sst_meta, record_batch_stream)
@@ -385,12 +386,8 @@ mod tests {
             };
 
             let mut reader: Box<dyn SstReader + Send> = {
-                let mut reader = AsyncParquetReader::new(
-                    &sst_file_path,
-                    false,
-                    &store_picker,
-                    &sst_reader_options,
-                );
+                let mut reader =
+                    AsyncParquetReader::new(&sst_file_path, &store_picker, &sst_reader_options);
                 let mut sst_meta_readback = reader
                     .meta_data()
                     .await

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -386,8 +386,12 @@ mod tests {
             };
 
             let mut reader: Box<dyn SstReader + Send> = {
-                let mut reader =
-                    AsyncParquetReader::new(&sst_file_path, &store_picker, &sst_reader_options);
+                let mut reader = AsyncParquetReader::new(
+                    &sst_file_path,
+                    &sst_reader_options,
+                    None,
+                    &store_picker,
+                );
                 let mut sst_meta_readback = reader
                     .meta_data()
                     .await

--- a/analytic_engine/src/sst/parquet/builder.rs
+++ b/analytic_engine/src/sst/parquet/builder.rs
@@ -20,7 +20,7 @@ use crate::{
     sst::{
         builder::{
             self, EncodeRecordBatch, OtherNoCause, PollRecordBatch, RecordBatchStream, Result,
-            SstBuilder, SstInfo, Storage,
+            SstInfo, SstWriter, Storage,
         },
         factory::{ObjectStorePickerRef, SstBuildOptions},
         meta_data::SstMetaData,
@@ -218,8 +218,8 @@ impl RecordBytesReader {
 }
 
 #[async_trait]
-impl<'a> SstBuilder for ParquetSstBuilder<'a> {
-    async fn build(
+impl<'a> SstWriter for ParquetSstBuilder<'a> {
+    async fn write(
         &mut self,
         request_id: RequestId,
         meta: &SstMetaData,
@@ -361,12 +361,12 @@ mod tests {
                 Poll::Ready(Some(Ok(batch)))
             }));
 
-            let mut builder = sst_factory
-                .create_builder(&sst_builder_options, &sst_file_path, &store_picker)
+            let mut writer = sst_factory
+                .create_writer(&sst_builder_options, &sst_file_path, &store_picker)
                 .await
                 .unwrap();
-            let sst_info = builder
-                .build(RequestId::next_id(), &sst_meta, record_batch_stream)
+            let sst_info = writer
+                .write(RequestId::next_id(), &sst_meta, record_batch_stream)
                 .await
                 .unwrap();
 

--- a/analytic_engine/src/sst/parquet/encoding.rs
+++ b/analytic_engine/src/sst/parquet/encoding.rs
@@ -673,13 +673,13 @@ pub struct ParquetDecoder {
 }
 
 impl ParquetDecoder {
-    pub fn new(hybrid_encoding: bool, collapsible_cols_idx: &[u32]) -> Self {
-        let record_decoder: Box<dyn RecordDecoder> = if hybrid_encoding {
+    pub fn new(collapsible_cols_idx: &[u32]) -> Self {
+        let record_decoder: Box<dyn RecordDecoder> = if collapsible_cols_idx.is_empty() {
+            Box::new(ColumnarRecordDecoder {})
+        } else {
             Box::new(HybridRecordDecoder {
                 collapsible_cols_idx: collapsible_cols_idx.to_vec(),
             })
-        } else {
-            Box::new(ColumnarRecordDecoder {})
         };
 
         Self { record_decoder }

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -18,7 +18,7 @@ use analytic_engine::{
     sst::{
         factory::{
             FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
-            SstReaderOptions,
+            SstReadOptions,
         },
         meta_data::cache::MetaCacheRef,
     },
@@ -48,7 +48,7 @@ pub struct MergeMemTableBench {
     space_id: SpaceId,
     table_id: TableId,
     dedup: bool,
-    sst_reader_options: SstReaderOptions,
+    sst_read_options: SstReadOptions,
 }
 
 impl MergeMemTableBench {
@@ -100,7 +100,7 @@ impl MergeMemTableBench {
                 id: *id,
             });
         }
-        let sst_reader_options = mock_sst_reader_options(projected_schema.clone(), runtime.clone());
+        let sst_read_options = mock_sst_read_options(projected_schema.clone(), runtime.clone());
 
         MergeMemTableBench {
             store,
@@ -112,7 +112,7 @@ impl MergeMemTableBench {
             space_id,
             table_id,
             dedup: true,
-            sst_reader_options,
+            sst_read_options,
         }
     }
 
@@ -149,7 +149,7 @@ impl MergeMemTableBench {
             projected_schema,
             predicate: Arc::new(Predicate::empty()),
             sst_factory: &sst_factory,
-            sst_reader_options: self.sst_reader_options.clone(),
+            sst_read_options: self.sst_read_options.clone(),
             store_picker: &store_picker,
             merge_iter_options: iter_options.clone(),
             need_dedup: true,
@@ -190,11 +190,11 @@ impl MergeMemTableBench {
     }
 }
 
-fn mock_sst_reader_options(
+fn mock_sst_read_options(
     projected_schema: ProjectedSchema,
     runtime: Arc<Runtime>,
-) -> SstReaderOptions {
-    SstReaderOptions {
+) -> SstReadOptions {
+    SstReadOptions {
         read_batch_row_num: 500,
         reverse: false,
         frequency: ReadFrequency::Frequent,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -16,7 +16,7 @@ use analytic_engine::{
     sst::{
         factory::{
             FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
-            SstReaderOptions,
+            SstReadOptions,
         },
         file::{FileHandle, FilePurgeQueue, Request},
         meta_data::cache::MetaCacheRef,
@@ -36,7 +36,7 @@ pub struct MergeSstBench {
     store: ObjectStoreRef,
     max_projections: usize,
     schema: Schema,
-    sst_reader_options: SstReaderOptions,
+    sst_read_options: SstReadOptions,
     runtime: Arc<Runtime>,
     space_id: SpaceId,
     table_id: TableId,
@@ -61,7 +61,7 @@ impl MergeSstBench {
 
         let predicate = config.predicate.into_predicate();
         let projected_schema = ProjectedSchema::no_projection(schema.clone());
-        let sst_reader_options = SstReaderOptions {
+        let sst_read_options = SstReadOptions {
             read_batch_row_num: config.read_batch_row_num,
             reverse: false,
             frequency: ReadFrequency::Frequent,
@@ -90,7 +90,7 @@ impl MergeSstBench {
             store,
             max_projections,
             schema,
-            sst_reader_options,
+            sst_read_options,
             runtime,
             space_id,
             table_id,
@@ -109,7 +109,7 @@ impl MergeSstBench {
         let projected_schema =
             util::projected_schema_by_number(&self.schema, i, self.max_projections);
 
-        self.sst_reader_options.projected_schema = projected_schema;
+        self.sst_read_options.projected_schema = projected_schema;
         self.dedup = dedup;
     }
 
@@ -118,7 +118,7 @@ impl MergeSstBench {
         let table_id = self.table_id;
         let sequence = u64::MAX;
         let iter_options = IterOptions::default();
-        let projected_schema = self.sst_reader_options.projected_schema.clone();
+        let projected_schema = self.sst_read_options.projected_schema.clone();
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
 
         let request_id = RequestId::next_id();
@@ -132,7 +132,7 @@ impl MergeSstBench {
             projected_schema,
             predicate: Arc::new(Predicate::empty()),
             sst_factory: &sst_factory,
-            sst_reader_options: self.sst_reader_options.clone(),
+            sst_read_options: self.sst_read_options.clone(),
             store_picker: &store_picker,
             merge_iter_options: iter_options.clone(),
             need_dedup: true,
@@ -169,7 +169,7 @@ impl MergeSstBench {
     fn run_no_dedup_bench(&self) {
         let space_id = self.space_id;
         let table_id = self.table_id;
-        let projected_schema = self.sst_reader_options.projected_schema.clone();
+        let projected_schema = self.sst_read_options.projected_schema.clone();
         let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
 
         let request_id = RequestId::next_id();
@@ -182,7 +182,7 @@ impl MergeSstBench {
             projected_schema,
             predicate: Arc::new(Predicate::empty()),
             sst_factory: &sst_factory,
-            sst_reader_options: self.sst_reader_options.clone(),
+            sst_read_options: self.sst_read_options.clone(),
             store_picker: &store_picker,
         })
         .ssts(vec![self.file_handles.clone()]);

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -4,12 +4,11 @@
 
 use std::{cmp, sync::Arc, time::Instant};
 
-use analytic_engine::{
-    sst::{
-        factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
-        meta_data::cache::{MetaCache, MetaCacheRef},
+use analytic_engine::sst::{
+    factory::{
+        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderHint, SstReaderOptions,
     },
-    table_options::StorageFormat,
+    meta_data::cache::{MetaCache, MetaCacheRef},
 };
 use common_types::{projected_schema::ProjectedSchema, schema::Schema};
 use common_util::runtime::Runtime;
@@ -84,9 +83,9 @@ impl SstBench {
         self.runtime.block_on(async {
             let mut sst_reader = sst_factory
                 .create_reader(
-                    &self.sst_reader_options,
                     &sst_path,
-                    StorageFormat::Columnar,
+                    &self.sst_reader_options,
+                    SstReaderHint::default(),
                     &store_picker,
                 )
                 .await

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -89,6 +89,7 @@ impl SstBench {
                     StorageFormat::Columnar,
                     &store_picker,
                 )
+                .await
                 .unwrap();
             let begin_instant = Instant::now();
             let mut sst_stream = sst_reader.read().await.unwrap();

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -83,7 +83,7 @@ impl SstBench {
 
         self.runtime.block_on(async {
             let mut sst_reader = sst_factory
-                .new_sst_reader(
+                .create_reader(
                     &self.sst_reader_options,
                     &sst_path,
                     StorageFormat::Columnar,

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -16,7 +16,7 @@ use analytic_engine::{
         builder::RecordBatchStream,
         factory::{
             Factory, FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
-            SstBuildOptions, SstReadHint, SstReadOptions,
+            SstReadHint, SstReadOptions, SstWriteOptions,
         },
         file::FilePurgeQueue,
         manager::FileId,
@@ -47,15 +47,15 @@ struct SstConfig {
 
 async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBatchStream) {
     let sst_factory = FactoryImpl;
-    let sst_builder_options = SstBuildOptions {
+    let sst_write_options = SstWriteOptions {
         storage_format_hint: StorageFormatHint::Auto,
         num_rows_per_row_group: config.num_rows_per_row_group,
         compression: config.compression,
     };
 
     info!(
-        "create sst from stream, config:{:?}, sst_builder_options:{:?}",
-        config, sst_builder_options
+        "create sst from stream, config:{:?}, sst_write_options:{:?}",
+        config, sst_write_options
     );
 
     let store: ObjectStoreRef =
@@ -64,7 +64,7 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
     let sst_file_path = Path::from(config.sst_file_name);
 
     let mut writer = sst_factory
-        .create_writer(&sst_builder_options, &sst_file_path, &store_picker)
+        .create_writer(&sst_write_options, &sst_file_path, &store_picker)
         .await
         .unwrap();
     writer

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -63,12 +63,12 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
     let store_picker: ObjectStorePickerRef = Arc::new(store);
     let sst_file_path = Path::from(config.sst_file_name);
 
-    let mut builder = sst_factory
-        .create_builder(&sst_builder_options, &sst_file_path, &store_picker)
+    let mut writer = sst_factory
+        .create_writer(&sst_builder_options, &sst_file_path, &store_picker)
         .await
         .unwrap();
-    builder
-        .build(RequestId::next_id(), &config.sst_meta, record_batch_stream)
+    writer
+        .write(RequestId::next_id(), &config.sst_meta, record_batch_stream)
         .await
         .unwrap();
 }

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -65,6 +65,7 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
 
     let mut builder = sst_factory
         .new_sst_builder(&sst_builder_options, &sst_file_path, &store_picker)
+        .await
         .unwrap();
     builder
         .build(RequestId::next_id(), &config.sst_meta, record_batch_stream)
@@ -137,6 +138,7 @@ async fn sst_to_record_batch_stream(
             StorageFormat::Columnar,
             &store_picker,
         )
+        .await
         .unwrap();
 
     let sst_stream = sst_reader.read().await.unwrap();

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -16,14 +16,14 @@ use analytic_engine::{
         builder::RecordBatchStream,
         factory::{
             Factory, FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
-            SstBuilderOptions, SstReaderOptions,
+            SstBuilderOptions, SstReaderHint, SstReaderOptions,
         },
         file::FilePurgeQueue,
         manager::FileId,
         meta_data::{self, SstMetaData, SstMetaReader},
     },
     table::sst_util,
-    table_options::{Compression, StorageFormat, StorageFormatHint},
+    table_options::{Compression, StorageFormatHint},
 };
 use common_types::{projected_schema::ProjectedSchema, request_id::RequestId};
 use common_util::runtime::Runtime;
@@ -132,10 +132,9 @@ async fn sst_to_record_batch_stream(
     let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
     let mut sst_reader = sst_factory
         .create_reader(
-            sst_reader_options,
             input_path,
-            // FIXME: this storage format should be detected from the file itself.
-            StorageFormat::Columnar,
+            sst_reader_options,
+            SstReaderHint::default(),
             &store_picker,
         )
         .await

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -64,7 +64,7 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
     let sst_file_path = Path::from(config.sst_file_name);
 
     let mut builder = sst_factory
-        .new_sst_builder(&sst_builder_options, &sst_file_path, &store_picker)
+        .create_builder(&sst_builder_options, &sst_file_path, &store_picker)
         .await
         .unwrap();
     builder
@@ -131,7 +131,7 @@ async fn sst_to_record_batch_stream(
     let sst_factory = FactoryImpl;
     let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
     let mut sst_reader = sst_factory
-        .new_sst_reader(
+        .create_reader(
             sst_reader_options,
             input_path,
             // FIXME: this storage format should be detected from the file itself.

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -112,7 +112,7 @@ pub async fn load_sst_to_memtable(
     let sst_factory = FactoryImpl;
     let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
     let mut sst_reader = sst_factory
-        .new_sst_reader(
+        .create_reader(
             &sst_reader_options,
             sst_path,
             StorageFormat::Columnar,

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -8,7 +8,10 @@ use analytic_engine::{
     memtable::{key::KeySequence, MemTableRef, PutContext},
     space::SpaceId,
     sst::{
-        factory::{Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderOptions},
+        factory::{
+            Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderHint,
+            SstReaderOptions,
+        },
         file::{FileHandle, FileMeta, FilePurgeQueue},
         manager::FileId,
         meta_data::{cache::MetaCacheRef, SstMetaData},
@@ -113,9 +116,9 @@ pub async fn load_sst_to_memtable(
     let store_picker: ObjectStorePickerRef = Arc::new(store.clone());
     let mut sst_reader = sst_factory
         .create_reader(
-            &sst_reader_options,
             sst_path,
-            StorageFormat::Columnar,
+            &sst_reader_options,
+            SstReaderHint::default(),
             &store_picker,
         )
         .await

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -9,8 +9,7 @@ use analytic_engine::{
     space::SpaceId,
     sst::{
         factory::{
-            Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReaderHint,
-            SstReaderOptions,
+            Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReadHint, SstReadOptions,
         },
         file::{FileHandle, FileMeta, FilePurgeQueue},
         manager::FileId,
@@ -101,7 +100,7 @@ pub async fn load_sst_to_memtable(
     memtable: &MemTableRef,
     runtime: Arc<Runtime>,
 ) {
-    let sst_reader_options = SstReaderOptions {
+    let sst_read_options = SstReadOptions {
         read_batch_row_num: 500,
         reverse: false,
         frequency: ReadFrequency::Frequent,
@@ -117,8 +116,8 @@ pub async fn load_sst_to_memtable(
     let mut sst_reader = sst_factory
         .create_reader(
             sst_path,
-            &sst_reader_options,
-            SstReaderHint::default(),
+            &sst_read_options,
+            SstReadHint::default(),
             &store_picker,
         )
         .await

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -118,6 +118,7 @@ pub async fn load_sst_to_memtable(
             StorageFormat::Columnar,
             &store_picker,
         )
+        .await
         .unwrap();
 
     let mut sst_stream = sst_reader.read().await.unwrap();

--- a/components/parquet_ext/Cargo.toml
+++ b/components/parquet_ext/Cargo.toml
@@ -13,7 +13,9 @@ workspace = true
 [dependencies]
 arrow = { workspace = true }
 arrow_ext = { workspace = true }
+async-trait = { workspace = true }
 bytes = { workspace = true }
+common_util = { workspace = true }
 datafusion = { workspace = true }
 datafusion-expr = { workspace = true }
 log = { workspace = true }

--- a/components/parquet_ext/src/lib.rs
+++ b/components/parquet_ext/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+pub mod meta_data;
 pub mod prune;
 pub mod reverse_reader;
 #[cfg(test)]

--- a/components/parquet_ext/src/meta_data.rs
+++ b/components/parquet_ext/src/meta_data.rs
@@ -1,0 +1,67 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::ops::Range;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use common_util::error::GenericResult;
+use parquet::{
+    errors::{ParquetError, Result},
+    file::{footer, metadata::ParquetMetaData},
+};
+
+#[async_trait]
+pub trait ChunkReader: Sync + Send {
+    async fn get_bytes(&self, range: Range<usize>) -> GenericResult<Bytes>;
+}
+
+/// Fetch and parse [`ParquetMetadata`] from the file reader.
+///
+/// Referring to: https://github.com/apache/arrow-datafusion/blob/ac2e5d15e5452e83c835d793a95335e87bf35569/datafusion/core/src/datasource/file_format/parquet.rs#L390-L449
+pub async fn fetch_parquet_metadata(
+    file_size: usize,
+    file_reader: &dyn ChunkReader,
+) -> Result<ParquetMetaData> {
+    const FOOTER_LEN: usize = 8;
+
+    if file_size < FOOTER_LEN {
+        let err_msg = format!("file size of {} is less than footer", file_size);
+        return Err(ParquetError::General(err_msg));
+    }
+
+    let footer_start = file_size - FOOTER_LEN;
+
+    let footer_bytes = file_reader
+        .get_bytes(footer_start..file_size)
+        .await
+        .map_err(|e| {
+            let err_msg = format!("failed to get footer bytes, err:{}", e);
+            ParquetError::General(err_msg)
+        })?;
+
+    assert_eq!(footer_bytes.len(), FOOTER_LEN);
+    let mut footer = [0; FOOTER_LEN];
+    footer.copy_from_slice(&footer_bytes);
+
+    let metadata_len = footer::decode_footer(&footer)?;
+
+    if file_size < metadata_len + FOOTER_LEN {
+        let err_msg = format!(
+            "file size of {} is smaller than footer + metadata {}",
+            file_size,
+            metadata_len + FOOTER_LEN
+        );
+        return Err(ParquetError::General(err_msg));
+    }
+
+    let metadata_start = file_size - metadata_len - FOOTER_LEN;
+    let metadata_bytes = file_reader
+        .get_bytes(metadata_start..footer_start)
+        .await
+        .map_err(|e| {
+            let err_msg = format!("failed to get metadata bytes, err:{}", e);
+            ParquetError::General(err_msg)
+        })?;
+
+    footer::decode_metadata(&metadata_bytes)
+}

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -93,7 +93,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let input_format = StorageFormat::try_from(args.input_format.as_str())
         .with_context(|| format!("invalid input storage format:{}", args.input_format))?;
     let mut reader = factory
-        .new_sst_reader(&reader_opts, &input_path, input_format, &store_picker)
+        .create_reader(&reader_opts, &input_path, input_format, &store_picker)
         .await
         .expect("no sst reader found");
 
@@ -107,7 +107,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     };
     let output = Path::from(args.output);
     let mut builder = factory
-        .new_sst_builder(&builder_opts, &output, &store_picker)
+        .create_builder(&builder_opts, &output, &store_picker)
         .await
         .expect("no sst builder found");
     let sst_stream = reader

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -6,8 +6,8 @@ use std::{error::Error, sync::Arc};
 
 use analytic_engine::{
     sst::factory::{
-        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstBuilderOptions,
-        SstReaderHint, SstReaderOptions,
+        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstBuildOptions, SstReadHint,
+        SstReadOptions,
     },
     table_options::{Compression, StorageFormatHint},
 };
@@ -74,7 +74,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let input_path = Path::from(args.input);
     let sst_meta = sst_util::meta_from_sst(&store, &input_path).await;
     let factory = FactoryImpl;
-    let reader_opts = SstReaderOptions {
+    let reader_opts = SstReadOptions {
         read_batch_row_num: 8192,
         reverse: false,
         frequency: ReadFrequency::Once,
@@ -90,7 +90,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         .create_reader(
             &input_path,
             &reader_opts,
-            SstReaderHint::default(),
+            SstReadHint::default(),
             &store_picker,
         )
         .await
@@ -98,7 +98,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
 
     let output_format_hint = StorageFormatHint::try_from(args.output_format.as_str())
         .with_context(|| format!("invalid storage format:{}", args.output_format))?;
-    let builder_opts = SstBuilderOptions {
+    let builder_opts = SstBuildOptions {
         storage_format_hint: output_format_hint,
         num_rows_per_row_group: args.batch_size,
         compression: Compression::parse_from(&args.compression)

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -105,8 +105,8 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
             .with_context(|| format!("invalid compression:{}", args.compression))?,
     };
     let output = Path::from(args.output);
-    let mut builder = factory
-        .create_builder(&builder_opts, &output, &store_picker)
+    let mut writer = factory
+        .create_writer(&builder_opts, &output, &store_picker)
         .await
         .expect("no sst builder found");
     let sst_stream = reader
@@ -115,8 +115,8 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         .unwrap()
         .map(|batch| batch.map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>));
     let sst_stream = Box::new(sst_stream) as _;
-    let sst_info = builder
-        .build(RequestId::next_id(), &sst_meta, sst_stream)
+    let sst_info = writer
+        .write(RequestId::next_id(), &sst_meta, sst_stream)
         .await?;
 
     println!("Write success, info:{:?}", sst_info);

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -6,8 +6,8 @@ use std::{error::Error, sync::Arc};
 
 use analytic_engine::{
     sst::factory::{
-        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstBuildOptions, SstReadHint,
-        SstReadOptions,
+        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReadHint, SstReadOptions,
+        SstWriteOptions,
     },
     table_options::{Compression, StorageFormatHint},
 };
@@ -98,7 +98,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
 
     let output_format_hint = StorageFormatHint::try_from(args.output_format.as_str())
         .with_context(|| format!("invalid storage format:{}", args.output_format))?;
-    let builder_opts = SstBuildOptions {
+    let builder_opts = SstWriteOptions {
         storage_format_hint: output_format_hint,
         num_rows_per_row_group: args.batch_size,
         compression: Compression::parse_from(&args.compression)

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -94,6 +94,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         .with_context(|| format!("invalid input storage format:{}", args.input_format))?;
     let mut reader = factory
         .new_sst_reader(&reader_opts, &input_path, input_format, &store_picker)
+        .await
         .expect("no sst reader found");
 
     let output_format_hint = StorageFormatHint::try_from(args.output_format.as_str())
@@ -107,6 +108,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let output = Path::from(args.output);
     let mut builder = factory
         .new_sst_builder(&builder_opts, &output, &store_picker)
+        .await
         .expect("no sst builder found");
     let sst_stream = reader
         .read()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #495

# Rationale for this change
 In order to introduce our custom storage format, we choose to put the 4B header into the sst file, which is uniform with the parquet file format.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add `SstReadHint` to avoid some other extra io;
- Add `HeaderParser` for supporting detect file format;
- According to the header, decide which reader to use.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
