### PR TITLE
feat: implement prom remote storage api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,8 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "prom-remote-api"
-version = "0.1.0"
-source = "git+https://github.com/jiacai2050/prom-remote-api#1532c2ad46a8f0abd9d8c7c71a46f45be886e341"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b375194cde05179f99e00565a6434293408ddeee4df8547d8aeb40ab831d664"
 dependencies = [
  "async-trait",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4266,8 +4266,7 @@ dependencies = [
 [[package]]
 name = "prom-remote-api"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5015def9ab9bfb1e61c9f86b93de221ec0cfe29cc2e0cb880b4f80e1682e004f"
+source = "git+https://github.com/jiacai2050/prom-remote-api#1532c2ad46a8f0abd9d8c7c71a46f45be886e341"
 dependencies = [
  "async-trait",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.57"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
+checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4264,6 +4264,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prom-remote-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5015def9ab9bfb1e61c9f86b93de221ec0cfe29cc2e0cb880b4f80e1682e004f"
+dependencies = [
+ "async-trait",
+ "prost",
+ "prost-build",
+ "snap",
+ "warp",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes 1.2.1",
  "prost-derive",
@@ -4330,9 +4343,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
  "bytes 1.2.1",
  "heck 0.4.0",
@@ -4341,18 +4354,20 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
+ "prettyplease",
  "prost",
  "prost-types",
  "regex",
+ "syn",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4363,9 +4378,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.1"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes 1.2.1",
  "prost",
@@ -5310,6 +5325,7 @@ dependencies = [
  "opensrv-mysql",
  "paste 1.0.8",
  "profile",
+ "prom-remote-api",
  "prometheus 0.12.0",
  "prometheus-static-metric",
  "prost",
@@ -5591,9 +5607,9 @@ dependencies = [
 
 [[package]]
 name = "snap"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snappy-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "datafusion",
  "env_logger",
  "ethbloom",
- "futures 0.3.21",
+ "futures 0.3.25",
  "lazy_static",
  "log",
  "lru",
@@ -249,7 +249,7 @@ dependencies = [
  "chrono",
  "either",
  "fallible-streaming-iterator",
- "futures 0.3.21",
+ "futures 0.3.25",
  "hash_hasher",
  "num-traits",
  "parquet2",
@@ -445,7 +445,7 @@ dependencies = [
  "common_util",
  "criterion",
  "env_logger",
- "futures 0.3.21",
+ "futures 0.3.25",
  "log",
  "object_store 1.0.0-alpha02",
  "parquet",
@@ -856,7 +856,7 @@ dependencies = [
  "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=12024e7f5c18cca7e40461f51b275c824dd37851)",
  "common_types 0.4.0",
  "dashmap 5.4.0",
- "futures 0.3.21",
+ "futures 0.3.25",
  "tokio 1.24.1",
  "tonic",
 ]
@@ -1527,7 +1527,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-row",
  "datafusion-sql",
- "futures 0.3.21",
+ "futures 0.3.25",
  "glob",
  "hashbrown",
  "itertools",
@@ -2115,9 +2115,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2130,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-cpupool"
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2167,15 +2167,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2184,21 +2184,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3180,7 +3180,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "common_util",
- "futures 0.3.21",
+ "futures 0.3.25",
  "log",
  "rskafka",
  "serde",
@@ -3198,7 +3198,7 @@ dependencies = [
  "ceresdbproto 0.1.0 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9430fe7d321955878ca06c431b115d73640f5d8f)",
  "common_types 1.0.0-alpha02",
  "common_util",
- "futures 0.3.21",
+ "futures 0.3.25",
  "log",
  "prost",
  "rand 0.7.3",
@@ -3673,7 +3673,7 @@ dependencies = [
  "async-trait",
  "bytes 1.2.1",
  "chrono",
- "futures 0.3.21",
+ "futures 0.3.25",
  "itertools",
  "parking_lot 0.12.1",
  "percent-encoding 2.1.0",
@@ -3694,7 +3694,7 @@ dependencies = [
  "clru",
  "common_util",
  "crc",
- "futures 0.3.21",
+ "futures 0.3.25",
  "lazy_static",
  "log",
  "lru",
@@ -3958,7 +3958,7 @@ dependencies = [
  "bytes 1.2.1",
  "chrono",
  "flate2",
- "futures 0.3.21",
+ "futures 0.3.25",
  "hashbrown",
  "lz4",
  "num",
@@ -3987,7 +3987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1a672c84c3e5b5eb6530286b2d22cc1ea8e1e3560e4c314218d6ab749c6db99"
 dependencies = [
  "async-trait",
- "futures 0.3.21",
+ "futures 0.3.25",
  "integer-encoding 3.0.4",
 ]
 
@@ -3999,7 +3999,7 @@ checksum = "73fd2690ad041f9296876daef1f2706f6347073bdbcc719090887f1691e4a09d"
 dependencies = [
  "async-stream",
  "bitpacking",
- "futures 0.3.21",
+ "futures 0.3.25",
  "parquet-format-async-temp",
  "streaming-decompression",
 ]
@@ -4265,11 +4265,12 @@ dependencies = [
 
 [[package]]
 name = "prom-remote-api"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b375194cde05179f99e00565a6434293408ddeee4df8547d8aeb40ab831d664"
+checksum = "bbef7d8c450f6570e12606546fd941696561ed97a07a353e4131f4fc715da09f"
 dependencies = [
  "async-trait",
+ "futures 0.3.25",
  "prost",
  "prost-build",
  "snap",
@@ -4483,7 +4484,7 @@ dependencies = [
  "datafusion",
  "datafusion-expr",
  "df_operator",
- "futures 0.3.21",
+ "futures 0.3.25",
  "log",
  "serde",
  "serde_derive",
@@ -4849,7 +4850,7 @@ dependencies = [
  "clru",
  "common_types 1.0.0-alpha02",
  "common_util",
- "futures 0.3.21",
+ "futures 0.3.25",
  "log",
  "proto 1.0.0-alpha02",
  "router",
@@ -5002,7 +5003,7 @@ dependencies = [
  "chrono",
  "crc32c",
  "flate2",
- "futures 0.3.21",
+ "futures 0.3.25",
  "integer-encoding 3.0.4",
  "lz4",
  "parking_lot 0.12.1",
@@ -5315,7 +5316,7 @@ dependencies = [
  "common_util",
  "datafusion",
  "df_operator",
- "futures 0.3.21",
+ "futures 0.3.25",
  "http 0.2.8",
  "interpreters",
  "lazy_static",
@@ -5890,7 +5891,7 @@ dependencies = [
  "catalog",
  "common_types 1.0.0-alpha02",
  "common_util",
- "futures 0.3.21",
+ "futures 0.3.25",
  "log",
  "prost",
  "proto 1.0.0-alpha02",
@@ -5913,7 +5914,7 @@ dependencies = [
  "datafusion-proto",
  "df_operator",
  "env_logger",
- "futures 0.3.21",
+ "futures 0.3.25",
  "itertools",
  "log",
  "parquet",
@@ -6461,7 +6462,7 @@ dependencies = [
  "common_types 1.0.0-alpha02",
  "common_util",
  "env_logger",
- "futures 0.3.21",
+ "futures 0.3.25",
  "object_store 1.0.0-alpha02",
  "parquet",
  "parquet_ext",
@@ -6867,7 +6868,7 @@ dependencies = [
  "common_types 1.0.0-alpha02",
  "common_util",
  "env_logger",
- "futures 0.3.21",
+ "futures 0.3.25",
  "log",
  "message_queue",
  "prost",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -34,7 +34,7 @@ opensrv-mysql = "0.1.0"
 paste = { workspace = true }
 profile = { workspace = true }
 # prom-remote-api = { version = "0.1.0", features = ["warp"] }
-prom-remote-api = { git ="https://github.com/jiacai2050/prom-remote-api", features = ["warp"] }
+prom-remote-api = { git = "https://github.com/jiacai2050/prom-remote-api", features = ["warp"] }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 prost = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,7 +33,7 @@ meta_client = { workspace = true }
 opensrv-mysql = "0.1.0"
 paste = { workspace = true }
 profile = { workspace = true }
-prom-remote-api = { version = "0.2.0", features = ["warp"] }
+prom-remote-api = { version = "0.2.1", features = ["warp"] }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 prost = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,7 +33,8 @@ meta_client = { workspace = true }
 opensrv-mysql = "0.1.0"
 paste = { workspace = true }
 profile = { workspace = true }
-prom-remote-api = { version = "0.1.0", features = ["warp"] }
+# prom-remote-api = { version = "0.1.0", features = ["warp"] }
+prom-remote-api = { git ="https://github.com/jiacai2050/prom-remote-api", features = ["warp"] }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 prost = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,8 +33,7 @@ meta_client = { workspace = true }
 opensrv-mysql = "0.1.0"
 paste = { workspace = true }
 profile = { workspace = true }
-# prom-remote-api = { version = "0.1.0", features = ["warp"] }
-prom-remote-api = { git = "https://github.com/jiacai2050/prom-remote-api", features = ["warp"] }
+prom-remote-api = { version = "0.2.0", features = ["warp"] }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 prost = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,6 +33,7 @@ meta_client = { workspace = true }
 opensrv-mysql = "0.1.0"
 paste = { workspace = true }
 profile = { workspace = true }
+prom-remote-api = { version = "0.1.0", features = ["warp"] }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 prost = { workspace = true }

--- a/server/src/context.rs
+++ b/server/src/context.rs
@@ -27,6 +27,7 @@ define_result!(Error);
 /// Context for request, may contains
 /// 1. Request context and options
 /// 2. Info from http headers
+#[derive(Clone)]
 pub struct RequestContext {
     /// Catalog of the request
     pub catalog: String,

--- a/server/src/context.rs
+++ b/server/src/context.rs
@@ -27,7 +27,6 @@ define_result!(Error);
 /// Context for request, may contains
 /// 1. Request context and options
 /// 2. Info from http headers
-#[derive(Clone)]
 pub struct RequestContext {
     /// Catalog of the request
     pub catalog: String,

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -47,7 +47,7 @@ pub mod forward;
 mod meta_event_service;
 mod metrics;
 mod remote_engine_service;
-mod storage_service;
+pub(crate) mod storage_service;
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/server/src/grpc/storage_service/mod.rs
+++ b/server/src/grpc/storage_service/mod.rs
@@ -52,7 +52,7 @@ pub(crate) mod error;
 mod prom_query;
 mod query;
 mod route;
-mod write;
+pub(crate) mod write;
 
 const STREAM_QUERY_CHANNEL_LEN: usize = 20;
 
@@ -491,11 +491,11 @@ impl<Q: QueryExecutor + 'static> StorageService for StorageServiceImpl<Q> {
 
 /// Create CreateTablePlan from a write metric.
 // The caller must ENSURE that the HandlerContext's schema_config is not None.
-pub fn write_metric_to_create_table_plan<Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<Q>,
+pub fn write_metric_to_create_table_plan(
+    schema_config: Option<&SchemaConfig>,
     write_metric: &WriteMetric,
 ) -> Result<CreateTablePlan> {
-    let schema_config = ctx.schema_config.unwrap();
+    let schema_config = schema_config.unwrap();
     Ok(CreateTablePlan {
         engine: schema_config.default_engine_type.clone(),
         if_not_exists: true,

--- a/server/src/grpc/storage_service/write.rs
+++ b/server/src/grpc/storage_service/write.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use ceresdbproto::storage::{value, WriteEntry, WriteMetric, WriteRequest, WriteResponse};
+use cluster::config::SchemaConfig;
 use common_types::{
     bytes::Bytes,
     datum::{Datum, DatumKind},
@@ -24,10 +25,13 @@ use snafu::{ensure, OptionExt, ResultExt};
 use sql::plan::{InsertPlan, Plan};
 use table_engine::table::TableRef;
 
-use crate::grpc::storage_service::{
-    self,
-    error::{self, ErrNoCause, ErrWithCause, Result},
-    HandlerContext,
+use crate::{
+    grpc::storage_service::{
+        self,
+        error::{self, ErrNoCause, ErrWithCause, Result},
+        HandlerContext,
+    },
+    instance::InstanceRef,
 };
 
 pub(crate) async fn handle_write<Q: QueryExecutor + 'static>(
@@ -37,11 +41,12 @@ pub(crate) async fn handle_write<Q: QueryExecutor + 'static>(
     let request_id = RequestId::next_id();
     let begin_instant = Instant::now();
     let deadline = ctx.timeout.map(|t| begin_instant + t);
-
+    let catalog = ctx.catalog();
+    let schema = ctx.schema();
     debug!(
         "Grpc handle write begin, catalog:{}, schema:{}, request_id:{}, first_table:{:?}, num_tables:{}",
-        ctx.catalog(),
-        ctx.schema(),
+        catalog,
+        schema,
         request_id,
         req.metrics
             .first()
@@ -49,58 +54,28 @@ pub(crate) async fn handle_write<Q: QueryExecutor + 'static>(
         req.metrics.len(),
     );
 
-    let instance = &ctx.instance;
-    let plan_vec = write_request_to_insert_plan(ctx, req, request_id, deadline).await?;
+    let plan_vec = write_request_to_insert_plan(
+        request_id,
+        catalog,
+        schema,
+        ctx.instance.clone(),
+        req,
+        ctx.schema_config,
+        deadline,
+    )
+    .await?;
 
     let mut success = 0;
     for insert_plan in plan_vec {
-        debug!(
-            "Grpc handle write table begin, table:{}, row_num:{}",
-            insert_plan.table.name(),
-            insert_plan.rows.num_rows()
-        );
-        let plan = Plan::Insert(insert_plan);
-
-        ctx.instance
-            .limiter
-            .try_limit(&plan)
-            .map_err(|e| Box::new(e) as _)
-            .context(ErrWithCause {
-                code: StatusCode::FORBIDDEN,
-                msg: "Insert is blocked",
-            })?;
-
-        let interpreter_ctx = InterpreterContext::builder(request_id, deadline)
-            // Use current ctx's catalog and schema as default catalog and schema
-            .default_catalog_and_schema(ctx.catalog().to_string(), ctx.schema().to_string())
-            .build();
-        let interpreter_factory = Factory::new(
-            instance.query_executor.clone(),
-            instance.catalog_manager.clone(),
-            instance.table_engine.clone(),
-            instance.table_manipulator.clone(),
-        );
-        let interpreter = interpreter_factory
-            .create(interpreter_ctx, plan)
-            .map_err(|e| Box::new(e) as _)
-            .with_context(|| ErrWithCause {
-                code: StatusCode::INTERNAL_SERVER_ERROR,
-                msg: "Failed to create interpreter",
-            })?;
-
-        let row_num = match interpreter
-            .execute()
-            .await
-            .map_err(|e| Box::new(e) as _)
-            .context(ErrWithCause {
-                code: StatusCode::INTERNAL_SERVER_ERROR,
-                msg: "failed to execute interpreter",
-            })? {
-            Output::AffectedRows(n) => n,
-            _ => unreachable!(),
-        };
-
-        success += row_num;
+        success += execute_plan(
+            request_id,
+            catalog,
+            schema,
+            ctx.instance.clone(),
+            insert_plan,
+            deadline,
+        )
+        .await?;
     }
 
     let resp = WriteResponse {
@@ -111,32 +86,97 @@ pub(crate) async fn handle_write<Q: QueryExecutor + 'static>(
 
     debug!(
         "Grpc handle write finished, catalog:{}, schema:{}, resp:{:?}",
-        ctx.catalog(),
-        ctx.schema(),
-        resp
+        catalog, schema, resp
     );
 
     Ok(resp)
 }
 
-async fn write_request_to_insert_plan<Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, Q>,
-    write_request: WriteRequest,
+pub async fn execute_plan<Q: QueryExecutor + 'static>(
     request_id: RequestId,
+    catalog: &str,
+    schema: &str,
+    instance: InstanceRef<Q>,
+    insert_plan: InsertPlan,
+    deadline: Option<Instant>,
+) -> Result<usize> {
+    debug!(
+        "Grpc handle write table begin, table:{}, row_num:{}",
+        insert_plan.table.name(),
+        insert_plan.rows.num_rows()
+    );
+    let plan = Plan::Insert(insert_plan);
+
+    instance
+        .limiter
+        .try_limit(&plan)
+        .map_err(|e| Box::new(e) as _)
+        .context(ErrWithCause {
+            code: StatusCode::FORBIDDEN,
+            msg: "Insert is blocked",
+        })?;
+
+    let interpreter_ctx = InterpreterContext::builder(request_id, deadline)
+        // Use current ctx's catalog and schema as default catalog and schema
+        .default_catalog_and_schema(catalog.to_string(), schema.to_string())
+        .build();
+    let interpreter_factory = Factory::new(
+        instance.query_executor.clone(),
+        instance.catalog_manager.clone(),
+        instance.table_engine.clone(),
+        instance.table_manipulator.clone(),
+    );
+    let interpreter = interpreter_factory
+        .create(interpreter_ctx, plan)
+        .map_err(|e| Box::new(e) as _)
+        .with_context(|| ErrWithCause {
+            code: StatusCode::INTERNAL_SERVER_ERROR,
+            msg: "Failed to create interpreter",
+        })?;
+
+    match interpreter
+        .execute()
+        .await
+        .map_err(|e| Box::new(e) as _)
+        .context(ErrWithCause {
+            code: StatusCode::INTERNAL_SERVER_ERROR,
+            msg: "failed to execute interpreter",
+        })? {
+        Output::AffectedRows(n) => Ok(n),
+        _ => unreachable!(),
+    }
+}
+
+pub async fn write_request_to_insert_plan<Q: QueryExecutor + 'static>(
+    request_id: RequestId,
+    catalog: &str,
+    schema: &str,
+    instance: InstanceRef<Q>,
+    write_request: WriteRequest,
+    schema_config: Option<&SchemaConfig>,
     deadline: Option<Instant>,
 ) -> Result<Vec<InsertPlan>> {
     let mut plan_vec = Vec::with_capacity(write_request.metrics.len());
 
     for write_metric in write_request.metrics {
         let table_name = &write_metric.metric;
-        let mut table = try_get_table(ctx, table_name)?;
+        let mut table = try_get_table(catalog, schema, instance.clone(), table_name)?;
 
         if table.is_none() {
-            if let Some(config) = ctx.schema_config {
+            if let Some(config) = schema_config {
                 if config.auto_create_tables {
-                    create_table(ctx, &write_metric, request_id, deadline).await?;
+                    create_table(
+                        request_id,
+                        catalog,
+                        schema,
+                        instance.clone(),
+                        &write_metric,
+                        schema_config,
+                        deadline,
+                    )
+                    .await?;
                     // try to get table again
-                    table = try_get_table(ctx, table_name)?;
+                    table = try_get_table(catalog, schema, instance.clone(), table_name)?;
                 }
             }
         }
@@ -149,11 +189,7 @@ async fn write_request_to_insert_plan<Q: QueryExecutor + 'static>(
             None => {
                 return ErrNoCause {
                     code: StatusCode::BAD_REQUEST,
-                    msg: format!(
-                        "Table not found, schema:{}, table:{}",
-                        ctx.schema(),
-                        table_name
-                    ),
+                    msg: format!("Table not found, schema:{}, table:{}", schema, table_name),
                 }
                 .fail();
             }
@@ -164,30 +200,32 @@ async fn write_request_to_insert_plan<Q: QueryExecutor + 'static>(
 }
 
 fn try_get_table<Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, Q>,
+    catalog: &str,
+    schema: &str,
+    instance: InstanceRef<Q>,
     table_name: &str,
 ) -> Result<Option<TableRef>> {
-    ctx.instance
+    instance
         .catalog_manager
-        .catalog_by_name(ctx.catalog())
+        .catalog_by_name(catalog)
         .map_err(|e| Box::new(e) as _)
         .with_context(|| ErrWithCause {
             code: StatusCode::INTERNAL_SERVER_ERROR,
-            msg: format!("Failed to find catalog, catalog_name:{}", ctx.catalog()),
+            msg: format!("Failed to find catalog, catalog_name:{}", catalog),
         })?
         .with_context(|| ErrNoCause {
             code: StatusCode::BAD_REQUEST,
-            msg: format!("Catalog not found, catalog_name:{}", ctx.catalog()),
+            msg: format!("Catalog not found, catalog_name:{}", catalog),
         })?
-        .schema_by_name(ctx.schema())
+        .schema_by_name(schema)
         .map_err(|e| Box::new(e) as _)
         .with_context(|| ErrWithCause {
             code: StatusCode::INTERNAL_SERVER_ERROR,
-            msg: format!("Failed to find schema, schema_name:{}", ctx.schema()),
+            msg: format!("Failed to find schema, schema_name:{}", schema),
         })?
         .with_context(|| ErrNoCause {
             code: StatusCode::BAD_REQUEST,
-            msg: format!("Schema not found, schema_name:{}", ctx.schema()),
+            msg: format!("Schema not found, schema_name:{}", schema),
         })?
         .table_by_name(table_name)
         .map_err(|e| Box::new(e) as _)
@@ -198,28 +236,30 @@ fn try_get_table<Q: QueryExecutor + 'static>(
 }
 
 async fn create_table<Q: QueryExecutor + 'static>(
-    ctx: &HandlerContext<'_, Q>,
-    write_metric: &WriteMetric,
     request_id: RequestId,
+    catalog: &str,
+    schema: &str,
+    instance: InstanceRef<Q>,
+    write_metric: &WriteMetric,
+    schema_config: Option<&SchemaConfig>,
     deadline: Option<Instant>,
 ) -> Result<()> {
-    let create_table_plan = storage_service::write_metric_to_create_table_plan(ctx, write_metric)
-        .map_err(|e| Box::new(e) as _)
-        .with_context(|| ErrWithCause {
-            code: StatusCode::INTERNAL_SERVER_ERROR,
-            msg: format!(
-                "Failed to build creating table plan from metric, table:{}",
-                write_metric.metric
-            ),
-        })?;
+    let create_table_plan =
+        storage_service::write_metric_to_create_table_plan(schema_config, write_metric)
+            .map_err(|e| Box::new(e) as _)
+            .with_context(|| ErrWithCause {
+                code: StatusCode::INTERNAL_SERVER_ERROR,
+                msg: format!(
+                    "Failed to build creating table plan from metric, table:{}",
+                    write_metric.metric
+                ),
+            })?;
 
     debug!(
         "Grpc handle create table begin, table:{}, schema:{:?}",
         create_table_plan.table, create_table_plan.table_schema,
     );
     let plan = Plan::Create(create_table_plan);
-
-    let instance = &ctx.instance;
 
     instance
         .limiter
@@ -232,7 +272,7 @@ async fn create_table<Q: QueryExecutor + 'static>(
 
     let interpreter_ctx = InterpreterContext::builder(request_id, deadline)
         // Use current ctx's catalog and schema as default catalog and schema
-        .default_catalog_and_schema(ctx.catalog().to_string(), ctx.schema().to_string())
+        .default_catalog_and_schema(catalog.to_string(), schema.to_string())
         .build();
     let interpreter_factory = Factory::new(
         instance.query_executor.clone(),

--- a/server/src/handlers/mod.rs
+++ b/server/src/handlers/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod admin;
 pub mod error;
+pub mod prom;
 pub mod sql;
 
 mod prelude {

--- a/server/src/handlers/prom.rs
+++ b/server/src/handlers/prom.rs
@@ -1,0 +1,35 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use async_trait::async_trait;
+use prom_remote_api::types::{ReadRequest, ReadResponse, RemoteStorage, Result, WriteRequest};
+use query_engine::executor::Executor as QueryExecutor;
+
+use crate::instance::InstanceRef;
+
+pub struct CeresDBStorage<Q: QueryExecutor + 'static> {
+    #[allow(dead_code)]
+    instance: InstanceRef<Q>,
+}
+
+impl<Q: QueryExecutor + 'static> CeresDBStorage<Q> {
+    pub fn new(instance: InstanceRef<Q>) -> Self {
+        Self { instance }
+    }
+}
+
+#[async_trait]
+impl<Q: QueryExecutor + 'static> RemoteStorage for CeresDBStorage<Q> {
+    /// Write samples to remote storage
+    async fn write(&self, req: WriteRequest) -> Result<()> {
+        println!("mock write, req:{req:?}");
+
+        Ok(())
+    }
+
+    /// Read samples from remote storage
+    async fn read(&self, req: ReadRequest) -> Result<ReadResponse> {
+        println!("mock query, req:{req:?}");
+
+        Ok(ReadResponse::default())
+    }
+}

--- a/server/src/handlers/prom.rs
+++ b/server/src/handlers/prom.rs
@@ -1,10 +1,27 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use async_trait::async_trait;
-use prom_remote_api::types::{ReadRequest, ReadResponse, RemoteStorage, Result, WriteRequest};
+use log::debug;
+use prom_remote_api::types::{
+    label_matcher, ReadRequest, ReadResponse, RemoteStorage, Result, WriteRequest,
+};
 use query_engine::executor::Executor as QueryExecutor;
+use snafu::{OptionExt, Snafu};
 
 use crate::instance::InstanceRef;
+
+#[derive(Debug, Snafu)]
+enum Error {
+    #[snafu(display("Metric name is not found"))]
+    MissingMetricName,
+
+    #[snafu(display("Invalid matcher type, value:{}", value))]
+    InvalidMatcherType { value: i32 },
+}
+
+const NAME_LABEL: &str = "__name__";
+const TIMESTAMP_NAME: &str = "timestamp";
+const VALUE_COLUMN: &str = "value";
 
 pub struct CeresDBStorage<Q: QueryExecutor + 'static> {
     #[allow(dead_code)]
@@ -21,15 +38,44 @@ impl<Q: QueryExecutor + 'static> CeresDBStorage<Q> {
 impl<Q: QueryExecutor + 'static> RemoteStorage for CeresDBStorage<Q> {
     /// Write samples to remote storage
     async fn write(&self, req: WriteRequest) -> Result<()> {
-        println!("mock write, req:{req:?}");
+        debug!("mock write, req:{req:?}");
 
-        Ok(())
+        unimplemented!()
     }
 
     /// Read samples from remote storage
     async fn read(&self, req: ReadRequest) -> Result<ReadResponse> {
         println!("mock query, req:{req:?}");
+        let q = &req.queries[0];
 
+        let mut filters = Vec::with_capacity(q.matchers.len());
+        filters.push(format!(
+            "{} between ({}, {})",
+            TIMESTAMP_NAME, q.start_timestamp_ms, q.end_timestamp_ms
+        ));
+        let mut measurement = None;
+        for m in &q.matchers {
+            if m.name == NAME_LABEL {
+                measurement = Some(m.value.to_string());
+                continue;
+            }
+
+            let filter = match m.r#type() {
+                label_matcher::Type::Eq => format!("{} = {}", m.name, m.value),
+                label_matcher::Type::Neq => format!("{} != {}", m.name, m.value),
+                label_matcher::Type::Re => format!("regexp_match({}, {})", m.name, m.value),
+                label_matcher::Type::Nre => format!("not(regexp_match({}, {}))", m.name, m.value),
+            };
+            filters.push(filter)
+        }
+
+        let measurement = measurement.context(MissingMetricName).unwrap();
+        let sql = format!(
+            "select {} from {} where {}",
+            VALUE_COLUMN,
+            measurement,
+            filters.join(" and ")
+        );
         Ok(ReadResponse::default())
     }
 }

--- a/server/src/handlers/prom.rs
+++ b/server/src/handlers/prom.rs
@@ -1,30 +1,96 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+use std::collections::HashMap;
+
 use async_trait::async_trait;
+use common_types::{
+    datum::DatumKind,
+    schema::{RecordSchema, TIMESTAMP_COLUMN, TSID_COLUMN},
+};
+use interpreters::interpreter::Output;
 use log::debug;
 use prom_remote_api::types::{
-    label_matcher, ReadRequest, ReadResponse, RemoteStorage, Result, WriteRequest,
+    label_matcher, Label, Query, QueryResult, ReadRequest, ReadResponse, RemoteStorage, Sample,
+    TimeSeries, WriteRequest,
 };
-use query_engine::executor::Executor as QueryExecutor;
-use snafu::{OptionExt, Snafu};
+use query_engine::executor::{Executor as QueryExecutor, RecordBatchVec};
+use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
+use warp::reject;
 
-use crate::instance::InstanceRef;
+use crate::{context::RequestContext, handlers, instance::InstanceRef};
 
 #[derive(Debug, Snafu)]
-enum Error {
-    #[snafu(display("Metric name is not found"))]
-    MissingMetricName,
+pub enum Error {
+    #[snafu(display("Metric name is not found.\nBacktrace:\n{}", backtrace))]
+    MissingName { backtrace: Backtrace },
 
-    #[snafu(display("Invalid matcher type, value:{}", value))]
-    InvalidMatcherType { value: i32 },
+    #[snafu(display("Invalid matcher type, value:{}.\nBacktrace:\n{}", value, backtrace))]
+    InvalidMatcherType { value: i32, backtrace: Backtrace },
+
+    #[snafu(display("Read response must be Rows.\nBacktrace:\n{}", backtrace))]
+    ResponseMustRows { backtrace: Backtrace },
+
+    #[snafu(display("TSID column is missing in query response.\nBacktrace:\n{}", backtrace))]
+    MissingTSID { backtrace: Backtrace },
+
+    #[snafu(display(
+        "Timestamp column is missing in query response.\nBacktrace:\n{}",
+        backtrace
+    ))]
+    MissingTimestamp { backtrace: Backtrace },
+
+    #[snafu(display(
+        "Value column is missing in query response.\nBacktrace:\n{}",
+        backtrace
+    ))]
+    MissingValue { backtrace: Backtrace },
+
+    #[snafu(display("Handle sql failed, err:{}.", source))]
+    SqlHandle {
+        source: Box<crate::handlers::error::Error>,
+    },
+
+    #[snafu(display("Tsid must be u64, current:{}.\nBacktrace:\n{}", kind, backtrace))]
+    TsidMustU64 {
+        kind: DatumKind,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Timestamp wrong type, current:{}.\nBacktrace:\n{}", kind, backtrace))]
+    MustTimestamp {
+        kind: DatumKind,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "Value must be f64 compatible type, current:{}.\nBacktrace:\n{}",
+        kind,
+        backtrace
+    ))]
+    F64Castable {
+        kind: DatumKind,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "Tag must be string type, current:{}.\nBacktrace:\n{}",
+        kind,
+        backtrace
+    ))]
+    TagMustString {
+        kind: DatumKind,
+        backtrace: Backtrace,
+    },
 }
 
+define_result!(Error);
+
+impl reject::Reject for Error {}
+
 const NAME_LABEL: &str = "__name__";
-const TIMESTAMP_NAME: &str = "timestamp";
 const VALUE_COLUMN: &str = "value";
 
 pub struct CeresDBStorage<Q: QueryExecutor + 'static> {
-    #[allow(dead_code)]
     instance: InstanceRef<Q>,
 }
 
@@ -34,24 +100,12 @@ impl<Q: QueryExecutor + 'static> CeresDBStorage<Q> {
     }
 }
 
-#[async_trait]
-impl<Q: QueryExecutor + 'static> RemoteStorage for CeresDBStorage<Q> {
-    /// Write samples to remote storage
-    async fn write(&self, req: WriteRequest) -> Result<()> {
-        debug!("mock write, req:{req:?}");
-
-        unimplemented!()
-    }
-
-    /// Read samples from remote storage
-    async fn read(&self, req: ReadRequest) -> Result<ReadResponse> {
-        println!("mock query, req:{req:?}");
-        let q = &req.queries[0];
-
+impl<Q: QueryExecutor + 'static> CeresDBStorage<Q> {
+    async fn read_inner(&self, ctx: RequestContext, q: Query) -> Result<QueryResult> {
         let mut filters = Vec::with_capacity(q.matchers.len());
         filters.push(format!(
-            "{} between ({}, {})",
-            TIMESTAMP_NAME, q.start_timestamp_ms, q.end_timestamp_ms
+            "{} between {} AND {}",
+            TIMESTAMP_COLUMN, q.start_timestamp_ms, q.end_timestamp_ms
         ));
         let mut measurement = None;
         for m in &q.matchers {
@@ -61,21 +115,195 @@ impl<Q: QueryExecutor + 'static> RemoteStorage for CeresDBStorage<Q> {
             }
 
             let filter = match m.r#type() {
-                label_matcher::Type::Eq => format!("{} = {}", m.name, m.value),
-                label_matcher::Type::Neq => format!("{} != {}", m.name, m.value),
-                label_matcher::Type::Re => format!("regexp_match({}, {})", m.name, m.value),
-                label_matcher::Type::Nre => format!("not(regexp_match({}, {}))", m.name, m.value),
+                label_matcher::Type::Eq => format!("{} = '{}'", m.name, m.value),
+                label_matcher::Type::Neq => format!("{} != '{}'", m.name, m.value),
+                // https://github.com/prometheus/prometheus/blob/2ce94ac19673a3f7faf164e9e078a79d4d52b767/model/labels/regexp.go#L29
+                label_matcher::Type::Re => format!("{} ~ '^(?:{})'", m.name, m.value),
+                label_matcher::Type::Nre => format!("{} !~ '^(?:{})'", m.name, m.value),
             };
             filters.push(filter)
         }
 
-        let measurement = measurement.context(MissingMetricName).unwrap();
+        let measurement = measurement.context(MissingName).unwrap();
         let sql = format!(
-            "select {} from {} where {}",
-            VALUE_COLUMN,
+            "select * from {} where {} order by {}, {}",
             measurement,
-            filters.join(" and ")
+            filters.join(" and "),
+            TSID_COLUMN,
+            TIMESTAMP_COLUMN
         );
-        Ok(ReadResponse::default())
+
+        debug!("remote storage read, sql:{}", sql);
+        let result = handlers::sql::handle_sql(ctx, self.instance.clone(), sql.into())
+            .await
+            .map_err(Box::new)
+            .context(SqlHandle)?;
+        convert_query_result(measurement, result)
     }
+}
+
+#[async_trait]
+impl<Q: QueryExecutor + 'static> RemoteStorage for CeresDBStorage<Q> {
+    type Context = RequestContext;
+    type Err = Error;
+
+    /// Write samples to remote storage
+    async fn write(&self, _ctx: Self::Context, req: WriteRequest) -> Result<()> {
+        debug!("mock write, req:{req:?}");
+
+        unimplemented!()
+    }
+
+    /// Read samples from remote storage
+    async fn read(&self, ctx: Self::Context, req: ReadRequest) -> Result<ReadResponse> {
+        let results = futures::future::join_all(
+            req.queries
+                .into_iter()
+                .map(|q| async { self.read_inner(ctx.clone(), q).await }),
+        )
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
+
+        Ok(ReadResponse { results })
+    }
+}
+
+struct Converter {
+    tsid_idx: usize,
+    timestamp_idx: usize,
+    value_idx: usize,
+    // (column_name, index)
+    tags: Vec<(String, usize)>,
+}
+
+impl Converter {
+    fn try_new(schema: &RecordSchema) -> Result<Self> {
+        let tsid_idx = schema.index_of(TSID_COLUMN).context(MissingTSID)?;
+        let timestamp_idx = schema
+            .index_of(TIMESTAMP_COLUMN)
+            .context(MissingTimestamp)?;
+        let value_idx = schema.index_of(VALUE_COLUMN).context(MissingValue)?;
+        let tags = schema
+            .columns()
+            .iter()
+            .enumerate()
+            .filter(|(_, col)| col.is_tag)
+            .map(|(i, col)| {
+                ensure!(
+                    matches!(col.data_type, DatumKind::String),
+                    TagMustString {
+                        kind: col.data_type
+                    }
+                );
+
+                Ok((col.name.to_string(), i))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        ensure!(
+            matches!(schema.column(tsid_idx).data_type, DatumKind::UInt64),
+            TsidMustU64 {
+                kind: schema.column(tsid_idx).data_type
+            }
+        );
+        ensure!(
+            schema.column(timestamp_idx).data_type.is_timestamp(),
+            MustTimestamp {
+                kind: schema.column(timestamp_idx).data_type
+            }
+        );
+        ensure!(
+            schema.column(value_idx).data_type.is_f64_castable(),
+            F64Castable {
+                kind: schema.column(value_idx).data_type
+            }
+        );
+
+        Ok(Converter {
+            tsid_idx,
+            timestamp_idx,
+            value_idx,
+            tags,
+        })
+    }
+
+    fn convert(&self, measurement: String, record_batches: RecordBatchVec) -> Result<QueryResult> {
+        let mut series_by_tsid = HashMap::new();
+        debug!("convert query result, tags:{:?}.", self.tags);
+        for batch in record_batches {
+            let tsid_col = batch.column(self.tsid_idx);
+            let timestamp_col = batch.column(self.timestamp_idx);
+            let value_col = batch.column(self.value_idx);
+            let tag_cols = self
+                .tags
+                .iter()
+                .map(|(_, idx)| batch.column(*idx))
+                .collect::<Vec<_>>();
+            for row_idx in 0..batch.num_rows() {
+                let tsid = tsid_col
+                    .datum(row_idx)
+                    .as_u64()
+                    .expect("checked in try_new");
+                series_by_tsid
+                    .entry(tsid)
+                    .or_insert_with(|| {
+                        let mut labels = self
+                            .tags
+                            .iter()
+                            .enumerate()
+                            .map(|(idx, (col_name, _))| {
+                                let col_value = tag_cols[idx].datum(row_idx);
+                                let col_value = col_value.as_str().expect("checked in try_new");
+                                Label {
+                                    name: col_name.to_string(),
+                                    value: col_value.to_string(),
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        labels.push(Label {
+                            name: NAME_LABEL.to_string(),
+                            value: measurement.clone(),
+                        });
+
+                        TimeSeries {
+                            labels,
+                            ..Default::default()
+                        }
+                    })
+                    .samples
+                    .push(Sample {
+                        timestamp: timestamp_col
+                            .datum(row_idx)
+                            .as_timestamp()
+                            .expect("checked in try_new")
+                            .as_i64(),
+                        value: value_col
+                            .datum(row_idx)
+                            .as_f64()
+                            .expect("checked in try_new"),
+                    });
+            }
+        }
+
+        Ok(QueryResult {
+            timeseries: series_by_tsid.into_values().collect(),
+        })
+    }
+}
+
+fn convert_query_result(measurement: String, resp: Output) -> Result<QueryResult> {
+    let record_batches = match resp {
+        Output::AffectedRows(_) => return ResponseMustRows {}.fail(),
+        Output::Records(v) => v,
+    };
+
+    let converter = match record_batches.first() {
+        None => {
+            return Ok(QueryResult::default());
+        }
+        Some(batch) => Converter::try_new(batch.schema())?,
+    };
+
+    converter.convert(measurement, record_batches)
 }

--- a/server/src/handlers/prom.rs
+++ b/server/src/handlers/prom.rs
@@ -1,5 +1,9 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+//! This module implements prometheus remote storage API.
+//! It converts write request to gRPC write request, and
+//! translates query request to SQL for execution.
+
 use std::{collections::HashMap, time::Instant};
 
 use async_trait::async_trait;
@@ -154,11 +158,11 @@ impl<Q: QueryExecutor + 'static> CeresDBStorage<Q> {
             TIMESTAMP_COLUMN
         );
 
-        debug!("remote storage read, sql:{}", sql);
         let result = handlers::sql::handle_sql(ctx, self.instance.clone(), sql.into())
             .await
             .map_err(Box::new)
             .context(SqlHandle)?;
+
         convert_query_result(measurement, result)
     }
 

--- a/server/src/handlers/sql.rs
+++ b/server/src/handlers/sql.rs
@@ -105,7 +105,7 @@ impl From<Bytes> for Request {
 }
 
 pub async fn handle_sql<Q: QueryExecutor + 'static>(
-    ctx: RequestContext,
+    ctx: &RequestContext,
     instance: InstanceRef<Q>,
     request: Request,
 ) -> Result<Output> {
@@ -164,7 +164,7 @@ pub async fn handle_sql<Q: QueryExecutor + 'static>(
     // Execute in interpreter
     let interpreter_ctx = InterpreterContext::builder(request_id, deadline)
         // Use current ctx's catalog and tenant as default catalog and tenant
-        .default_catalog_and_schema(ctx.catalog, ctx.schema)
+        .default_catalog_and_schema(ctx.catalog.to_string(), ctx.schema.to_string())
         .enable_partition_table_access(ctx.enable_partition_table_access)
         .build();
     let interpreter_factory = Factory::new(

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -175,7 +175,7 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
             .and(self.with_context())
             .and(self.with_instance())
             .and_then(|req, ctx, instance| async move {
-                let result = handlers::sql::handle_sql(ctx, instance, req)
+                let result = handlers::sql::handle_sql(&ctx, instance, req)
                     .await
                     .map(handlers::sql::convert_output)
                     .map_err(|e| {

--- a/server/src/mysql/worker.rs
+++ b/server/src/mysql/worker.rs
@@ -113,7 +113,7 @@ where
         let ctx = self.create_ctx()?;
 
         let req = Request::from(sql.to_string());
-        handlers::sql::handle_sql(ctx, self.instance.clone(), req)
+        handlers::sql::handle_sql(&ctx, self.instance.clone(), req)
             .await
             // TODO(chenxiang): no need for this convert for MySQL, remove it
             .map(handlers::sql::convert_output)

--- a/server/src/mysql/worker.rs
+++ b/server/src/mysql/worker.rs
@@ -115,6 +115,8 @@ where
         let req = Request::from(sql.to_string());
         handlers::sql::handle_sql(ctx, self.instance.clone(), req)
             .await
+            // TODO(chenxiang): no need for this convert for MySQL, remove it
+            .map(handlers::sql::convert_output)
             .map_err(|e| {
                 error!("Mysql service Failed to handle sql, err: {}", e);
                 e

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -296,11 +296,16 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
         // Start http service
         let engine_runtimes = self.engine_runtimes.context(MissingEngineRuntimes)?;
         let log_runtime = self.log_runtime.context(MissingLogRuntime)?;
+        let schema_config_provider = self
+            .schema_config_provider
+            .clone()
+            .context(MissingSchemaConfigProvider)?;
         let http_service = http::Builder::new(http_config)
             .engine_runtimes(engine_runtimes.clone())
             .log_runtime(log_runtime)
             .instance(instance.clone())
             .enable_tenant_as_schema(self.config.enable_tenant_as_schema)
+            .schema_config_provider(schema_config_provider)
             .build()
             .context(StartHttpService)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #577

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Add remote storage API support in HTTP module.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

Yes, add two HTTP API, prometheus users can use them by add following config to their prometheus.yml

```yml
remote_write:
  - url: "http://127.0.0.1:5000/prom/v1/write"

remote_read:
  - url: "http://127.0.0.1:5000/prom/v1/read"
```
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

Manually
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

