### PR TITLE
feat: improve the release profile and add release-slim profile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,9 @@ repos:
       - id: cargo-sort
         name: Check Cargo.toml is sorted
         entry: cargo-sort
+        args: ["--workspace"]
         language: rust
         types: [file, toml]
         files: Cargo\.toml
+        pass_filenames: false
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,8 @@ debug = true
 lto = true
 overflow-checks = true
 
-# This profile is used to produce a smaller(no symbols) but a little bit slower binary in a faster speed and with low memory consumption.
+# This profile is used to produce a smaller (no symbols) binary with a little bit poorer performance,
+# but with a faster speed and low memory consumption required by compiling.
 [profile.release-slim]
 inherits = "release"
 codegen-units = 16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,15 +150,19 @@ tracing_util = { workspace = true }
 [build-dependencies]
 vergen = { version = "5", default-features = false, features = ["build", "git"] }
 
-[profile.bench]
-debug = true
-
 # This profile optimizes for good runtime performance.
 [profile.release]
+# reference: https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+codegen-units = 1
 debug = true
+# reference: https://doc.rust-lang.org/cargo/reference/profiles.html#lto
+lto = true
 overflow-checks = true
 
-# This profile optimizes for best runtime performance but with more memory consumption.
-[profile.better-release]
+# This profile is used to produce a smaller(no symbols) but a little bit slower binary in a faster speed and with low memory consumption.
+[profile.release-slim]
+codegen-units = 16
+debug = false
 inherits = "release"
-lto = true
+lto = false
+strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,8 +161,8 @@ overflow-checks = true
 
 # This profile is used to produce a smaller(no symbols) but a little bit slower binary in a faster speed and with low memory consumption.
 [profile.release-slim]
+inherits = "release"
 codegen-units = 16
 debug = false
-inherits = "release"
 lto = false
 strip = true

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -2,7 +2,7 @@
 
 ## Running test
 
-First the sqlness needs to be compiled. Run `cargo build --release` under this folder. It will be compiled to `ceresdb-test` under `$REPO/target/release`.
+First the sqlness needs to be compiled. Run `cargo build --bin ceresdb-server` under this folder. It will be compiled to `ceresdb-test` under `$REPO/target/release`.
 
 The binary takes these env variables to run:
 - `BINARY_PATH_ENV`: The binary to test.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Current release profile is not the best concerning performance, and some options can be configured for better performance, but with slow compiling time and high memory consumption.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Add `lto=true` and `codegen-units=1` to `release` profile;
- Remove `better-release` profile, and add `release-slim` profile for a smaller and slower binary;
- Fix the bug that `cargo-sort` doesn't work in the precommit;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Current ci.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
