### PR TITLE
feat restrict partition num

### DIFF
--- a/sql/src/parser.rs
+++ b/sql/src/parser.rs
@@ -17,9 +17,13 @@ use sqlparser::{
 };
 use table_engine::ANALYTIC_ENGINE_TYPE;
 
-use crate::ast::{
-    AlterAddColumn, AlterModifySetting, CreateTable, DescribeTable, DropTable, ExistsTable,
-    HashPartition, KeyPartition, Partition, ShowCreate, ShowCreateObject, ShowTables, Statement,
+use crate::{
+    ast::{
+        AlterAddColumn, AlterModifySetting, CreateTable, DescribeTable, DropTable, ExistsTable,
+        HashPartition, KeyPartition, Partition, ShowCreate, ShowCreateObject, ShowTables,
+        Statement,
+    },
+    partition,
 };
 
 define_result!(ParserError);
@@ -635,16 +639,27 @@ impl<'a> Parser<'a> {
 
     // Parse second part: "PARTITIONS num" (if not set, num will use 1 as default).
     fn parse_partition_num(&mut self) -> Result<u64> {
-        if self.parser.parse_keyword(Keyword::PARTITIONS) {
+        let partition_num = if self.parser.parse_keyword(Keyword::PARTITIONS) {
             match self.parser.parse_number_value()? {
                 sqlparser::ast::Value::Number(v, _) => match v.parse::<u64>() {
-                    Ok(v) => Ok(v),
-                    Err(e) => parser_err!(format!("invalid partition num, raw:{}, err:{}", v, e)),
+                    Ok(v) => v,
+                    Err(e) => {
+                        return parser_err!(format!("invalid partition num, raw:{}, err:{}", v, e))
+                    }
                 },
-                v => parser_err!(format!("expect partition number, found:{}", v)),
+                v => return parser_err!(format!("expect partition number, found:{}", v)),
             }
         } else {
-            Ok(1)
+            1
+        };
+
+        if partition_num > partition::MAX_PARTITION_NUM {
+            parser_err!(format!(
+                "partition num must be <= MAX_PARTITION_NUM, MAX_PARTITION_NUM:{}, set partition num:{}",
+                partition::MAX_PARTITION_NUM, partition_num
+            ))
+        } else {
+            Ok(partition_num)
         }
     }
 
@@ -1393,5 +1408,35 @@ mod tests {
                 ParserError(r#"partition key must be tag, key name:"value""#.to_string())
             )
         }
+    }
+
+    #[test]
+    fn test_partition_num_restriction() {
+        let invalid_partition_num = partition::MAX_PARTITION_NUM + 1;
+        let invalid_partition_num_sql =
+            create_sql_with_partition_num(partition::MAX_PARTITION_NUM + 1);
+        let result = Parser::parse_sql(&invalid_partition_num_sql);
+        assert_eq!(
+            result.err().unwrap(),
+            ParserError(format!(
+                r#"partition num must be <= MAX_PARTITION_NUM, MAX_PARTITION_NUM:{}, set partition num:{}"#,
+                partition::MAX_PARTITION_NUM,
+                invalid_partition_num
+            ))
+        );
+
+        let valid_partition_num = partition::MAX_PARTITION_NUM - 1;
+        let valid_partition_num_sql = create_sql_with_partition_num(valid_partition_num);
+        let result = Parser::parse_sql(&valid_partition_num_sql);
+        assert!(result.is_ok());
+    }
+
+    fn create_sql_with_partition_num(partition_num: u64) -> String {
+        format!(
+            r#"CREATE TABLE `demo` (`name` string TAG, `value` double NOT NULL,
+            `t` timestamp NOT NULL, TIMESTAMP KEY(t)) PARTITION BY KEY(name) PARTITIONS {}
+            ENGINE=Analytic with (enable_ttl="false")"#,
+            partition_num
+        )
     }
 }

--- a/sql/src/partition.rs
+++ b/sql/src/partition.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 const DEFAULT_PARTITION_VERSION: i32 = 0;
+pub const MAX_PARTITION_NUM: u64 = 1024;
 
 pub struct PartitionParser;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Now partition num in table partition is not restricted,  you can set the partition num to an unaccpetable huge number. 

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
In this pr we make a restriction on it, it cannot be greater than MAX_PARTITION_NUM(1024 now).
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
User can not set a partition num greater than MAX_PARTITION_NUM while creating partitioned table.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
