### PR TITLE
chore: make nightly image name readable

### DIFF
--- a/.github/workflows/dockerhub-publish-nightly.yml
+++ b/.github/workflows/dockerhub-publish-nightly.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Set environment variables
+      - name: Set Environment Variables
         run: |
             echo "BUILD_DATE=$(TZ=':Asia/Shanghai' date '+%Y%m%d')" >> $GITHUB_ENV
             # only first 7 chars of commit id

--- a/.github/workflows/dockerhub-publish-nightly.yml
+++ b/.github/workflows/dockerhub-publish-nightly.yml
@@ -19,12 +19,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Set datetime
+      - name: Set environment variables
         run: |
-            echo "BUILD_DATE=$(TZ=':Asia/Shanghai' date '+%Y%m%d%H%M%S')" >> $GITHUB_ENV
+            echo "BUILD_DATE=$(TZ=':Asia/Shanghai' date '+%Y%m%d')" >> $GITHUB_ENV
+            # only first 7 chars of commit id
+            echo "COMMIT_ID=${GITHUB_SHA::7}" >> $GITHUB_ENV
       - name: Build and Push CeresDB Server Docker Image
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: ceresdb/ceresdb-server:nightly-${{ env.BUILD_DATE }}-${{ github.sha }}
+          tags: ceresdb/ceresdb-server:nightly-${{ env.BUILD_DATE }}-${{ env.COMMIT_ID }}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Current nightly docker image name is too verbose, this PR make it more readable

- before: nightly-20230201214631-aa306ecb54a5f3863d4041182e2a46d48daad3d0
- after: nightly-20230201-aa306ec

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

