### PR TITLE
feat: make bloom filter optional on column level

### DIFF
--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -152,7 +152,7 @@ impl<'a> Reader<'a> {
         let filter = RowGroupFilter::try_new(
             &schema,
             row_groups,
-            bloom_filter.map(|v| v.filters()),
+            bloom_filter.map(|v| v.row_group_filters()),
             self.predicate.exprs(),
         )?;
 

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -303,36 +303,12 @@ mod tests {
             bloom_filter.row_group_filters().len(),
         );
         assert_eq!(
-            decoded_bloom_filter.row_group_filters[0]
-                .column_filters
-                .len(),
-            bloom_filter.row_group_filters()[0].column_filters.len(),
+            decoded_bloom_filter.row_group_filters[0].column_filters,
+            bloom_filter.row_group_filters()[0].column_filters
         );
         assert_eq!(
-            decoded_bloom_filter.row_group_filters[1]
-                .column_filters
-                .len(),
-            bloom_filter.row_group_filters()[1].column_filters.len(),
-        );
-        assert_eq!(
-            decoded_bloom_filter.row_group_filters[0].column_filters[0]
-                .as_ref()
-                .unwrap()
-                .data(),
-            bloom_filter.row_group_filters()[0].column_filters[0]
-                .as_ref()
-                .unwrap()
-                .data(),
-        );
-        assert_eq!(
-            decoded_bloom_filter.row_group_filters[0].column_filters[1]
-                .as_ref()
-                .unwrap()
-                .data(),
-            bloom_filter.row_group_filters()[0].column_filters[1]
-                .as_ref()
-                .unwrap()
-                .data(),
+            decoded_bloom_filter.row_group_filters[1],
+            bloom_filter.row_group_filters()[1],
         );
     }
 }

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -7,9 +7,9 @@ use std::{fmt, sync::Arc};
 use bytes::Bytes;
 use common_types::{schema::Schema, time::TimeRange, SequenceNumber};
 use common_util::define_result;
-use ethbloom::Bloom;
+use ethbloom::{Bloom, Input};
 use proto::{common as common_pb, sst as sst_pb};
-use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 
 use crate::sst::writer::MetaData;
 
@@ -29,6 +29,13 @@ pub enum Error {
     ))]
     InvalidBloomFilterSize { size: usize, backtrace: Backtrace },
 
+    #[snafu(display(
+        "Unsupported bloom filter version, version:{}.\nBacktrace\n:{}",
+        version,
+        backtrace
+    ))]
+    UnsupportedBloomFilter { version: u32, backtrace: Backtrace },
+
     #[snafu(display("Failed to convert time range, err:{}", source))]
     ConvertTimeRange { source: common_types::time::Error },
 
@@ -38,40 +45,88 @@ pub enum Error {
 
 define_result!(Error);
 
+const DEFAULT_BLOOM_FILTER_VERSION: u32 = 0;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RowGroupBloomFilter {
+    // The column filter can be None if the column is not indexed.
+    column_filters: Vec<Option<Bloom>>,
+}
+
+impl RowGroupBloomFilter {
+    pub fn with_num_columns(num_columns: usize) -> Self {
+        Self {
+            column_filters: vec![None; num_columns],
+        }
+    }
+
+    pub fn push_column_filter(&mut self, column_filter: Option<Bloom>) {
+        self.column_filters.push(column_filter);
+    }
+
+    /// Accrue the data belonging to one column.
+    ///
+    /// Caller should ensure the `column_idx` is in the range.
+    pub fn accrue_column_data(&mut self, column_idx: usize, data: &[u8]) {
+        if self.column_filters[column_idx].is_none() {
+            self.column_filters[column_idx] = Some(Bloom::default());
+        }
+
+        let column_filter = self.column_filters[column_idx].as_mut().unwrap();
+        column_filter.accrue(Input::Raw(data));
+    }
+
+    /// Return None if the column is not indexed.
+    pub fn contains_column_data(&self, column_idx: usize, data: &[u8]) -> Option<bool> {
+        self.column_filters[column_idx].map(|v| v.contains_input(Input::Raw(data)))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct BloomFilter {
-    // Two level vector means
-    // 1. row group
-    // 2. column
-    filters: Vec<Vec<Bloom>>,
+    // Every filter is a row group filter consists of column filters.
+    //
+    // The row group filter can be None if the row group is not indexed.
+    row_group_filters: Vec<Option<RowGroupBloomFilter>>,
 }
 
 impl BloomFilter {
-    pub fn new(filters: Vec<Vec<Bloom>>) -> Self {
-        Self { filters }
+    pub fn new(row_group_filters: Vec<Option<RowGroupBloomFilter>>) -> Self {
+        Self { row_group_filters }
     }
 
-    #[inline]
-    pub fn filters(&self) -> &[Vec<Bloom>] {
-        &self.filters
+    pub fn row_group_filters(&self) -> &[Option<RowGroupBloomFilter>] {
+        &self.row_group_filters
     }
 }
 
 impl From<BloomFilter> for sst_pb::SstBloomFilter {
     fn from(bloom_filter: BloomFilter) -> Self {
         let row_group_filters = bloom_filter
-            .filters
+            .row_group_filters
             .iter()
             .map(|row_group_filter| {
-                let column_filters = row_group_filter
-                    .iter()
-                    .map(|column_filter| column_filter.data().to_vec())
-                    .collect::<Vec<_>>();
+                let column_filters = match row_group_filter {
+                    Some(v) => v
+                        .column_filters
+                        .iter()
+                        .map(|column_filter| {
+                            column_filter
+                                .map(|v| v.data().to_vec())
+                                // If the column filter does not exist, use an empty vector for it.
+                                .unwrap_or_default()
+                        })
+                        .collect::<Vec<_>>(),
+                    None => Vec::new(),
+                };
                 sst_pb::sst_bloom_filter::RowGroupFilter { column_filters }
             })
             .collect::<Vec<_>>();
 
-        sst_pb::SstBloomFilter { row_group_filters }
+        sst_pb::SstBloomFilter {
+            version: DEFAULT_BLOOM_FILTER_VERSION,
+            row_group_filters,
+        }
     }
 }
 
@@ -79,27 +134,45 @@ impl TryFrom<sst_pb::SstBloomFilter> for BloomFilter {
     type Error = Error;
 
     fn try_from(src: sst_pb::SstBloomFilter) -> Result<Self> {
-        let filters = src
+        ensure!(
+            src.version == DEFAULT_BLOOM_FILTER_VERSION,
+            UnsupportedBloomFilter {
+                version: src.version
+            }
+        );
+
+        let row_group_filters = src
             .row_group_filters
             .into_iter()
             .map(|row_group_filter| {
-                row_group_filter
-                    .column_filters
-                    .into_iter()
-                    .map(|encoded_bytes| {
-                        let size = encoded_bytes.len();
-                        let bs: [u8; 256] = encoded_bytes
-                            .try_into()
-                            .ok()
-                            .context(InvalidBloomFilterSize { size })?;
+                // If no column filter exists in the row group, it means the row group is not
+                // indexed.
+                if row_group_filter.column_filters.is_empty() {
+                    Ok(None)
+                } else {
+                    let column_filters = row_group_filter
+                        .column_filters
+                        .into_iter()
+                        .map(|encoded_bytes| {
+                            if encoded_bytes.is_empty() {
+                                Ok(None)
+                            } else {
+                                let size = encoded_bytes.len();
+                                let bs: [u8; 256] = encoded_bytes
+                                    .try_into()
+                                    .ok()
+                                    .context(InvalidBloomFilterSize { size })?;
 
-                        Ok(Bloom::from(bs))
-                    })
-                    .collect::<Result<Vec<_>>>()
+                                Ok(Some(Bloom::from(bs)))
+                            }
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    Ok(Some(RowGroupBloomFilter { column_filters }))
+                }
             })
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(BloomFilter { filters })
+        Ok(BloomFilter { row_group_filters })
     }
 }
 

--- a/analytic_engine/src/sst/parquet/row_group_filter.rs
+++ b/analytic_engine/src/sst/parquet/row_group_filter.rs
@@ -7,7 +7,6 @@ use std::cmp::Ordering;
 use arrow::datatypes::SchemaRef;
 use common_types::datum::Datum;
 use datafusion::{prelude::Expr, scalar::ScalarValue};
-use ethbloom::{Bloom, Input};
 use log::debug;
 use parquet::file::metadata::RowGroupMetaData;
 use parquet_ext::prune::{
@@ -16,6 +15,7 @@ use parquet_ext::prune::{
 };
 use snafu::ensure;
 
+use super::meta_data::RowGroupBloomFilter;
 use crate::sst::reader::error::{OtherNoCause, Result};
 
 /// A filter to prune row groups according to the provided predicates.
@@ -25,7 +25,7 @@ use crate::sst::reader::error::{OtherNoCause, Result};
 pub struct RowGroupFilter<'a> {
     schema: &'a SchemaRef,
     row_groups: &'a [RowGroupMetaData],
-    blooms: Option<&'a [Vec<Bloom>]>,
+    blooms: Option<&'a [Option<RowGroupBloomFilter>]>,
     predicates: &'a [Expr],
 }
 
@@ -33,7 +33,7 @@ impl<'a> RowGroupFilter<'a> {
     pub fn try_new(
         schema: &'a SchemaRef,
         row_groups: &'a [RowGroupMetaData],
-        blooms: Option<&'a [Vec<Bloom>]>,
+        blooms: Option<&'a [Option<RowGroupBloomFilter>]>,
         predicates: &'a [Expr],
     ) -> Result<Self> {
         if let Some(blooms) = blooms {
@@ -92,12 +92,18 @@ impl<'a> RowGroupFilter<'a> {
     }
 
     /// Filter row groups according to the bloom filter.
-    fn filter_by_bloom(&self, blooms: &[Vec<Bloom>]) -> Vec<usize> {
+    fn filter_by_bloom(
+        &self,
+        row_group_bloom_filters: &[Option<RowGroupBloomFilter>],
+    ) -> Vec<usize> {
         let is_equal =
             |col_pos: ColumnPosition, val: &ScalarValue, negated: bool| -> Option<bool> {
                 let datum = Datum::from_scalar_value(val)?;
-                let col_bloom = blooms.get(col_pos.row_group_idx)?.get(col_pos.column_idx)?;
-                let exist = col_bloom.contains_input(Input::Raw(&datum.to_bytes()));
+                let exist = row_group_bloom_filters
+                    .get(col_pos.row_group_idx)
+                    .as_ref()?
+                    .as_ref()?
+                    .contains_column_data(col_pos.column_idx, &datum.to_bytes())?;
                 if exist {
                     // bloom filter has false positivity, that is to say we are unsure whether this
                     // value exists even if the bloom filter says it exists.

--- a/analytic_engine/src/sst/parquet/row_group_filter.rs
+++ b/analytic_engine/src/sst/parquet/row_group_filter.rs
@@ -25,7 +25,7 @@ use crate::sst::reader::error::{OtherNoCause, Result};
 pub struct RowGroupFilter<'a> {
     schema: &'a SchemaRef,
     row_groups: &'a [RowGroupMetaData],
-    blooms: Option<&'a [Option<RowGroupBloomFilter>]>,
+    blooms: Option<&'a [RowGroupBloomFilter]>,
     predicates: &'a [Expr],
 }
 
@@ -33,7 +33,7 @@ impl<'a> RowGroupFilter<'a> {
     pub fn try_new(
         schema: &'a SchemaRef,
         row_groups: &'a [RowGroupMetaData],
-        blooms: Option<&'a [Option<RowGroupBloomFilter>]>,
+        blooms: Option<&'a [RowGroupBloomFilter]>,
         predicates: &'a [Expr],
     ) -> Result<Self> {
         if let Some(blooms) = blooms {
@@ -92,17 +92,12 @@ impl<'a> RowGroupFilter<'a> {
     }
 
     /// Filter row groups according to the bloom filter.
-    fn filter_by_bloom(
-        &self,
-        row_group_bloom_filters: &[Option<RowGroupBloomFilter>],
-    ) -> Vec<usize> {
+    fn filter_by_bloom(&self, row_group_bloom_filters: &[RowGroupBloomFilter]) -> Vec<usize> {
         let is_equal =
             |col_pos: ColumnPosition, val: &ScalarValue, negated: bool| -> Option<bool> {
                 let datum = Datum::from_scalar_value(val)?;
                 let exist = row_group_bloom_filters
-                    .get(col_pos.row_group_idx)
-                    .as_ref()?
-                    .as_ref()?
+                    .get(col_pos.row_group_idx)?
                     .contains_column_data(col_pos.column_idx, &datum.to_bytes())?;
                 if exist {
                     // bloom filter has false positivity, that is to say we are unsure whether this

--- a/analytic_engine/src/sst/parquet/row_group_filter.rs
+++ b/analytic_engine/src/sst/parquet/row_group_filter.rs
@@ -15,8 +15,10 @@ use parquet_ext::prune::{
 };
 use snafu::ensure;
 
-use super::meta_data::RowGroupBloomFilter;
-use crate::sst::reader::error::{OtherNoCause, Result};
+use crate::sst::{
+    parquet::meta_data::RowGroupBloomFilter,
+    reader::error::{OtherNoCause, Result},
+};
 
 /// A filter to prune row groups according to the provided predicates.
 ///

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -15,13 +15,12 @@ use log::debug;
 use object_store::{ObjectStoreRef, Path};
 use snafu::ResultExt;
 
-use super::meta_data::RowGroupBloomFilter;
 use crate::{
     sst::{
         factory::{ObjectStorePickerRef, SstWriteOptions},
         parquet::{
             encoding::ParquetEncoder,
-            meta_data::{BloomFilter, ParquetMetaData},
+            meta_data::{BloomFilter, ParquetMetaData, RowGroupBloomFilter},
         },
         writer::{
             self, EncodeRecordBatch, MetaData, PollRecordBatch, RecordBatchStream, Result, SstInfo,

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -171,7 +171,7 @@ impl RecordBytesReader {
                     }
                 }
 
-                Some(row_group_filter)
+                row_group_filter
             })
             .collect::<Vec<_>>();
 

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -10,12 +10,12 @@ use std::sync::{
 use async_trait::async_trait;
 use common_types::{record_batch::RecordBatchWithKey, request_id::RequestId};
 use datafusion::parquet::basic::Compression;
-use ethbloom::{Bloom, Input};
 use futures::StreamExt;
 use log::debug;
 use object_store::{ObjectStoreRef, Path};
 use snafu::ResultExt;
 
+use super::meta_data::RowGroupBloomFilter;
 use crate::{
     sst::{
         factory::{ObjectStorePickerRef, SstWriteOptions},
@@ -158,20 +158,20 @@ impl RecordBytesReader {
             .partitioned_record_batch
             .iter()
             .map(|row_group_batch| {
-                let mut row_group_filters =
-                    vec![Bloom::default(); row_group_batch[0].num_columns()];
+                let mut row_group_filter =
+                    RowGroupBloomFilter::with_num_columns(row_group_batch[0].num_columns());
 
                 for partial_batch in row_group_batch {
                     for (col_idx, column) in partial_batch.columns().iter().enumerate() {
                         for row in 0..column.num_rows() {
                             let datum = column.datum(row);
                             let bytes = datum.to_bytes();
-                            row_group_filters[col_idx].accrue(Input::Raw(&bytes));
+                            row_group_filter.accrue_column_data(col_idx, &bytes);
                         }
                     }
                 }
 
-                row_group_filters
+                Some(row_group_filter)
             })
             .collect::<Vec<_>>();
 

--- a/proto/protos/sst.proto
+++ b/proto/protos/sst.proto
@@ -12,7 +12,8 @@ message SstBloomFilter {
     repeated bytes column_filters = 1;
   };
 
-  repeated RowGroupFilter row_group_filters = 1;
+  uint32 version = 1;
+  repeated RowGroupFilter row_group_filters = 2;
 }
 
 message SstMetaData {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
Currently, the bloom filter is only optional on file level, and the bloom filters on column level are still required. However, in some cases, a column bloom filter may be useless, which can be avoided after this PR.

And for compatibility, the version of bloom filter should be introduced.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Introduce the version of bloom filter. [Breaking Change]
- Make bloom filter optional on column level.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
