### PR TITLE
primary keys defaults to tsid, timestamp

### DIFF
--- a/server/src/grpc/storage_service/mod.rs
+++ b/server/src/grpc/storage_service/mod.rs
@@ -638,7 +638,7 @@ fn build_schema_from_write_table_request(
         msg: "invalid timestamp column schema to build",
     })?;
 
-    // Use (timestamp, tsid) as primary key.
+    // Use (tsid, timestamp) as primary key.
     let tsid_column_schema =
         column_schema::Builder::new(TSID_COLUMN.to_string(), DatumKind::UInt64)
             .is_nullable(false)
@@ -650,17 +650,17 @@ fn build_schema_from_write_table_request(
             })?;
 
     schema_builder = schema_builder
-        .add_key_column(timestamp_column_schema)
-        .map_err(|e| Box::new(e) as _)
-        .context(ErrWithCause {
-            code: StatusCode::BAD_REQUEST,
-            msg: "invalid timestamp column to add",
-        })?
         .add_key_column(tsid_column_schema)
         .map_err(|e| Box::new(e) as _)
         .context(ErrWithCause {
             code: StatusCode::BAD_REQUEST,
             msg: "invalid tsid column to add",
+        })?
+        .add_key_column(timestamp_column_schema)
+        .map_err(|e| Box::new(e) as _)
+        .context(ErrWithCause {
+            code: StatusCode::BAD_REQUEST,
+            msg: "invalid timestamp column to add",
         })?;
 
     for col in name_column_map.into_values() {

--- a/server/src/grpc/storage_service/mod.rs
+++ b/server/src/grpc/storage_service/mod.rs
@@ -832,8 +832,8 @@ mod tests {
 
         let key_columns = schema.key_columns();
         assert_eq!(2, key_columns.len());
-        assert_eq!(TIMESTAMP_COLUMN, key_columns[0].name);
-        assert_eq!("tsid", key_columns[1].name);
+        assert_eq!("tsid", key_columns[0].name);
+        assert_eq!(TIMESTAMP_COLUMN, key_columns[1].name);
 
         let columns = schema.normal_columns();
         assert_eq!(6, columns.len());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
I find this bug when write docs https://github.com/CeresDB/docs/pull/25

Primary key already is `tsid, timestamp` by default in SQL, update grpc to follow this.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->
No 
# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
UT

