### PR TITLE
fix: avoid some unwrap with result

### DIFF
--- a/df_operator/src/udfs/time_bucket.rs
+++ b/df_operator/src/udfs/time_bucket.rs
@@ -266,10 +266,10 @@ impl Period {
 
     fn truncate_day(ts: Timestamp, period: u16) -> Option<Timestamp> {
         let offset = FixedOffset::east_opt(DEFAULT_TIMEZONE_OFFSET_SECS).expect("won't panic");
-        // Convert to local time.
+        // Convert to local time. Won't panic.
         let datetime = offset.timestamp_millis_opt(ts.as_i64()).unwrap();
 
-        // Truncate day
+        // Truncate day. Won't panic.
         let day = datetime.day();
         let day = day - (day % u32::from(period));
         let truncated_datetime = offset
@@ -282,10 +282,10 @@ impl Period {
 
     fn truncate_week(ts: Timestamp) -> Timestamp {
         let offset = FixedOffset::east_opt(DEFAULT_TIMEZONE_OFFSET_SECS).expect("won't panic");
-        // Convert to local time.
+        // Convert to local time. Won't panic.
         let datetime = offset.timestamp_millis_opt(ts.as_i64()).unwrap();
 
-        // Truncate week.
+        // Truncate week. Won't panic.
         let week_offset = datetime.weekday().num_days_from_monday();
         let week_millis = 7 * 24 * 3600 * 1000;
         let ts_offset = week_offset * week_millis;
@@ -298,10 +298,10 @@ impl Period {
 
     fn truncate_month(ts: Timestamp) -> Timestamp {
         let offset = FixedOffset::east_opt(DEFAULT_TIMEZONE_OFFSET_SECS).expect("won't panic");
-        // Convert to local time.
+        // Convert to local time. Won't panic.
         let datetime = offset.timestamp_millis_opt(ts.as_i64()).unwrap();
 
-        // Truncate month
+        // Truncate month. Won't panic.
         let truncated_datetime = offset
             .with_ymd_and_hms(datetime.year(), datetime.month(), 1, 0, 0, 0)
             .unwrap();
@@ -312,10 +312,10 @@ impl Period {
 
     fn truncate_year(ts: Timestamp) -> Timestamp {
         let offset = FixedOffset::east_opt(DEFAULT_TIMEZONE_OFFSET_SECS).expect("won't panic");
-        // Convert to local time.
+        // Convert to local time. Won't panic.
         let datetime = offset.timestamp_millis_opt(ts.as_i64()).unwrap();
 
-        // Truncate year
+        // Truncate year. Won't panic.
         let truncated_datetime = offset
             .with_ymd_and_hms(datetime.year(), 1, 1, 0, 0, 0)
             .unwrap();


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 In #601 , some `Result`s are handled directly using `unwrap`, which is too rough.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Return error instead of unwrap.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Old tests are covered.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
