### PR TITLE
feat: use ConfigOptions to transfer custom settings

### DIFF
--- a/query_engine/src/executor.rs
+++ b/query_engine/src/executor.rs
@@ -97,8 +97,7 @@ impl Executor for ExecutorImpl {
         let plan = query.plan;
 
         // Register catalogs to datafusion execution context.
-        let catalogs =
-            CatalogProviderAdapter::new_adapters(plan.tables.clone(), self.config.read_parallelism);
+        let catalogs = CatalogProviderAdapter::new_adapters(plan.tables.clone());
         let df_ctx = ctx.build_df_session_ctx(&self.config, ctx.request_id, ctx.deadline);
         for (name, catalog) in catalogs {
             df_ctx.register_catalog(&name, Arc::new(catalog));

--- a/table_engine/src/provider.rs
+++ b/table_engine/src/provider.rs
@@ -110,19 +110,14 @@ pub struct TableProviderAdapter {
     /// snapshot for read to avoid the reader sees different schema during
     /// query
     read_schema: Schema,
-    read_parallelism: usize,
 }
 
 impl TableProviderAdapter {
-    pub fn new(table: TableRef, read_parallelism: usize) -> Self {
+    pub fn new(table: TableRef) -> Self {
         // Take a snapshot of the schema
         let read_schema = table.schema();
 
-        Self {
-            table,
-            read_schema,
-            read_parallelism,
-        }
+        Self { table, read_schema }
     }
 
     pub fn as_table_ref(&self) -> &TableRef {
@@ -160,7 +155,7 @@ impl TableProviderAdapter {
         {
             1
         } else {
-            self.read_parallelism
+            state.config().target_partitions()
         };
 
         let predicate = self.check_and_build_predicate_from_filters(filters);
@@ -524,7 +519,7 @@ mod test {
             user_defined_pk_schema,
             "memory".to_string(),
         );
-        let provider = TableProviderAdapter::new(Arc::new(table), 1);
+        let provider = TableProviderAdapter::new(Arc::new(table));
         let predicate = provider.check_and_build_predicate_from_filters(&test_filters);
 
         let expected_filters = vec![test_filters[0].clone(), test_filters[1].clone()];
@@ -542,7 +537,7 @@ mod test {
             default_pk_schema,
             "memory".to_string(),
         );
-        let provider = TableProviderAdapter::new(Arc::new(table), 1);
+        let provider = TableProviderAdapter::new(Arc::new(table));
         let predicate = provider.check_and_build_predicate_from_filters(&test_filters);
 
         let expected_filters = vec![test_filters[0].clone(), test_filters[2].clone()];


### PR DESCRIPTION
# Which issue does this PR close?

Closes #622 

# Rationale for this change
 ConfigOptions is a structure for passing setting in `datafusion`, which supports passing custom setting.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Use ConfigOptions to transfer custom settings.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Add new test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
