### PR TITLE
chore: refacor ceresdb config

### DIFF
--- a/docs/example-cluster-0.toml
+++ b/docs/example-cluster-0.toml
@@ -1,4 +1,4 @@
-[service]
+[server]
 bind_addr = "0.0.0.0"
 http_port = 5440
 grpc_port = 8831

--- a/docs/example-cluster-1.toml
+++ b/docs/example-cluster-1.toml
@@ -1,4 +1,4 @@
-[service]
+[server]
 bind_addr = "0.0.0.0"
 http_port = 5441
 grpc_port = 8832

--- a/docs/example-standalone-static-routing.toml
+++ b/docs/example-standalone-static-routing.toml
@@ -1,4 +1,4 @@
-[service]
+[server]
 bind_addr = "0.0.0.0"
 http_port = 5000
 grpc_port = 8831

--- a/docs/minimal.toml
+++ b/docs/minimal.toml
@@ -1,4 +1,4 @@
-[service]
+[server]
 bind_addr = "0.0.0.0"
 http_port = 5440
 grpc_port = 8831

--- a/integration_tests/cases/local/config.toml
+++ b/integration_tests/cases/local/config.toml
@@ -1,9 +1,8 @@
-[service]
+[server]
 bind_addr = "127.0.0.1"
 http_port = 5440
 grpc_port = 8831
 log_level = "debug"
-enable_cluster = true
 
 [query]
 read_parallelism = 8

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -121,7 +121,7 @@ impl From<&StaticTopologyConfig> for ClusterView {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
-pub struct ServiceConfig {
+pub struct ServerConfig {
     /// The address to listen.
     pub bind_addr: String,
     pub mysql_port: u16,
@@ -132,13 +132,14 @@ pub struct ServiceConfig {
     pub timeout: Option<ReadableDuration>,
     /// The minimum length of the response body to compress.
     pub resp_compress_min_length: ReadableSize,
+    pub deploy_mode: DeployMode,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(default)]
 pub struct Config {
-    /// Config for service, including http, mysql and grpc.
-    pub service: ServiceConfig,
+    /// Config for service of server, including http, mysql and grpc.
+    pub server: ServerConfig,
     pub runtime: RuntimeConfig,
 
     /// Log related configs:
@@ -161,7 +162,6 @@ pub struct Config {
     pub query: query_engine::Config,
 
     /// Deployment configs:
-    pub deploy_mode: DeployMode,
     pub cluster: ClusterConfig,
 
     /// Config of limiter
@@ -182,7 +182,7 @@ impl Default for RuntimeConfig {
     }
 }
 
-impl Default for ServiceConfig {
+impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             bind_addr: String::from("127.0.0.1"),
@@ -193,6 +193,7 @@ impl Default for ServiceConfig {
             grpc_server_cq_count: 20,
             timeout: None,
             resp_compress_min_length: ReadableSize::mb(4),
+            deploy_mode: DeployMode::Standalone,
         }
     }
 }
@@ -200,7 +201,7 @@ impl Default for ServiceConfig {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            service: ServiceConfig::default(),
+            server: ServerConfig::default(),
             runtime: RuntimeConfig::default(),
             log_level: "debug".to_string(),
             enable_async_log: true,
@@ -211,7 +212,6 @@ impl Default for Config {
             static_route: StaticRouteConfig::default(),
             query: query_engine::Config::default(),
             analytic: analytic_engine::Config::default(),
-            deploy_mode: DeployMode::Standalone,
             cluster: ClusterConfig::default(),
             limiter: LimiterConfig::default(),
             forward: forward::Config::default(),

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -283,14 +283,14 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
 
         // Create http config
         let endpoint = Endpoint {
-            addr: self.config.service.bind_addr.clone(),
-            port: self.config.service.http_port,
+            addr: self.config.server.bind_addr.clone(),
+            port: self.config.server.http_port,
         };
 
         let http_config = HttpConfig {
             endpoint,
-            max_body_size: self.config.service.http_max_body_size,
-            timeout: self.config.service.timeout.map(|v| v.0),
+            max_body_size: self.config.server.http_max_body_size,
+            timeout: self.config.server.timeout.map(|v| v.0),
         };
 
         // Start http service
@@ -308,9 +308,9 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .context(StartHttpService)?;
 
         let mysql_config = mysql::MysqlConfig {
-            ip: self.config.service.bind_addr.clone(),
-            port: self.config.service.mysql_port,
-            timeout: self.config.service.timeout.map(|v| v.0),
+            ip: self.config.server.bind_addr.clone(),
+            port: self.config.server.mysql_port,
+            timeout: self.config.server.timeout.map(|v| v.0),
         };
 
         let mysql_service = mysql::Builder::new(mysql_config)
@@ -322,15 +322,15 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
         let router = self.router.context(MissingRouter)?;
         let rpc_services = grpc::Builder::new()
             .endpoint(
-                Endpoint::new(self.config.service.bind_addr, self.config.service.grpc_port)
+                Endpoint::new(self.config.server.bind_addr, self.config.server.grpc_port)
                     .to_string(),
             )
             .local_endpoint(
-                Endpoint::new(self.config.cluster.node.addr, self.config.service.grpc_port)
+                Endpoint::new(self.config.cluster.node.addr, self.config.server.grpc_port)
                     .to_string(),
             )
             .resp_compress_min_length(
-                self.config.service.resp_compress_min_length.as_bytes() as usize
+                self.config.server.resp_compress_min_length.as_bytes() as usize
             )
             .runtimes(engine_runtimes)
             .instance(instance.clone())
@@ -338,7 +338,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .cluster(self.cluster.clone())
             .schema_config_provider(provider)
             .forward_config(self.config.forward)
-            .timeout(self.config.service.timeout.map(|v| v.0))
+            .timeout(self.config.server.timeout.map(|v| v.0))
             .build()
             .context(BuildGrpcService)?;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -142,7 +142,7 @@ async fn run_server_with_runtimes<T>(
         .limiter(limiter);
 
     let engine_builder = T::default();
-    let builder = match config.deploy_mode {
+    let builder = match config.server.deploy_mode {
         DeployMode::Standalone => {
             build_in_standalone_mode(&config, builder, runtimes.clone(), engine_builder).await
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 It is strange that `DeployMode` is placed in the top-level configuration, it needs to be placed in a sub-configuration.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
The `service` section in config is renamed to `server`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
The `service` section in config is renamed to `server`.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Manual testing.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
