### PR TITLE
fix: fix varbinary type error

### DIFF
--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -213,6 +213,7 @@ impl TryFrom<&SqlDataType> for DatumKind {
             SqlDataType::Int(_) => Ok(Self::Int32),
             SqlDataType::SmallInt(_) => Ok(Self::Int16),
             SqlDataType::String => Ok(Self::String),
+            SqlDataType::Varbinary(_) => Ok(Self::Varbinary),
             SqlDataType::Custom(objects, _) if objects.0.len() == 1 => {
                 match objects.0[0].value.as_str() {
                     "UINT64" | "uint64" => Ok(Self::UInt64),
@@ -223,7 +224,6 @@ impl TryFrom<&SqlDataType> for DatumKind {
                     "INT32" | "int32" => Ok(Self::Int32),
                     "INT16" | "int16" => Ok(Self::Int16),
                     "TINYINT" | "INT8" | "tinyint" | "int8" => Ok(Self::Int8),
-                    "VARBINARY" | "varbinary" => Ok(Self::Varbinary),
                     _ => UnsupportedDataType {
                         sql_type: sql_type.clone(),
                     }

--- a/integration_tests/cases/local/03_dml/issue-637.result
+++ b/integration_tests/cases/local/03_dml/issue-637.result
@@ -1,0 +1,31 @@
+DROP TABLE IF EXISTS `issue637`;
+
+affected_rows: 0
+
+CREATE TABLE IF NOT EXISTS `issue637`
+(
+    str_tag string TAG,
+    int_tag int32 TAG,
+    var_tag VARBINARY TAG,
+    str_field string,
+    int_field int32,
+    bin_field string,
+    t timestamp NOT NULL,
+     TIMESTAMP KEY (t)
+) ENGINE=Analytic with(enable_ttl = 'false');
+
+affected_rows: 0
+
+INSERT INTO issue637
+    (`str_tag`,`int_tag`,`var_tag`,`str_field`,`int_field`,`bin_field`,`t`)
+VALUES
+    ("t1",1,"v1","s1",1,"b1",1651737067000);
+
+affected_rows: 1
+
+select * from `issue637`;
+
+tsid,t,str_tag,int_tag,var_tag,str_field,int_field,bin_field,
+UInt64(15527369105987057363),Timestamp(1651737067000),String("t1"),Int32(1),Varbinary([118, 49]),String("s1"),Int32(1),String("b1"),
+
+

--- a/integration_tests/cases/local/03_dml/issue-637.result
+++ b/integration_tests/cases/local/03_dml/issue-637.result
@@ -23,9 +23,43 @@ VALUES
 
 affected_rows: 1
 
-select * from `issue637`;
+SELECT * FROM `issue637`;
 
 tsid,t,str_tag,int_tag,var_tag,str_field,int_field,bin_field,
 UInt64(15527369105987057363),Timestamp(1651737067000),String("t1"),Int32(1),Varbinary([118, 49]),String("s1"),Int32(1),String("b1"),
+
+
+CREATE TABLE IF NOT EXISTS `issue637_1`
+(
+    t timestamp NOT NULL,
+    double_filed double,
+    float_filed float,
+    str_field string,
+    var_field varbinary,
+    u64_field uint64,
+    u32_field uint32,
+    u16_field uint16,
+    u8_field uint8,
+    i64_field int64,
+    i32_field int32,
+    i16_field int16,
+    i8_field int8,
+    bool_field boolean,
+    TIMESTAMP KEY (t)
+) ENGINE=Analytic with(enable_ttl = 'false');
+
+affected_rows: 0
+
+INSERT INTO issue637_1
+    (`t`,`double_filed`,`float_filed`,`str_field`,`var_field`,`u64_field`,`u32_field`,`u16_field`,`u8_field`,`i64_field`,`i32_field`,`i16_field`,`i8_field`,`bool_field`)
+VALUES
+    (1651737067000,100,100,"s","v",100,100,100,100,100,100,100,100,false);
+
+affected_rows: 1
+
+SELECT * FROM `issue637_1`;
+
+tsid,t,double_filed,float_filed,str_field,var_field,u64_field,u32_field,u16_field,u8_field,i64_field,i32_field,i16_field,i8_field,bool_field,
+UInt64(0),Timestamp(1651737067000),Double(100.0),Float(100.0),String("s"),Varbinary([118]),UInt64(100),UInt32(100),UInt16(100),UInt8(100),Int64(100),Int32(100),Int16(100),Int8(100),Boolean(false),
 
 

--- a/integration_tests/cases/local/03_dml/issue-637.sql
+++ b/integration_tests/cases/local/03_dml/issue-637.sql
@@ -1,0 +1,22 @@
+DROP TABLE IF EXISTS `issue637`;
+
+CREATE TABLE IF NOT EXISTS `issue637`
+(
+    str_tag string TAG,
+    int_tag int32 TAG,
+    var_tag VARBINARY TAG,
+    str_field string,
+    int_field int32,
+    bin_field string,
+    t timestamp NOT NULL,
+     TIMESTAMP KEY (t)
+) ENGINE=Analytic with(enable_ttl = 'false');
+
+
+INSERT INTO issue637
+    (`str_tag`,`int_tag`,`var_tag`,`str_field`,`int_field`,`bin_field`,`t`)
+VALUES
+    ("t1",1,"v1","s1",1,"b1",1651737067000);
+
+select * from `issue637`;
+

--- a/integration_tests/cases/local/03_dml/issue-637.sql
+++ b/integration_tests/cases/local/03_dml/issue-637.sql
@@ -18,5 +18,31 @@ INSERT INTO issue637
 VALUES
     ("t1",1,"v1","s1",1,"b1",1651737067000);
 
-select * from `issue637`;
+SELECT * FROM `issue637`;
 
+-- Test all data types mentioned in our user document.
+CREATE TABLE IF NOT EXISTS `issue637_1`
+(
+    t timestamp NOT NULL,
+    double_filed double,
+    float_filed float,
+    str_field string,
+    var_field varbinary,
+    u64_field uint64,
+    u32_field uint32,
+    u16_field uint16,
+    u8_field uint8,
+    i64_field int64,
+    i32_field int32,
+    i16_field int16,
+    i8_field int8,
+    bool_field boolean,
+    TIMESTAMP KEY (t)
+) ENGINE=Analytic with(enable_ttl = 'false');
+
+INSERT INTO issue637_1
+    (`t`,`double_filed`,`float_filed`,`str_field`,`var_field`,`u64_field`,`u32_field`,`u16_field`,`u8_field`,`i64_field`,`i32_field`,`i16_field`,`i8_field`,`bool_field`)
+VALUES
+    (1651737067000,100,100,"s","v",100,100,100,100,100,100,100,100,false);
+
+SELECT * FROM `issue637_1`;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #637 

# Rationale for this change
Fix the problem of table creation failure mentioned in issue.

# What changes are included in this PR?
* Fix `SqlDataType` convert error.
* Add create table test with `VARBINARY` type. 

# Are there any user-facing changes?
User could create table with `VARBINARY` type normally.

# How does this change test
Pass integration tests.
