### PR TITLE
refactor: remove encoder method from WalManager

### DIFF
--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -190,18 +190,6 @@ pub enum Error {
     StoreVersionEdit { source: GenericError },
 
     #[snafu(display(
-        "Failed to get to log batch encoder, table:{}, wal_location:{:?}, err:{}",
-        table,
-        wal_location,
-        source
-    ))]
-    GetLogBatchEncoder {
-        table: String,
-        wal_location: WalLocation,
-        source: wal::manager::Error,
-    },
-
-    #[snafu(display(
         "Failed to encode payloads, table:{}, wal_location:{:?}, err:{}",
         table,
         wal_location,
@@ -252,7 +240,6 @@ impl From<Error> for table_engine::engine::Error {
             | Error::OperateByWriteWorker { .. }
             | Error::FlushTable { .. }
             | Error::StoreVersionEdit { .. }
-            | Error::GetLogBatchEncoder { .. }
             | Error::EncodePayloads { .. }
             | Error::DoManifestSnapshot { .. } => Self::Unexpected {
                 source: Box::new(err),

--- a/benchmarks/src/wal_write_bench.rs
+++ b/benchmarks/src/wal_write_bench.rs
@@ -8,6 +8,7 @@ use common_util::runtime::Runtime;
 use rand::prelude::*;
 use table_kv::memory::MemoryImpl;
 use wal::{
+    kv_encoder::LogBatchEncoder,
     manager::{WalLocation, WalManager, WriteContext},
     table_kv_impl::{model::NamespaceConfig, wal::WalNamespaceImpl, WalRuntimes},
 };
@@ -74,9 +75,7 @@ impl WalWriteBench {
             .expect("should succeed to open WalNamespaceImpl(Memory)");
 
             let values = self.build_value_vec();
-            let wal_encoder = wal
-                .encoder(WalLocation::new(1, 1, 1))
-                .expect("should succeed to create wal encoder");
+            let wal_encoder = LogBatchEncoder::create(WalLocation::new(1, 1, 1));
             let log_batch = wal_encoder
                 .encode_batch::<WritePayload, Vec<u8>>(values.as_slice())
                 .expect("should succeed to encode payload batch");

--- a/wal/src/lib.rs
+++ b/wal/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! Write Ahead Log
 
-mod kv_encoder;
+pub mod kv_encoder;
 pub mod log_batch;
 pub mod manager;
 pub mod message_queue_impl;

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -15,7 +15,6 @@ pub use error::*;
 use snafu::ResultExt;
 
 use crate::{
-    kv_encoder::LogBatchEncoder,
     log_batch::{LogEntry, LogWriteBatch, PayloadDecoder},
     manager,
 };
@@ -319,11 +318,6 @@ pub trait WalManager: Send + Sync + fmt::Debug + 'static {
         ctx: &ReadContext,
         req: &ReadRequest,
     ) -> Result<BatchLogIteratorAdapter>;
-
-    /// Provide the encoder for encoding payloads.
-    fn encoder(&self, location: WalLocation) -> Result<LogBatchEncoder> {
-        Ok(LogBatchEncoder::create(location))
-    }
 
     /// Write a batch of log entries to log.
     ///

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -25,6 +25,7 @@ use table_kv::memory::MemoryImpl;
 use tempfile::TempDir;
 
 use crate::{
+    kv_encoder::LogBatchEncoder,
     log_batch::{LogWriteBatch, Payload, PayloadDecoder},
     manager::{
         BatchLogIteratorAdapter, ReadContext, WalLocation, WalManager, WalManagerRef, WriteContext,
@@ -204,17 +205,13 @@ impl<B: WalBuilder> TestEnv<B> {
     /// Build the log batch with [TestPayload].val range [start, end).
     pub async fn build_log_batch(
         &self,
-        wal: WalManagerRef,
         location: WalLocation,
         start: u32,
         end: u32,
     ) -> (Vec<TestPayload>, LogWriteBatch) {
         let log_entries = (start..end).collect::<Vec<_>>();
 
-        let log_batch_encoder = wal
-            .encoder(location)
-            .expect("should succeed to create log batch encoder");
-
+        let log_batch_encoder = LogBatchEncoder::create(location);
         let log_batch = log_batch_encoder
             .encode_batch::<TestPayload, u32>(&log_entries)
             .expect("should succeed to encode payloads");


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Currently, the default implementation of `encoder` method in `WalManager` trait is useless because callers can use the `LogBatchEncoder` directly to create such encoder.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Remove the `encode` method defined in `WalManager`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
