### PR TITLE
refactor: remove cluster version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5637,6 +5637,7 @@ dependencies = [
  "tokio 1.25.0",
  "tokio-stream",
  "tonic",
+ "wal",
  "warp",
  "zstd 0.12.1+zstd.1.5.2",
 ]

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -76,7 +76,6 @@ impl Instance {
         let snapshot_request = SnapshotRequest {
             space_id: space.id,
             table_id: table_data.id,
-            cluster_version: table_data.shard_info.cluster_version,
             shard_id: table_data.shard_info.shard_id,
         };
         self.space_store

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -231,9 +231,5 @@ pub type InstanceRef = Arc<Instance>;
 
 #[inline]
 pub(crate) fn create_wal_location(table_id: TableId, shard_info: TableShardInfo) -> WalLocation {
-    WalLocation::new(
-        shard_info.shard_id as u64,
-        shard_info.cluster_version,
-        table_id,
-    )
+    WalLocation::new(shard_info.shard_id as u64, table_id)
 }

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -216,7 +216,6 @@ impl Instance {
         let load_req = LoadRequest {
             space_id,
             table_id,
-            cluster_version: request.cluster_version,
             shard_id: request.shard_id,
         };
         let manifest_data = self

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -291,11 +291,7 @@ impl Manifest for ManifestImpl {
 
         let table_id = request.meta_update.table_id();
         let shard_id = request.shard_info.shard_id;
-        let location = WalLocation::new(
-            shard_id as u64,
-            request.shard_info.cluster_version,
-            table_id.as_u64(),
-        );
+        let location = WalLocation::new(shard_id as u64, table_id.as_u64());
         let space_id = request.meta_update.space_id();
         let table_id = request.meta_update.table_id();
         self.store_update_to_wal(request.meta_update, location)
@@ -310,11 +306,7 @@ impl Manifest for ManifestImpl {
     async fn load_data(&self, load_req: &LoadRequest) -> GenericResult<Option<TableManifestData>> {
         info!("Manifest load data, request:{:?}", load_req);
 
-        let location = WalLocation::new(
-            load_req.shard_id as u64,
-            load_req.cluster_version,
-            load_req.table_id.as_u64(),
-        );
+        let location = WalLocation::new(load_req.shard_id as u64, load_req.table_id.as_u64());
 
         let log_store = WalBasedLogStore {
             opts: self.opts.clone(),
@@ -340,11 +332,7 @@ impl Manifest for ManifestImpl {
         info!("Manifest do snapshot, request:{:?}", request);
 
         let table_id = request.table_id;
-        let location = WalLocation::new(
-            request.shard_id as u64,
-            request.cluster_version,
-            table_id.as_u64(),
-        );
+        let location = WalLocation::new(request.shard_id as u64, table_id.as_u64());
         let space_id = request.space_id;
         let table_id = request.table_id;
 
@@ -1078,7 +1066,6 @@ mod tests {
             let load_req = LoadRequest {
                 table_id,
                 shard_id: DEFAULT_SHARD_ID,
-                cluster_version: DEFAULT_CLUSTER_VERSION,
                 space_id: ctx.schema_id.as_u32(),
             };
             let expected_table_manifest_data = manifest_data_builder.build();
@@ -1161,11 +1148,7 @@ mod tests {
                 expr: Bytes::from("test"),
                 linear: false,
             }));
-            let location = WalLocation::new(
-                DEFAULT_SHARD_ID as u64,
-                DEFAULT_CLUSTER_VERSION,
-                table_id.as_u64(),
-            );
+            let location = WalLocation::new(DEFAULT_SHARD_ID as u64, table_id.as_u64());
             let mut manifest_data_builder = TableManifestDataBuilder::default();
             let manifest = ctx.open_manifest().await;
             ctx.add_table_with_manifest(
@@ -1191,7 +1174,6 @@ mod tests {
             let load_req = LoadRequest {
                 space_id: ctx.schema_id.as_u32(),
                 table_id,
-                cluster_version: DEFAULT_CLUSTER_VERSION,
                 shard_id: DEFAULT_SHARD_ID,
             };
             ctx.check_table_manifest_data_with_manifest(
@@ -1212,7 +1194,6 @@ mod tests {
             let load_req = LoadRequest {
                 space_id: ctx.schema_id.as_u32(),
                 table_id,
-                cluster_version: DEFAULT_CLUSTER_VERSION,
                 shard_id: table_id.as_u64() as u32,
             };
             let mut manifest_data_builder = TableManifestDataBuilder::default();
@@ -1236,11 +1217,7 @@ mod tests {
             )
             .await;
 
-            let location = WalLocation::new(
-                DEFAULT_SHARD_ID as u64,
-                DEFAULT_CLUSTER_VERSION,
-                table_id.as_u64(),
-            );
+            let location = WalLocation::new(DEFAULT_SHARD_ID as u64, table_id.as_u64());
             manifest
                 .maybe_do_snapshot(ctx.schema_id.as_u32(), table_id, location, true)
                 .await
@@ -1369,11 +1346,7 @@ mod tests {
         input_updates: Vec<MetaUpdate>,
         updates_after_snapshot: Vec<MetaUpdate>,
     ) {
-        let location = WalLocation::new(
-            DEFAULT_SHARD_ID as u64,
-            DEFAULT_CLUSTER_VERSION,
-            table_id.as_u64(),
-        );
+        let location = WalLocation::new(DEFAULT_SHARD_ID as u64, table_id.as_u64());
         let log_store = MemLogStore::from_updates(&input_updates);
         let snapshot_store = MemSnapshotStore::new();
 

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -22,7 +22,6 @@ use crate::{
 pub struct LoadRequest {
     pub space_id: SpaceId,
     pub table_id: TableId,
-    pub cluster_version: u64,
     pub shard_id: ShardId,
 }
 

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -157,10 +157,10 @@ pub trait WalsOpener: Send + Sync + Default {
 
 /// [RocksEngine] builder.
 #[derive(Default)]
-pub struct RocksDBWalEngineBuilder;
+pub struct RocksDBWalsOpener;
 
 #[async_trait]
-impl WalsOpener for RocksDBWalEngineBuilder {
+impl WalsOpener for RocksDBWalsOpener {
     async fn open_wals(
         &self,
         config: &WalStorageConfig,
@@ -201,10 +201,10 @@ impl WalsOpener for RocksDBWalEngineBuilder {
 
 /// [ReplicatedEngine] builder.
 #[derive(Default)]
-pub struct ObkvWalEngineBuilder;
+pub struct ObkvWalsOpener;
 
 #[async_trait]
-impl WalsOpener for ObkvWalEngineBuilder {
+impl WalsOpener for ObkvWalsOpener {
     async fn open_wals(
         &self,
         config: &WalStorageConfig,
@@ -239,12 +239,12 @@ impl WalsOpener for ObkvWalEngineBuilder {
 /// All engine built by this builder share same [MemoryImpl] instance, so the
 /// data wrote by the engine still remains after the engine dropped.
 #[derive(Default)]
-pub struct MemWalEngineBuilder {
+pub struct MemWalsOpener {
     table_kv: MemoryImpl,
 }
 
 #[async_trait]
-impl WalsOpener for MemWalEngineBuilder {
+impl WalsOpener for MemWalsOpener {
     async fn open_wals(
         &self,
         config: &WalStorageConfig,
@@ -272,10 +272,10 @@ impl WalsOpener for MemWalEngineBuilder {
 }
 
 #[derive(Default)]
-pub struct KafkaWalEngineBuilder;
+pub struct KafkaWalsOpener;
 
 #[async_trait]
-impl WalsOpener for KafkaWalEngineBuilder {
+impl WalsOpener for KafkaWalsOpener {
     async fn open_wals(
         &self,
         config: &WalStorageConfig,

--- a/analytic_engine/src/tests/alter_test.rs
+++ b/analytic_engine/src/tests/alter_test.rs
@@ -20,7 +20,8 @@ use crate::{
         row_util,
         table::{self, FixedSchemaTable},
         util::{
-            EngineContext, MemoryEngineContext, Null, RocksDBEngineContext, TestContext, TestEnv,
+            EngineBuildContext, MemoryEngineBuildContext, Null, RocksDBEngineContext, TestContext,
+            TestEnv,
         },
     },
 };
@@ -34,11 +35,11 @@ fn test_alter_table_add_column_rocks() {
 #[ignore = "Enable this test when manifest use another snapshot implementation"]
 #[test]
 fn test_alter_table_add_column_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_alter_table_add_column(memory_ctx);
 }
 
-fn test_alter_table_add_column<T: EngineContext>(engine_context: T) {
+fn test_alter_table_add_column<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -109,7 +110,7 @@ fn add_columns(schema_builder: schema::Builder) -> schema::Builder {
         .unwrap()
 }
 
-async fn alter_schema_same_schema_version_case<T: EngineContext>(
+async fn alter_schema_same_schema_version_case<T: EngineBuildContext>(
     test_ctx: &TestContext<T>,
     table_name: &str,
 ) {
@@ -131,7 +132,7 @@ async fn alter_schema_same_schema_version_case<T: EngineContext>(
     assert!(res.is_err());
 }
 
-async fn alter_schema_old_pre_version_case<T: EngineContext>(
+async fn alter_schema_old_pre_version_case<T: EngineBuildContext>(
     test_ctx: &TestContext<T>,
     table_name: &str,
 ) {
@@ -157,7 +158,7 @@ async fn alter_schema_old_pre_version_case<T: EngineContext>(
     assert!(res.is_err());
 }
 
-async fn alter_schema_add_column_case<T: EngineContext>(
+async fn alter_schema_add_column_case<T: EngineBuildContext>(
     test_ctx: &mut TestContext<T>,
     table_name: &str,
     start_ms: i64,
@@ -345,7 +346,7 @@ async fn alter_schema_add_column_case<T: EngineContext>(
     .await;
 }
 
-async fn check_read_row_group<T: EngineContext>(
+async fn check_read_row_group<T: EngineBuildContext>(
     test_ctx: &TestContext<T>,
     msg: &str,
     table_name: &str,
@@ -375,11 +376,11 @@ fn test_alter_table_options_rocks() {
 #[ignore = "Enable this test when manifest use another snapshot implementation"]
 #[test]
 fn test_alter_table_options_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_alter_table_options(memory_ctx);
 }
 
-fn test_alter_table_options<T: EngineContext>(engine_context: T) {
+fn test_alter_table_options<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -418,7 +419,7 @@ fn test_alter_table_options<T: EngineContext>(engine_context: T) {
     });
 }
 
-async fn alter_immutable_option_case<T: EngineContext>(
+async fn alter_immutable_option_case<T: EngineBuildContext>(
     test_ctx: &TestContext<T>,
     table_name: &str,
     opt_key: &str,
@@ -439,7 +440,7 @@ async fn alter_immutable_option_case<T: EngineContext>(
     assert_options_eq(&old_opts, &opts_after_alter);
 }
 
-async fn alter_mutable_option_case<T: EngineContext>(
+async fn alter_mutable_option_case<T: EngineBuildContext>(
     test_ctx: &mut TestContext<T>,
     table_name: &str,
     opt_key: &str,

--- a/analytic_engine/src/tests/alter_test.rs
+++ b/analytic_engine/src/tests/alter_test.rs
@@ -15,6 +15,7 @@ use log::info;
 use table_engine::table::AlterSchemaRequest;
 
 use crate::{
+    setup::WalsOpener,
     table_options::TableOptions,
     tests::{
         row_util,
@@ -110,7 +111,7 @@ fn add_columns(schema_builder: schema::Builder) -> schema::Builder {
         .unwrap()
 }
 
-async fn alter_schema_same_schema_version_case<T: EngineBuildContext>(
+async fn alter_schema_same_schema_version_case<T: WalsOpener>(
     test_ctx: &TestContext<T>,
     table_name: &str,
 ) {
@@ -132,7 +133,7 @@ async fn alter_schema_same_schema_version_case<T: EngineBuildContext>(
     assert!(res.is_err());
 }
 
-async fn alter_schema_old_pre_version_case<T: EngineBuildContext>(
+async fn alter_schema_old_pre_version_case<T: WalsOpener>(
     test_ctx: &TestContext<T>,
     table_name: &str,
 ) {
@@ -158,7 +159,7 @@ async fn alter_schema_old_pre_version_case<T: EngineBuildContext>(
     assert!(res.is_err());
 }
 
-async fn alter_schema_add_column_case<T: EngineBuildContext>(
+async fn alter_schema_add_column_case<T: WalsOpener>(
     test_ctx: &mut TestContext<T>,
     table_name: &str,
     start_ms: i64,
@@ -346,7 +347,7 @@ async fn alter_schema_add_column_case<T: EngineBuildContext>(
     .await;
 }
 
-async fn check_read_row_group<T: EngineBuildContext>(
+async fn check_read_row_group<T: WalsOpener>(
     test_ctx: &TestContext<T>,
     msg: &str,
     table_name: &str,
@@ -419,7 +420,7 @@ fn test_alter_table_options<T: EngineBuildContext>(engine_context: T) {
     });
 }
 
-async fn alter_immutable_option_case<T: EngineBuildContext>(
+async fn alter_immutable_option_case<T: WalsOpener>(
     test_ctx: &TestContext<T>,
     table_name: &str,
     opt_key: &str,
@@ -440,7 +441,7 @@ async fn alter_immutable_option_case<T: EngineBuildContext>(
     assert_options_eq(&old_opts, &opts_after_alter);
 }
 
-async fn alter_mutable_option_case<T: EngineBuildContext>(
+async fn alter_mutable_option_case<T: WalsOpener>(
     test_ctx: &mut TestContext<T>,
     table_name: &str,
     opt_key: &str,

--- a/analytic_engine/src/tests/alter_test.rs
+++ b/analytic_engine/src/tests/alter_test.rs
@@ -20,15 +20,15 @@ use crate::{
         row_util,
         table::{self, FixedSchemaTable},
         util::{
-            EngineBuildContext, MemoryEngineBuildContext, Null, RocksDBEngineContext, TestContext,
-            TestEnv,
+            EngineBuildContext, MemoryEngineBuildContext, Null, RocksDBEngineBuildContext,
+            TestContext, TestEnv,
         },
     },
 };
 
 #[test]
 fn test_alter_table_add_column_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_alter_table_add_column(rocksdb_ctx);
 }
 
@@ -369,7 +369,7 @@ async fn check_read_row_group<T: EngineBuildContext>(
 
 #[test]
 fn test_alter_table_options_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_alter_table_options(rocksdb_ctx);
 }
 

--- a/analytic_engine/src/tests/compaction_test.rs
+++ b/analytic_engine/src/tests/compaction_test.rs
@@ -8,14 +8,14 @@ use table_engine::table::FlushRequest;
 use crate::{
     compaction::SizeTieredCompactionOptions,
     tests::util::{
-        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestEnv,
+        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineBuildContext, TestEnv,
     },
 };
 
 #[test]
 #[ignore = "https://github.com/CeresDB/ceresdb/issues/427"]
 fn test_table_compact_current_segment_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_table_compact_current_segment(rocksdb_ctx);
 }
 

--- a/analytic_engine/src/tests/compaction_test.rs
+++ b/analytic_engine/src/tests/compaction_test.rs
@@ -7,7 +7,9 @@ use table_engine::table::FlushRequest;
 
 use crate::{
     compaction::SizeTieredCompactionOptions,
-    tests::util::{self, EngineContext, MemoryEngineContext, RocksDBEngineContext, TestEnv},
+    tests::util::{
+        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestEnv,
+    },
 };
 
 #[test]
@@ -20,11 +22,11 @@ fn test_table_compact_current_segment_rocks() {
 #[test]
 #[ignore = "https://github.com/CeresDB/ceresdb/issues/427"]
 fn test_table_compact_current_segment_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_table_compact_current_segment(memory_ctx);
 }
 
-fn test_table_compact_current_segment<T: EngineContext>(engine_context: T) {
+fn test_table_compact_current_segment<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 

--- a/analytic_engine/src/tests/drop_test.rs
+++ b/analytic_engine/src/tests/drop_test.rs
@@ -9,12 +9,14 @@ use table_engine::table::AlterSchemaRequest;
 
 use crate::tests::{
     table::FixedSchemaTable,
-    util::{self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestEnv},
+    util::{
+        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineBuildContext, TestEnv,
+    },
 };
 
 #[test]
 fn test_drop_table_once_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_drop_table_once(rocksdb_ctx);
 }
 
@@ -57,7 +59,7 @@ fn test_drop_table_once<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_drop_table_again_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_drop_table_again(rocksdb_ctx);
 }
 
@@ -94,7 +96,7 @@ fn test_drop_table_again<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_drop_create_table_mixed_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_drop_create_table_mixed(rocksdb_ctx);
 }
 
@@ -207,7 +209,7 @@ fn test_drop_create_same_table_case<T: EngineBuildContext>(flush: bool, engine_c
 
 #[test]
 fn test_drop_create_same_table_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_drop_create_same_table(rocksdb_ctx);
 }
 
@@ -225,7 +227,7 @@ fn test_drop_create_same_table<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_alter_schema_drop_create_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_alter_schema_drop_create(rocksdb_ctx);
 }
 
@@ -282,7 +284,7 @@ fn test_alter_schema_drop_create<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_alter_options_drop_create_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_alter_options_drop_create(rocksdb_ctx);
 }
 

--- a/analytic_engine/src/tests/drop_test.rs
+++ b/analytic_engine/src/tests/drop_test.rs
@@ -9,7 +9,7 @@ use table_engine::table::AlterSchemaRequest;
 
 use crate::tests::{
     table::FixedSchemaTable,
-    util::{self, EngineContext, MemoryEngineContext, RocksDBEngineContext, TestEnv},
+    util::{self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestEnv},
 };
 
 #[test]
@@ -20,11 +20,11 @@ fn test_drop_table_once_rocks() {
 
 #[test]
 fn test_drop_table_once_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_drop_table_once(memory_ctx);
 }
 
-fn test_drop_table_once<T: EngineContext>(engine_context: T) {
+fn test_drop_table_once<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -63,11 +63,11 @@ fn test_drop_table_again_rocks() {
 
 #[test]
 fn test_drop_table_again_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_drop_table_again(memory_ctx);
 }
 
-fn test_drop_table_again<T: EngineContext>(engine_context: T) {
+fn test_drop_table_again<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -100,11 +100,11 @@ fn test_drop_create_table_mixed_rocks() {
 
 #[test]
 fn test_drop_create_table_mixed_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_drop_create_table_mixed(memory_ctx);
 }
 
-fn test_drop_create_table_mixed<T: EngineContext>(engine_context: T) {
+fn test_drop_create_table_mixed<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -148,7 +148,7 @@ fn test_drop_create_table_mixed<T: EngineContext>(engine_context: T) {
     });
 }
 
-fn test_drop_create_same_table_case<T: EngineContext>(flush: bool, engine_context: T) {
+fn test_drop_create_same_table_case<T: EngineBuildContext>(flush: bool, engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -213,11 +213,11 @@ fn test_drop_create_same_table_rocks() {
 
 #[test]
 fn test_drop_create_same_table_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_drop_create_same_table(memory_ctx);
 }
 
-fn test_drop_create_same_table<T: EngineContext>(engine_context: T) {
+fn test_drop_create_same_table<T: EngineBuildContext>(engine_context: T) {
     test_drop_create_same_table_case::<T>(false, engine_context.clone());
 
     test_drop_create_same_table_case::<T>(true, engine_context);
@@ -231,11 +231,11 @@ fn test_alter_schema_drop_create_rocks() {
 
 #[test]
 fn test_alter_schema_drop_create_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_alter_schema_drop_create(memory_ctx);
 }
 
-fn test_alter_schema_drop_create<T: EngineContext>(engine_context: T) {
+fn test_alter_schema_drop_create<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -288,11 +288,11 @@ fn test_alter_options_drop_create_rocks() {
 
 #[test]
 fn test_alter_options_drop_create_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_alter_options_drop_create(memory_ctx);
 }
 
-fn test_alter_options_drop_create<T: EngineContext>(engine_context: T) {
+fn test_alter_options_drop_create<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 

--- a/analytic_engine/src/tests/open_test.rs
+++ b/analytic_engine/src/tests/open_test.rs
@@ -2,7 +2,9 @@
 
 //! Engine open test.
 
-use crate::tests::util::{EngineContext, MemoryEngineContext, RocksDBEngineContext, TestEnv};
+use crate::tests::util::{
+    EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestEnv,
+};
 
 #[test]
 fn test_open_engine_rocks() {
@@ -12,11 +14,11 @@ fn test_open_engine_rocks() {
 
 #[test]
 fn test_open_engine_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_open_engine(memory_ctx);
 }
 
-fn test_open_engine<T: EngineContext>(engine_context: T) {
+fn test_open_engine<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 

--- a/analytic_engine/src/tests/open_test.rs
+++ b/analytic_engine/src/tests/open_test.rs
@@ -3,12 +3,12 @@
 //! Engine open test.
 
 use crate::tests::util::{
-    EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestEnv,
+    EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineBuildContext, TestEnv,
 };
 
 #[test]
 fn test_open_engine_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_open_engine(rocksdb_ctx);
 }
 

--- a/analytic_engine/src/tests/read_write_test.rs
+++ b/analytic_engine/src/tests/read_write_test.rs
@@ -519,9 +519,9 @@ fn test_db_write_buffer_size_mem_wal() {
 }
 
 fn test_db_write_buffer_size<T: EngineBuildContext>(table_name: &str, engine_context: T) {
-    let mut env = TestEnv::builder().build();
-    env.config.db_write_buffer_size = 1;
-    let test_ctx = env.new_context(engine_context);
+    let env = TestEnv::builder().build();
+    let mut test_ctx = env.new_context(engine_context);
+    test_ctx.config_mut().db_write_buffer_size = 1;
     test_write_buffer_size_overflow(table_name, env, test_ctx);
 }
 
@@ -540,18 +540,17 @@ fn test_space_write_buffer_size_mem_wal() {
 }
 
 fn test_space_write_buffer_size<T: EngineBuildContext>(table_name: &str, engine_context: T) {
-    let mut env = TestEnv::builder().build();
-    env.config.db_write_buffer_size = 1;
-    let test_ctx = env.new_context(engine_context);
+    let env = TestEnv::builder().build();
+    let mut test_ctx = env.new_context(engine_context);
+    test_ctx.config_mut().space_write_buffer_size = 1;
     test_write_buffer_size_overflow(table_name, env, test_ctx);
 }
 
 fn test_write_buffer_size_overflow<T: WalsOpener>(
     test_table_name: &str,
     env: TestEnv,
-    test_ctx: TestContext<T>,
+    mut test_ctx: TestContext<T>,
 ) {
-    let mut test_ctx = test_ctx;
     env.block_on(async {
         test_ctx.open().await;
 

--- a/analytic_engine/src/tests/read_write_test.rs
+++ b/analytic_engine/src/tests/read_write_test.rs
@@ -9,6 +9,7 @@ use log::info;
 use table_engine::table::ReadOrder;
 
 use crate::{
+    setup::WalsOpener,
     table_options,
     tests::util::{
         self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineBuildContext, TestContext,
@@ -545,7 +546,7 @@ fn test_space_write_buffer_size<T: EngineBuildContext>(table_name: &str, engine_
     test_write_buffer_size_overflow(table_name, env, test_ctx);
 }
 
-fn test_write_buffer_size_overflow<T: EngineBuildContext>(
+fn test_write_buffer_size_overflow<T: WalsOpener>(
     test_table_name: &str,
     env: TestEnv,
     test_ctx: TestContext<T>,

--- a/analytic_engine/src/tests/read_write_test.rs
+++ b/analytic_engine/src/tests/read_write_test.rs
@@ -11,7 +11,8 @@ use table_engine::table::ReadOrder;
 use crate::{
     table_options,
     tests::util::{
-        self, EngineContext, MemoryEngineContext, RocksDBEngineContext, TestContext, TestEnv,
+        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestContext,
+        TestEnv,
     },
 };
 
@@ -23,11 +24,11 @@ fn test_multi_table_read_write_rocks() {
 
 #[test]
 fn test_multi_table_read_write_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_multi_table_read_write(memory_ctx);
 }
 
-fn test_multi_table_read_write<T: EngineContext>(engine_context: T) {
+fn test_multi_table_read_write<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -175,11 +176,11 @@ fn test_table_write_read_rocks() {
 
 #[test]
 fn test_table_write_read_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_table_write_read(memory_ctx);
 }
 
-fn test_table_write_read<T: EngineContext>(engine_context: T) {
+fn test_table_write_read<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -254,11 +255,11 @@ fn test_table_write_get_rocks() {
 
 #[test]
 fn test_table_write_get_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_table_write_get(memory_ctx);
 }
 
-fn test_table_write_get<T: EngineContext>(engine_context: T) {
+fn test_table_write_get<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -330,10 +331,10 @@ fn test_table_write_get_override_rocks() {
 
 #[test]
 fn test_table_write_get_override_mem_wal() {
-    test_table_write_get_override::<MemoryEngineContext>();
+    test_table_write_get_override::<MemoryEngineBuildContext>();
 }
 
-fn test_table_write_get_override<T: EngineContext>() {
+fn test_table_write_get_override<T: EngineBuildContext>() {
     test_table_write_get_override_case::<T>(FlushPoint::NoFlush, T::default());
 
     test_table_write_get_override_case::<T>(FlushPoint::AfterFirstWrite, T::default());
@@ -351,7 +352,7 @@ enum FlushPoint {
     FirstAndOverwrite,
 }
 
-fn test_table_write_get_override_case<T: EngineContext>(
+fn test_table_write_get_override_case<T: EngineBuildContext>(
     flush_point: FlushPoint,
     engine_context: T,
 ) {
@@ -511,15 +512,15 @@ fn test_db_write_buffer_size_rocks() {
 
 #[test]
 fn test_db_write_buffer_size_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     // Use different table name to avoid metrics collision.
     test_db_write_buffer_size("test_db_write_buffer_size_mem_wal", memory_ctx);
 }
 
-fn test_db_write_buffer_size<T: EngineContext>(table_name: &str, engine_context: T) {
-    let env = TestEnv::builder().build();
-    let mut test_ctx = env.new_context(engine_context);
-    test_ctx.context.config.db_write_buffer_size = 1;
+fn test_db_write_buffer_size<T: EngineBuildContext>(table_name: &str, engine_context: T) {
+    let mut env = TestEnv::builder().build();
+    env.config.db_write_buffer_size = 1;
+    let test_ctx = env.new_context(engine_context);
     test_write_buffer_size_overflow(table_name, env, test_ctx);
 }
 
@@ -532,19 +533,19 @@ fn test_space_write_buffer_size_rocks() {
 
 #[test]
 fn test_space_write_buffer_size_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     // Use different table name to avoid metrics collision.
     test_space_write_buffer_size("test_space_write_buffer_size_mem_wal", memory_ctx);
 }
 
-fn test_space_write_buffer_size<T: EngineContext>(table_name: &str, engine_context: T) {
-    let env = TestEnv::builder().build();
-    let mut test_ctx = env.new_context(engine_context);
-    test_ctx.context.config.space_write_buffer_size = 1;
+fn test_space_write_buffer_size<T: EngineBuildContext>(table_name: &str, engine_context: T) {
+    let mut env = TestEnv::builder().build();
+    env.config.db_write_buffer_size = 1;
+    let test_ctx = env.new_context(engine_context);
     test_write_buffer_size_overflow(table_name, env, test_ctx);
 }
 
-fn test_write_buffer_size_overflow<T: EngineContext>(
+fn test_write_buffer_size_overflow<T: EngineBuildContext>(
     test_table_name: &str,
     env: TestEnv,
     test_ctx: TestContext<T>,
@@ -665,11 +666,11 @@ fn test_table_write_read_reverse_rocks() {
 
 #[test]
 fn test_table_write_read_reverse_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_table_write_read_reverse(memory_ctx);
 }
 
-fn test_table_write_read_reverse<T: EngineContext>(engine_context: T) {
+fn test_table_write_read_reverse<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 
@@ -752,11 +753,11 @@ fn test_table_write_read_reverse_after_flush_rocks() {
 #[test]
 #[ignore = "https://github.com/CeresDB/ceresdb/issues/313"]
 fn test_table_write_read_reverse_after_flush_mem_wal() {
-    let memory_ctx = MemoryEngineContext::default();
+    let memory_ctx = MemoryEngineBuildContext::default();
     test_table_write_read_reverse_after_flush(memory_ctx);
 }
 
-fn test_table_write_read_reverse_after_flush<T: EngineContext>(engine_context: T) {
+fn test_table_write_read_reverse_after_flush<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
 

--- a/analytic_engine/src/tests/read_write_test.rs
+++ b/analytic_engine/src/tests/read_write_test.rs
@@ -11,14 +11,14 @@ use table_engine::table::ReadOrder;
 use crate::{
     table_options,
     tests::util::{
-        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineContext, TestContext,
+        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineBuildContext, TestContext,
         TestEnv,
     },
 };
 
 #[test]
 fn test_multi_table_read_write_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_multi_table_read_write(rocksdb_ctx);
 }
 
@@ -170,7 +170,7 @@ fn test_multi_table_read_write<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_table_write_read_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_table_write_read(rocksdb_ctx);
 }
 
@@ -249,7 +249,7 @@ fn test_table_write_read<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_table_write_get_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_table_write_get(rocksdb_ctx);
 }
 
@@ -326,7 +326,7 @@ fn test_table_write_get<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_table_write_get_override_rocks() {
-    test_table_write_get_override::<RocksDBEngineContext>();
+    test_table_write_get_override::<RocksDBEngineBuildContext>();
 }
 
 #[test]
@@ -505,7 +505,7 @@ fn test_table_write_get_override_case<T: EngineBuildContext>(
 
 #[test]
 fn test_db_write_buffer_size_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     // Use different table name to avoid metrics collision.
     test_db_write_buffer_size("test_db_write_buffer_size_rocks", rocksdb_ctx);
 }
@@ -526,7 +526,7 @@ fn test_db_write_buffer_size<T: EngineBuildContext>(table_name: &str, engine_con
 
 #[test]
 fn test_space_write_buffer_size_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     // Use different table name to avoid metrics collision.
     test_space_write_buffer_size("test_space_write_buffer_size_rocks", rocksdb_ctx);
 }
@@ -660,7 +660,7 @@ fn test_write_buffer_size_overflow<T: EngineBuildContext>(
 
 #[test]
 fn test_table_write_read_reverse_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_table_write_read_reverse(rocksdb_ctx);
 }
 
@@ -746,7 +746,7 @@ fn test_table_write_read_reverse<T: EngineBuildContext>(engine_context: T) {
 #[test]
 #[ignore = "https://github.com/CeresDB/ceresdb/issues/313"]
 fn test_table_write_read_reverse_after_flush_rocks() {
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_table_write_read_reverse_after_flush(rocksdb_ctx);
 }
 

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -109,9 +109,9 @@ pub struct TestContext<T> {
     config: Config,
     wals_opener: T,
     runtimes: Arc<EngineRuntimes>,
-    pub engine: Option<TableEngineRef>,
-    pub opened_wals: Option<OpenedWals>,
-    pub schema_id: SchemaId,
+    engine: Option<TableEngineRef>,
+    opened_wals: Option<OpenedWals>,
+    schema_id: SchemaId,
     last_table_seq: u32,
 
     name_to_tables: HashMap<String, TableRef>,
@@ -372,6 +372,10 @@ impl<T: WalsOpener> TestContext<T> {
 }
 
 impl<T> TestContext<T> {
+    pub fn config_mut(&mut self) -> &mut Config {
+        &mut self.config
+    }
+
     pub fn clone_engine(&self) -> TableEngineRef {
         self.engine.clone().unwrap()
     }
@@ -388,9 +392,13 @@ impl TestEnv {
         Builder::default()
     }
 
-    pub fn new_context<T: EngineBuildContext>(&self, build_context: T) -> TestContext<T> {
+    pub fn new_context<T: EngineBuildContext>(
+        &self,
+        build_context: T,
+    ) -> TestContext<T::WalsOpener> {
         let config = build_context.config();
         let wals_opener = build_context.wals_opener();
+
         TestContext {
             config,
             wals_opener,
@@ -463,7 +471,7 @@ impl Default for Builder {
 pub trait EngineBuildContext: Clone + Default {
     type WalsOpener: WalsOpener;
 
-    fn wal_opener(&self) -> Self::WalsOpener;
+    fn wals_opener(&self) -> Self::WalsOpener;
     fn config(&self) -> Config;
 }
 
@@ -523,9 +531,9 @@ impl Clone for RocksDBEngineBuildContext {
 }
 
 impl EngineBuildContext for RocksDBEngineBuildContext {
-    type WalOpener = RocksDBWalsOpener;
+    type WalsOpener = RocksDBWalsOpener;
 
-    fn wal_opener(&self) -> Self::WalOpener {
+    fn wals_opener(&self) -> Self::WalsOpener {
         RocksDBWalsOpener::default()
     }
 
@@ -563,9 +571,9 @@ impl Default for MemoryEngineBuildContext {
 }
 
 impl EngineBuildContext for MemoryEngineBuildContext {
-    type WalOpener = MemWalsOpener;
+    type WalsOpener = MemWalsOpener;
 
-    fn wal_opener(&self) -> Self::WalOpener {
+    fn wals_opener(&self) -> Self::WalsOpener {
         MemWalsOpener::default()
     }
 

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -459,11 +459,11 @@ pub trait EngineBuildContext: Clone + Default {
     fn config(&self) -> Config;
 }
 
-pub struct RocksDBEngineContext {
+pub struct RocksDBEngineBuildContext {
     config: Config,
 }
 
-impl Default for RocksDBEngineContext {
+impl Default for RocksDBEngineBuildContext {
     fn default() -> Self {
         let dir = tempfile::tempdir().unwrap();
 
@@ -489,7 +489,7 @@ impl Default for RocksDBEngineContext {
     }
 }
 
-impl Clone for RocksDBEngineContext {
+impl Clone for RocksDBEngineBuildContext {
     fn clone(&self) -> Self {
         let mut config = self.config.clone();
 
@@ -514,7 +514,7 @@ impl Clone for RocksDBEngineContext {
     }
 }
 
-impl EngineBuildContext for RocksDBEngineContext {
+impl EngineBuildContext for RocksDBEngineBuildContext {
     type WalOpener = RocksDBWalsOpener;
 
     fn wal_opener(&self) -> Self::WalOpener {

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -31,8 +31,8 @@ use tempfile::TempDir;
 
 use crate::{
     setup::{
-        EngineBuildContext, EngineBuildContextBuilder, EngineBuilder, MemWalEngineBuilder,
-        RocksDBWalEngineBuilder,
+        EngineBuildContext, EngineBuildContextBuilder, MemWalEngineBuilder,
+        RocksDBWalEngineBuilder, WalsOpener,
     },
     storage_options::{LocalOptions, ObjectStoreOptions, StorageOptions},
     tests::table::{self, FixedSchemaTable, RowTuple},
@@ -451,7 +451,7 @@ impl Default for Builder {
 }
 
 pub trait EngineContext: Clone + Default {
-    type EngineBuilder: EngineBuilder;
+    type EngineBuilder: WalsOpener;
 
     fn engine_builder(&self) -> Self::EngineBuilder;
     fn config(&self) -> Config;

--- a/benchmarks/src/wal_write_bench.rs
+++ b/benchmarks/src/wal_write_bench.rs
@@ -75,7 +75,7 @@ impl WalWriteBench {
             .expect("should succeed to open WalNamespaceImpl(Memory)");
 
             let values = self.build_value_vec();
-            let wal_encoder = LogBatchEncoder::create(WalLocation::new(1, 1, 1));
+            let wal_encoder = LogBatchEncoder::create(WalLocation::new(1, 1));
             let log_batch = wal_encoder
                 .encode_batch::<WritePayload, Vec<u8>>(values.as_slice())
                 .expect("should succeed to encode payload batch");

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -905,7 +905,7 @@ impl Schema for SchemaImpl {
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use analytic_engine::tests::util::{EngineBuildContext, RocksDBEngineContext, TestEnv};
+    use analytic_engine::tests::util::{EngineBuildContext, RocksDBEngineBuildContext, TestEnv};
     use catalog::{
         consts::DEFAULT_CATALOG,
         manager::Manager,
@@ -961,7 +961,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_catalog_by_name_schema_by_name_rocks() {
-        let rocksdb_ctx = RocksDBEngineContext::default();
+        let rocksdb_ctx = RocksDBEngineBuildContext::default();
         test_catalog_by_name_schema_by_name(rocksdb_ctx).await;
     }
 
@@ -1007,7 +1007,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_maybe_create_schema_by_name_rocks() {
-        let rocksdb_ctx = RocksDBEngineContext::default();
+        let rocksdb_ctx = RocksDBEngineBuildContext::default();
         test_maybe_create_schema_by_name(rocksdb_ctx).await;
     }
 
@@ -1039,7 +1039,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_table_rocks() {
-        let rocksdb_ctx = RocksDBEngineContext::default();
+        let rocksdb_ctx = RocksDBEngineBuildContext::default();
         test_create_table(rocksdb_ctx).await;
     }
 
@@ -1085,7 +1085,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drop_table_rocks() {
-        let rocksdb_ctx = RocksDBEngineContext::default();
+        let rocksdb_ctx = RocksDBEngineBuildContext::default();
         test_drop_table(rocksdb_ctx).await;
     }
 

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -905,7 +905,7 @@ impl Schema for SchemaImpl {
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use analytic_engine::tests::util::{EngineContext, RocksDBEngineContext, TestEnv};
+    use analytic_engine::tests::util::{EngineBuildContext, RocksDBEngineContext, TestEnv};
     use catalog::{
         consts::DEFAULT_CATALOG,
         manager::Manager,
@@ -967,7 +967,7 @@ mod tests {
 
     async fn test_catalog_by_name_schema_by_name<T>(engine_context: T)
     where
-        T: EngineContext,
+        T: EngineBuildContext,
     {
         let env = TestEnv::builder().build();
         let mut test_ctx = env.new_context(engine_context);
@@ -1013,7 +1013,7 @@ mod tests {
 
     async fn test_maybe_create_schema_by_name<T>(engine_context: T)
     where
-        T: EngineContext,
+        T: EngineBuildContext,
     {
         let env = TestEnv::builder().build();
         let mut test_ctx = env.new_context(engine_context);
@@ -1043,7 +1043,7 @@ mod tests {
         test_create_table(rocksdb_ctx).await;
     }
 
-    async fn test_create_table<T: EngineContext>(engine_context: T) {
+    async fn test_create_table<T: EngineBuildContext>(engine_context: T) {
         let env = TestEnv::builder().build();
         let mut test_ctx = env.new_context(engine_context);
         test_ctx.open().await;
@@ -1089,7 +1089,7 @@ mod tests {
         test_drop_table(rocksdb_ctx).await;
     }
 
-    async fn test_drop_table<T: EngineContext>(engine_context: T) {
+    async fn test_drop_table<T: EngineBuildContext>(engine_context: T) {
         let env = TestEnv::builder().build();
         let mut test_ctx = env.new_context(engine_context);
         test_ctx.open().await;

--- a/common_util/src/metric.rs
+++ b/common_util/src/metric.rs
@@ -16,7 +16,7 @@ use crate::time;
 /// Meters are used to calculate rate of an event.
 #[derive(Debug)]
 pub struct Meter {
-    moving_avarages: ExponentiallyWeightedMovingAverages,
+    moving_averages: ExponentiallyWeightedMovingAverages,
     count: AtomicU64,
     start_time: SystemTime,
 }
@@ -30,7 +30,7 @@ impl Default for Meter {
 impl Meter {
     pub fn new() -> Meter {
         Meter {
-            moving_avarages: ExponentiallyWeightedMovingAverages::new(),
+            moving_averages: ExponentiallyWeightedMovingAverages::new(),
             count: AtomicU64::from(0),
             start_time: SystemTime::now(),
         }
@@ -42,23 +42,23 @@ impl Meter {
 
     pub fn mark_n(&self, n: u64) {
         self.count.fetch_add(n, Ordering::Relaxed);
-        self.moving_avarages.tick_if_needed();
-        self.moving_avarages.update(n);
+        self.moving_averages.tick_if_needed();
+        self.moving_averages.update(n);
     }
 
     pub fn h1_rate(&self) -> f64 {
-        self.moving_avarages.tick_if_needed();
-        self.moving_avarages.h1_rate()
+        self.moving_averages.tick_if_needed();
+        self.moving_averages.h1_rate()
     }
 
     pub fn h2_rate(&self) -> f64 {
-        self.moving_avarages.tick_if_needed();
-        self.moving_avarages.h2_rate()
+        self.moving_averages.tick_if_needed();
+        self.moving_averages.h2_rate()
     }
 
     pub fn m15_rate(&self) -> f64 {
-        self.moving_avarages.tick_if_needed();
-        self.moving_avarages.m15_rate()
+        self.moving_averages.tick_if_needed();
+        self.moving_averages.m15_rate()
     }
 
     pub fn count(&self) -> u64 {

--- a/interpreters/src/tests.rs
+++ b/interpreters/src/tests.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use analytic_engine::tests::util::{EngineBuildContext, RocksDBEngineContext, TestEnv};
+use analytic_engine::tests::util::{EngineBuildContext, RocksDBEngineBuildContext, TestEnv};
 use catalog::{
     consts::{DEFAULT_CATALOG, DEFAULT_SCHEMA},
     manager::ManagerRef,
@@ -337,7 +337,7 @@ where
 #[tokio::test]
 async fn test_interpreters_rocks() {
     common_util::tests::init_log_for_test();
-    let rocksdb_ctx = RocksDBEngineContext::default();
+    let rocksdb_ctx = RocksDBEngineBuildContext::default();
     test_interpreters(rocksdb_ctx).await;
 }
 

--- a/interpreters/src/tests.rs
+++ b/interpreters/src/tests.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use analytic_engine::tests::util::{EngineContext, RocksDBEngineContext, TestEnv};
+use analytic_engine::tests::util::{EngineBuildContext, RocksDBEngineContext, TestEnv};
 use catalog::{
     consts::{DEFAULT_CATALOG, DEFAULT_SCHEMA},
     manager::ManagerRef,
@@ -341,7 +341,7 @@ async fn test_interpreters_rocks() {
     test_interpreters(rocksdb_ctx).await;
 }
 
-async fn test_interpreters<T: EngineContext>(engine_context: T) {
+async fn test_interpreters<T: EngineBuildContext>(engine_context: T) {
     let env = TestEnv::builder().build();
     let mut test_ctx = env.new_context(engine_context);
     test_ctx.open().await;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,6 +49,7 @@ table_engine = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = { workspace = true }
+wal = { workspace = true }
 warp = "0.3"
 zstd = { workspace = true }
 

--- a/server/src/grpc/meta_event_service/shard_operation.rs
+++ b/server/src/grpc/meta_event_service/shard_operation.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! Implementation of operations on shards.
+
+// TODO: Currently, only a specific operation (close wal region) is implemented,
+// and it is expected to encapsulate more operations on **Shard** in the future.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use common_types::table::ShardId;
+use common_util::error::{BoxError, GenericResult};
+use wal::manager::WalManagerRef;
+
+#[async_trait]
+pub trait WalRegionCloser: std::fmt::Debug + Send + Sync {
+    async fn close_region(&self, shard_id: ShardId) -> GenericResult<()>;
+}
+
+pub type WalRegionCloserRef = Arc<dyn WalRegionCloser>;
+
+#[derive(Debug)]
+pub struct WalCloserAdapter {
+    pub data_wal: WalManagerRef,
+    pub manifest_wal: WalManagerRef,
+}
+
+#[async_trait]
+impl WalRegionCloser for WalCloserAdapter {
+    async fn close_region(&self, shard_id: ShardId) -> GenericResult<()> {
+        let region_id = shard_id as u64;
+
+        self.data_wal.close_region(region_id).await.box_err()?;
+        self.manifest_wal.close_region(region_id).await.box_err()?;
+
+        Ok(())
+    }
+}

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use analytic_engine::setup::OpenedWals;
 use ceresdbproto::{
     meta_event::meta_event_service_server::MetaEventServiceServer,
     remote_engine::remote_engine_service_server::RemoteEngineServiceServer,
@@ -91,6 +92,9 @@ pub enum Error {
 
     #[snafu(display("Missing router.\nBacktrace:\n{}", backtrace))]
     MissingRouter { backtrace: Backtrace },
+
+    #[snafu(display("Missing wals.\nBacktrace:\n{}", backtrace))]
+    MissingWals { backtrace: Backtrace },
 
     #[snafu(display("Missing schema config provider.\nBacktrace:\n{}", backtrace))]
     MissingSchemaConfigProvider { backtrace: Backtrace },
@@ -205,6 +209,7 @@ pub struct Builder<Q> {
     instance: Option<InstanceRef<Q>>,
     router: Option<RouterRef>,
     cluster: Option<ClusterRef>,
+    opened_wals: Option<OpenedWals>,
     schema_config_provider: Option<SchemaConfigProviderRef>,
     forward_config: Option<forward::Config>,
 }
@@ -220,6 +225,7 @@ impl<Q> Builder<Q> {
             instance: None,
             router: None,
             cluster: None,
+            opened_wals: None,
             schema_config_provider: None,
             forward_config: None,
         }
@@ -262,6 +268,11 @@ impl<Q> Builder<Q> {
         self
     }
 
+    pub fn opened_wals(mut self, opened_wals: OpenedWals) -> Self {
+        self.opened_wals = Some(opened_wals);
+        self
+    }
+
     pub fn schema_config_provider(mut self, provider: SchemaConfigProviderRef) -> Self {
         self.schema_config_provider = Some(provider);
         self
@@ -283,17 +294,19 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
         let runtimes = self.runtimes.context(MissingRuntimes)?;
         let instance = self.instance.context(MissingInstance)?;
         let router = self.router.context(MissingRouter)?;
+        let opened_wals = self.opened_wals.context(MissingWals)?;
         let schema_config_provider = self
             .schema_config_provider
             .context(MissingSchemaConfigProvider)?;
 
         let meta_rpc_server = self.cluster.map(|v| {
-            let meta_service = MetaServiceImpl {
+            let builder = meta_event_service::Builder {
                 cluster: v,
                 instance: instance.clone(),
                 runtime: runtimes.meta_runtime.clone(),
+                opened_wals,
             };
-            MetaEventServiceServer::new(meta_service)
+            MetaEventServiceServer::new(builder.build())
         });
 
         let remote_engine_server = {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -263,7 +263,7 @@ async fn build_without_meta<Q: Executor + 'static, T: WalsOpener>(
         config: &config.analytic,
         router: None,
         engine_runtimes: runtimes.clone(),
-        opened_wals,
+        opened_wals: opened_wals.clone(),
     };
     let engine_proxy = build_table_engine_proxy(engine_builder).await;
 
@@ -314,6 +314,7 @@ async fn build_without_meta<Q: Executor + 'static, T: WalsOpener>(
         .catalog_manager(catalog_manager)
         .table_manipulator(table_manipulator)
         .router(router)
+        .opened_wals(opened_wals)
         .schema_config_provider(schema_config_provider)
         .local_tables_recoverer(local_tables_recoverer)
 }

--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -162,6 +162,12 @@ impl<M: MessageQueue> Namespace<M> {
         }
     }
 
+    pub async fn close_region(&self, region_id: RegionId) -> Result<()> {
+        let mut regions = self.inner.regions.write().await;
+        regions.remove(&region_id);
+        Ok(())
+    }
+
     /// Close namespace
     ///
     /// Mainly clear the regions and wait logs cleaning routine to stop.

--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -15,8 +15,7 @@ use crate::{
     kv_encoder::LogEncoding,
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
-        ReadContext, ReadRequest, ScanContext, ScanRequest, VersionedRegionId, WalLocation,
-        WriteContext,
+        ReadContext, ReadRequest, RegionId, ScanContext, ScanRequest, WalLocation, WriteContext,
     },
     message_queue_impl::{
         config::Config,
@@ -239,7 +238,7 @@ impl<M: MessageQueue> fmt::Debug for Namespace<M> {
 struct NamespaceInner<M: MessageQueue> {
     namespace: String,
     // TODO: should use some strategies(such as lru) to clean the invalid region.
-    regions: Arc<RwLock<HashMap<VersionedRegionId, RegionRef<M>>>>,
+    regions: Arc<RwLock<HashMap<RegionId, RegionRef<M>>>>,
     message_queue: Arc<M>,
     meta_encoding: MetaEncoding,
     log_encoding: LogEncoding,
@@ -265,14 +264,14 @@ impl<M: MessageQueue> NamespaceInner<M> {
     /// about above operations on an empty region.
     async fn get_or_open_region(
         &self,
-        versioned_region_id: VersionedRegionId,
+        region_id: RegionId,
     ) -> std::result::Result<RegionRef<M>, region::Error> {
         {
             let regions = self.regions.read().await;
-            if let Some(region) = regions.get(&versioned_region_id) {
+            if let Some(region) = regions.get(&region_id) {
                 debug!(
-                    "Region exists and return it, namespace:{}, versioned region id:{:?}",
-                    self.namespace, versioned_region_id
+                    "Region exists and return it, namespace:{}, region id:{:?}",
+                    self.namespace, region_id
                 );
                 return Ok(region.clone());
             }
@@ -280,27 +279,21 @@ impl<M: MessageQueue> NamespaceInner<M> {
 
         let mut regions = self.regions.write().await;
         // Multiple tables share one region, so double check here is needed.
-        if let Some(region) = regions.get(&versioned_region_id) {
+        if let Some(region) = regions.get(&region_id) {
             debug!(
-                "Region exists and return it, namespace:{}, versioned region id:{:?}",
-                self.namespace, versioned_region_id
+                "Region exists and return it, namespace:{}, region id:{:?}",
+                self.namespace, region_id
             );
             return Ok(region.clone());
         }
 
-        let region = Arc::new(
-            Region::open(
-                &self.namespace,
-                versioned_region_id.id,
-                self.message_queue.clone(),
-            )
-            .await?,
-        );
-        regions.insert(versioned_region_id, region.clone());
+        let region =
+            Arc::new(Region::open(&self.namespace, region_id, self.message_queue.clone()).await?);
+        regions.insert(region_id, region.clone());
 
         info!(
-            "Region open successfully, namespace:{}, versioned region id:{:?}",
-            self.namespace, versioned_region_id
+            "Region open successfully, namespace:{}, region id:{:?}",
+            self.namespace, region_id
         );
 
         Ok(region)
@@ -308,7 +301,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
 
     pub async fn sequence_num(&self, location: WalLocation) -> Result<SequenceNumber> {
         let region = self
-            .get_or_open_region(location.versioned_region_id)
+            .get_or_open_region(location.region_id)
             .await
             .context(GetSequence {
                 namespace: self.namespace.clone(),
@@ -340,7 +333,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
         );
 
         let region = self
-            .get_or_open_region(request.location.versioned_region_id)
+            .get_or_open_region(request.location.region_id)
             .await
             .context(ReadWithCause {
                 namespace: self.namespace.clone(),
@@ -375,7 +368,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
         );
 
         let region = self
-            .get_or_open_region(request.versioned_region_id)
+            .get_or_open_region(request.region_id)
             .await
             .context(ScanWithCause {
                 namespace: self.namespace.clone(),
@@ -414,7 +407,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
         );
 
         let region = self
-            .get_or_open_region(log_batch.location.versioned_region_id)
+            .get_or_open_region(log_batch.location.region_id)
             .await
             .context(Write {
                 namespace: self.namespace.clone(),
@@ -437,7 +430,7 @@ impl<M: MessageQueue> NamespaceInner<M> {
         debug!("Mark table logs delete in namespace, namespace:{}, location:{:?}, delete to sequence number:{}", self.namespace, location, sequence_num);
 
         let region = self
-            .get_or_open_region(location.versioned_region_id)
+            .get_or_open_region(location.region_id)
             .await
             .context(MarkDeleteTo {
                 namespace: self.namespace.clone(),

--- a/wal/src/message_queue_impl/test_util.rs
+++ b/wal/src/message_queue_impl/test_util.rs
@@ -59,7 +59,7 @@ impl<Mq: MessageQueue> TestContext<Mq> {
             .into_iter()
             .map(|(table_id, data)| {
                 let log_batch_encoder =
-                    LogBatchEncoder::create(WalLocation::new(region_id, region_version, table_id));
+                    LogBatchEncoder::create(WalLocation::new(region_id, table_id));
                 let log_write_batch = log_batch_encoder
                     .encode_batch::<TestPayload, u32>(&data)
                     .unwrap();

--- a/wal/src/message_queue_impl/wal.rs
+++ b/wal/src/message_queue_impl/wal.rs
@@ -13,8 +13,8 @@ use snafu::ResultExt;
 use crate::{
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
-        error::*, AsyncLogIterator, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext,
-        ScanRequest, WalLocation, WalManager, WriteContext,
+        error::*, AsyncLogIterator, BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId,
+        ScanContext, ScanRequest, WalLocation, WalManager, WriteContext,
     },
     message_queue_impl::{
         config::Config,
@@ -57,6 +57,14 @@ impl<M: MessageQueue> WalManager for MessageQueueImpl<M> {
             .await
             .box_err()
             .context(Delete)
+    }
+
+    async fn close_region(&self, region_id: RegionId) -> Result<()> {
+        self.0
+            .close_region(region_id)
+            .await
+            .box_err()
+            .context(Close)
     }
 
     async fn close_gracefully(&self) -> Result<()> {

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -27,8 +27,8 @@ use crate::{
     kv_encoder::{CommonLogEncoding, CommonLogKey, MaxSeqMetaEncoding, MaxSeqMetaValue, MetaKey},
     log_batch::{LogEntry, LogWriteBatch},
     manager::{
-        error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext, ScanRequest,
-        SyncLogIterator, WalLocation, WalManager, WriteContext,
+        error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId, ScanContext,
+        ScanRequest, SyncLogIterator, WalLocation, WalManager, WriteContext,
     },
 };
 
@@ -727,6 +727,15 @@ impl WalManager for RocksImpl {
                 .delete_entries_up_to(region_id, sequence_num)
                 .await;
         }
+
+        Ok(())
+    }
+
+    async fn close_region(&self, region_id: RegionId) -> Result<()> {
+        debug!(
+            "Close region for RocksDB based WAL is noop operation, region_id:{}",
+            region_id
+        );
 
         Ok(())
     }

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -162,7 +162,7 @@ impl TableUnit {
             return Ok(RocksLogIterator::new_empty(self.log_encoding.clone(), iter));
         };
 
-        let region_id = req.location.versioned_region_id.id;
+        let region_id = req.location.region_id;
         let (min_log_key, max_log_key) = (
             self.log_key(region_id, start_sequence),
             self.log_key(region_id, end_sequence),
@@ -187,7 +187,7 @@ impl TableUnit {
             let mut key_buf = BytesMut::new();
 
             for entry in &batch.entries {
-                let region_id = batch.location.versioned_region_id.id;
+                let region_id = batch.location.region_id;
                 self.log_encoding
                     .encode_key(
                         &mut key_buf,
@@ -722,7 +722,7 @@ impl WalManager for RocksImpl {
         sequence_num: SequenceNumber,
     ) -> Result<()> {
         if let Some(table_unit) = self.table_unit(&location) {
-            let region_id = location.versioned_region_id.id;
+            let region_id = location.region_id;
             return table_unit
                 .delete_entries_up_to(region_id, sequence_num)
                 .await;
@@ -768,7 +768,7 @@ impl WalManager for RocksImpl {
         let read_opts = ReadOptions::default();
         let iter = DBIterator::new(self.db.clone(), read_opts);
 
-        let region_id = req.versioned_region_id.id;
+        let region_id = req.region_id;
         let (min_log_key, max_log_key) = (
             CommonLogKey::new(region_id, TableId::MIN, SequenceNumber::MIN),
             CommonLogKey::new(region_id, TableId::MAX, SequenceNumber::MAX),

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -354,7 +354,7 @@ impl TableUnit {
             None => return Ok(TableLogIterator::new_empty(table_kv.clone())),
         };
 
-        let region_id = request.location.versioned_region_id.id;
+        let region_id = request.location.region_id;
         let table_id = request.location.table_id;
         let min_log_key = CommonLogKey::new(region_id, table_id, start_sequence);
         let max_log_key = CommonLogKey::new(region_id, table_id, end_sequence);
@@ -914,7 +914,7 @@ impl TableUnitWriter {
 
         let log_encoding = CommonLogEncoding::newest();
         let entries_num = log_batch.len() as u64;
-        let region_id = log_batch.location.versioned_region_id.id;
+        let region_id = log_batch.location.region_id;
         let table_id = log_batch.location.table_id;
         let (wb, max_sequence_num) = {
             let mut wb = T::WriteBatch::with_capacity(log_batch.len());

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -7,7 +7,7 @@ use std::{fmt, str, sync::Arc};
 use async_trait::async_trait;
 use common_types::SequenceNumber;
 use common_util::error::BoxError;
-use log::{info, warn};
+use log::info;
 use snafu::ResultExt;
 use table_kv::TableKv;
 
@@ -118,10 +118,12 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
             .context(Delete)
     }
 
-    async fn close_region(&self, region: RegionId) -> Result<()> {
-        warn!("Close region is not supported yet, region:{}", region);
-
-        Ok(())
+    async fn close_region(&self, region_id: RegionId) -> Result<()> {
+        self.namespace
+            .close_region(region_id)
+            .await
+            .box_err()
+            .context(CloseRegion { region: region_id })
     }
 
     async fn close_gracefully(&self) -> Result<()> {

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -7,14 +7,14 @@ use std::{fmt, str, sync::Arc};
 use async_trait::async_trait;
 use common_types::SequenceNumber;
 use common_util::error::BoxError;
-use log::info;
+use log::{info, warn};
 use snafu::ResultExt;
 use table_kv::TableKv;
 
 use crate::{
     log_batch::LogWriteBatch,
     manager::{
-        self, error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, ScanContext,
+        self, error::*, BatchLogIteratorAdapter, ReadContext, ReadRequest, RegionId, ScanContext,
         ScanRequest, WalLocation, WalManager,
     },
     table_kv_impl::{
@@ -116,6 +116,12 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
             .await
             .box_err()
             .context(Delete)
+    }
+
+    async fn close_region(&self, region: RegionId) -> Result<()> {
+        warn!("Close region is not supported yet, region:{}", region);
+
+        Ok(())
     }
 
     async fn close_gracefully(&self) -> Result<()> {

--- a/wal/src/tests/read_write.rs
+++ b/wal/src/tests/read_write.rs
@@ -182,11 +182,12 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
         .await;
 
         // The table are move to node 2 but in the same shard, so its region id is still
-        // 0, but region version changed to 1 for distinguishing this moving.
+        // 0.
+        wal_1.close_region(region_id).await.unwrap();
         let wal_2 = env.build_wal().await;
         simple_read_write_with_range_and_wal(
             &env,
-            wal_2,
+            wal_2.clone(),
             WalLocation::new(region_id, table_id),
             10,
             20,
@@ -194,8 +195,7 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
         .await;
 
         // Finally, the table with the same shard is moved to node 1 again.
-        // If version changed, wal manager can distinguish that
-        // the region info in it is outdated, it should reopen the region.
+        wal_2.close_region(region_id).await.unwrap();
         simple_read_write_with_range_and_wal(
             &env,
             wal_1,

--- a/wal/src/tests/read_write.rs
+++ b/wal/src/tests/read_write.rs
@@ -6,14 +6,12 @@ use std::{
 };
 
 use common_types::{
-    table::{TableId, DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID},
+    table::{TableId, DEFAULT_SHARD_ID},
     SequenceNumber,
 };
 
 use crate::{
-    manager::{
-        ReadBoundary, ReadRequest, ScanRequest, VersionedRegionId, WalLocation, WalManagerRef,
-    },
+    manager::{ReadBoundary, ReadRequest, ScanRequest, WalLocation, WalManagerRef},
     tests::util::{
         KafkaWalBuilder, MemoryTableWalBuilder, RocksTestEnv, RocksWalBuilder, TableKvTestEnv,
         TestEnv, TestPayload, TestTableData, WalBuilder,
@@ -88,7 +86,7 @@ fn test_simple_read_write_default_batch<B: WalBuilder>(builder: B) {
     let env = TestEnv::new(2, builder);
     env.runtime.block_on(simple_read_write(
         &env,
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
     ));
 }
 
@@ -101,7 +99,7 @@ fn test_simple_read_write_different_batch_size<B: WalBuilder>(builder: B) {
         env.read_ctx.batch_size = batch_size;
         env.runtime.block_on(simple_read_write(
             &env,
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+            WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         ));
     }
 }
@@ -174,11 +172,10 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
         // Use two wal managers to represent datanode 1 and datanode 2.
         // At first, write some things in node 1.
         let wal_1 = env.build_wal().await;
-        let region_version_1 = 0;
         simple_read_write_with_range_and_wal(
             &env,
             wal_1.clone(),
-            WalLocation::new(region_id, region_version_1, table_id),
+            WalLocation::new(region_id, table_id),
             0,
             10,
         )
@@ -187,11 +184,10 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
         // The table are move to node 2 but in the same shard, so its region id is still
         // 0, but region version changed to 1 for distinguishing this moving.
         let wal_2 = env.build_wal().await;
-        let region_version_2 = 1;
         simple_read_write_with_range_and_wal(
             &env,
             wal_2,
-            WalLocation::new(region_id, region_version_2, table_id),
+            WalLocation::new(region_id, table_id),
             10,
             20,
         )
@@ -200,11 +196,10 @@ fn test_move_from_nodes<B: WalBuilder>(builder: B) {
         // Finally, the table with the same shard is moved to node 1 again.
         // If version changed, wal manager can distinguish that
         // the region info in it is outdated, it should reopen the region.
-        let region_version_3 = 2;
         simple_read_write_with_range_and_wal(
             &env,
             wal_1,
-            WalLocation::new(region_id, region_version_3, table_id),
+            WalLocation::new(region_id, table_id),
             20,
             30,
         )
@@ -303,12 +298,8 @@ async fn simple_read_write_with_range_and_wal_internal<B: WalBuilder>(
 /// Test the read with different kinds of boundaries.
 async fn read_with_boundary<B: WalBuilder>(env: &TestEnv<B>) {
     let wal = env.build_wal().await;
-    let versioned_region_id = VersionedRegionId {
-        version: DEFAULT_CLUSTER_VERSION,
-        id: DEFAULT_SHARD_ID as u64,
-    };
     let location = WalLocation {
-        versioned_region_id,
+        region_id: DEFAULT_SHARD_ID as u64,
         table_id: TableId::MIN,
     };
     let (payload_batch, write_batch) = env.build_log_batch(location, 0, 10).await;
@@ -403,12 +394,12 @@ async fn write_multiple_regions_parallelly<B: WalBuilder + 'static>(env: Arc<Tes
         let read_write_0 = env.runtime.spawn(simple_read_write_with_wal(
             env.clone(),
             wal.clone(),
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, i),
+            WalLocation::new(DEFAULT_SHARD_ID as u64, i),
         ));
         let read_write_1 = env.runtime.spawn(simple_read_write_with_wal(
             env.clone(),
             wal.clone(),
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, i),
+            WalLocation::new(DEFAULT_SHARD_ID as u64, i),
         ));
         handles.push(read_write_0);
         handles.push(read_write_1);
@@ -431,10 +422,9 @@ async fn reopen<B: WalBuilder>(env: &TestEnv<B>, result_len: usize) {
         let wal = env.build_wal().await;
         for result_idx in 0..result_len {
             let region_id = result_idx as u64;
-            let region_version = result_idx as u64;
             let table_id = result_idx as u64;
             let (payload_batch, write_batch) = env
-                .build_log_batch(WalLocation::new(region_id, region_version, table_id), 0, 10)
+                .build_log_batch(WalLocation::new(region_id, table_id), 0, 10)
                 .await;
             let seq = wal
                 .write(&env.write_ctx, &write_batch)
@@ -442,19 +432,12 @@ async fn reopen<B: WalBuilder>(env: &TestEnv<B>, result_len: usize) {
                 .expect("should succeed to write");
 
             let last_seq = wal
-                .sequence_num(WalLocation::new(region_id, region_version, table_id))
+                .sequence_num(WalLocation::new(region_id, table_id))
                 .await
                 .unwrap();
             assert_eq!(seq, last_seq);
 
-            write_results.push((
-                region_id,
-                region_version,
-                table_id,
-                payload_batch,
-                write_batch,
-                seq,
-            ));
+            write_results.push((region_id, table_id, payload_batch, write_batch, seq));
         }
         wal.close_gracefully().await.unwrap();
     }
@@ -462,9 +445,9 @@ async fn reopen<B: WalBuilder>(env: &TestEnv<B>, result_len: usize) {
     // Reopen the wal.
     let wal = env.build_wal().await;
 
-    for (region_id, region_version, table_id, payload_batch, write_batch, seq) in write_results {
+    for (region_id, table_id, payload_batch, write_batch, seq) in write_results {
         let read_req = ReadRequest {
-            location: WalLocation::new(region_id, region_version, table_id),
+            location: WalLocation::new(region_id, table_id),
             start: ReadBoundary::Included(seq + 1 - write_batch.entries.len() as u64),
             end: ReadBoundary::Included(seq),
         };
@@ -493,7 +476,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
     let (start_val, mid_val, end_val) = (0, 10, 50);
     let (payload_batch1, write_batch_1) = env
         .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+            WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
             start_val,
             mid_val,
         )
@@ -504,7 +487,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
         .expect("should succeed to write");
     let (payload_batch2, write_batch_2) = env
         .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+            WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
             mid_val,
             end_val,
         )
@@ -518,7 +501,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
     check_write_batch(
         env,
         wal.clone(),
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         seq_1,
         &payload_batch1,
     )
@@ -527,7 +510,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
     check_write_batch(
         env,
         wal.clone(),
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         seq_2,
         &payload_batch2,
     )
@@ -538,7 +521,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
     check_write_batch(
         env,
         wal.clone(),
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         seq_3,
         &payload_batch3,
     )
@@ -554,7 +537,7 @@ async fn complex_read_write<B: WalBuilder>(env: &TestEnv<B>) {
     check_write_batch(
         env,
         wal.clone(),
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         seq_4,
         &payload_batch4,
     )
@@ -568,11 +551,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
     let table_id = 0;
     let wal = env.build_wal().await;
     let (payload_batch, write_batch) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     let seq = wal
         .write(&env.write_ctx, &write_batch)
@@ -581,31 +560,24 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
     check_write_batch(
         env,
         wal.clone(),
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         seq,
         &payload_batch,
     )
     .await;
 
     let last_seq = wal
-        .sequence_num(WalLocation::new(
-            DEFAULT_SHARD_ID as u64,
-            DEFAULT_CLUSTER_VERSION,
-            table_id,
-        ))
+        .sequence_num(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id))
         .await
         .unwrap();
     assert_eq!(seq, last_seq);
 
     // delete all logs
-    wal.mark_delete_entries_up_to(
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-        seq,
-    )
-    .await
-    .expect("should succeed to delete");
+    wal.mark_delete_entries_up_to(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), seq)
+        .await
+        .expect("should succeed to delete");
     let read_req = ReadRequest {
-        location: WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        location: WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         start: ReadBoundary::Min,
         end: ReadBoundary::Max,
     };
@@ -619,11 +591,7 @@ async fn simple_write_delete<B: WalBuilder>(env: &TestEnv<B>) {
 
     // Sequence num remains unchanged.
     let last_seq = wal
-        .sequence_num(WalLocation::new(
-            DEFAULT_SHARD_ID as u64,
-            DEFAULT_CLUSTER_VERSION,
-            table_id,
-        ))
+        .sequence_num(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id))
         .await
         .unwrap();
     assert_eq!(seq, last_seq);
@@ -636,11 +604,7 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
     let table_id = 0;
     let wal = env.build_wal().await;
     let (mut payload_batch, write_batch) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     let seq = wal
         .write(&env.write_ctx, &write_batch)
@@ -649,21 +613,18 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
     check_write_batch(
         env,
         wal.clone(),
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         seq,
         &payload_batch,
     )
     .await;
 
     // delete all logs
-    wal.mark_delete_entries_up_to(
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-        seq / 2,
-    )
-    .await
-    .expect("should succeed to delete");
+    wal.mark_delete_entries_up_to(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), seq / 2)
+        .await
+        .expect("should succeed to delete");
     let read_req = ReadRequest {
-        location: WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
+        location: WalLocation::new(DEFAULT_SHARD_ID as u64, table_id),
         start: ReadBoundary::Min,
         end: ReadBoundary::Max,
     };
@@ -678,11 +639,7 @@ async fn write_delete_half<B: WalBuilder>(env: &TestEnv<B>) {
 
     // Sequence num remains unchanged.
     let last_seq = wal
-        .sequence_num(WalLocation::new(
-            DEFAULT_SHARD_ID as u64,
-            DEFAULT_CLUSTER_VERSION,
-            table_id,
-        ))
+        .sequence_num(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id))
         .await
         .unwrap();
     assert_eq!(seq, last_seq);
@@ -695,11 +652,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
     let (table_id_1, table_id_2) = (1, 2);
     let wal = env.build_wal().await;
     let (_, write_batch_1) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id_1),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id_1), 0, 10)
         .await;
     let seq_1 = wal
         .write(&env.write_ctx, &write_batch_1)
@@ -708,7 +661,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
 
     let (payload_batch2, write_batch_2) = env
         .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id_2),
+            WalLocation::new(DEFAULT_SHARD_ID as u64, table_id_2),
             10,
             20,
         )
@@ -719,14 +672,11 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
         .expect("should succeed to write");
 
     // delete all logs of region 1.
-    wal.mark_delete_entries_up_to(
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id_1),
-        seq_1,
-    )
-    .await
-    .expect("should succeed to delete");
+    wal.mark_delete_entries_up_to(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id_1), seq_1)
+        .await
+        .expect("should succeed to delete");
     let read_req = ReadRequest {
-        location: WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id_1),
+        location: WalLocation::new(DEFAULT_SHARD_ID as u64, table_id_1),
         start: ReadBoundary::Min,
         end: ReadBoundary::Max,
     };
@@ -740,7 +690,7 @@ async fn write_delete_multiple_regions<B: WalBuilder>(env: &TestEnv<B>) {
     check_write_batch(
         env,
         wal.clone(),
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id_2),
+        WalLocation::new(DEFAULT_SHARD_ID as u64, table_id_2),
         seq_2,
         &payload_batch2,
     )
@@ -754,33 +704,21 @@ async fn sequence_increase_monotonically_multiple_writes<B: WalBuilder>(env: &Te
     let table_id = 0;
     let wal = env.build_wal().await;
     let (_, write_batch1) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     let seq_1 = wal
         .write(&env.write_ctx, &write_batch1)
         .await
         .expect("should succeed to write");
     let (_, write_batch2) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     let seq_2 = wal
         .write(&env.write_ctx, &write_batch2)
         .await
         .expect("should succeed to write");
     let (_, write_batch3) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
 
     let seq_3 = wal
@@ -800,11 +738,7 @@ async fn sequence_increase_monotonically_delete_write<B: WalBuilder>(env: &TestE
     let table_id = 0;
     let wal = env.build_wal().await;
     let (_, write_batch1) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     // write
     let seq_1 = wal
@@ -812,18 +746,11 @@ async fn sequence_increase_monotonically_delete_write<B: WalBuilder>(env: &TestE
         .await
         .expect("should succeed to write");
     // delete
-    wal.mark_delete_entries_up_to(
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-        seq_1,
-    )
-    .await
-    .expect("should succeed to delete");
+    wal.mark_delete_entries_up_to(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), seq_1)
+        .await
+        .expect("should succeed to delete");
     let (_, write_batch2) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     // write again
     let seq_2 = wal
@@ -832,11 +759,7 @@ async fn sequence_increase_monotonically_delete_write<B: WalBuilder>(env: &TestE
         .expect("should succeed to write");
 
     let last_seq = wal
-        .sequence_num(WalLocation::new(
-            DEFAULT_SHARD_ID as u64,
-            DEFAULT_CLUSTER_VERSION,
-            table_id,
-        ))
+        .sequence_num(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id))
         .await
         .unwrap();
     assert_eq!(seq_2, last_seq);
@@ -852,11 +775,7 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
     let table_id = 0;
     let wal = env.build_wal().await;
     let (_, write_batch1) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     // write
     let seq_1 = wal
@@ -864,12 +783,9 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
         .await
         .expect("should succeed to write");
     // delete
-    wal.mark_delete_entries_up_to(
-        WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-        seq_1,
-    )
-    .await
-    .expect("should succeed to delete");
+    wal.mark_delete_entries_up_to(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), seq_1)
+        .await
+        .expect("should succeed to delete");
 
     // restart
     wal.close_gracefully().await.unwrap();
@@ -878,11 +794,7 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
     let wal = env.build_wal().await;
     // write again
     let (_, write_batch2) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id), 0, 10)
         .await;
     let seq_2 = wal
         .write(&env.write_ctx, &write_batch2)
@@ -890,11 +802,7 @@ async fn sequence_increase_monotonically_delete_reopen_write<B: WalBuilder>(env:
         .expect("should succeed to write");
 
     let last_seq = wal
-        .sequence_num(WalLocation::new(
-            DEFAULT_SHARD_ID as u64,
-            DEFAULT_CLUSTER_VERSION,
-            table_id,
-        ))
+        .sequence_num(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id))
         .await
         .unwrap();
     assert_eq!(seq_2, last_seq);
@@ -911,11 +819,7 @@ async fn write_scan<B: WalBuilder>(env: &TestEnv<B>) {
     let wal = env.build_wal().await;
     // Write table 0.
     let (payload_batch1, write_batch1) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id_1),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id_1), 0, 10)
         .await;
 
     let seq_1 = wal
@@ -925,11 +829,7 @@ async fn write_scan<B: WalBuilder>(env: &TestEnv<B>) {
 
     // Write table 1.
     let (payload_batch2, write_batch2) = env
-        .build_log_batch(
-            WalLocation::new(DEFAULT_SHARD_ID as u64, DEFAULT_CLUSTER_VERSION, table_id_2),
-            0,
-            10,
-        )
+        .build_log_batch(WalLocation::new(DEFAULT_SHARD_ID as u64, table_id_2), 0, 10)
         .await;
 
     let seq_2 = wal
@@ -939,7 +839,7 @@ async fn write_scan<B: WalBuilder>(env: &TestEnv<B>) {
 
     // Scan and compare.
     let scan_request = ScanRequest {
-        versioned_region_id: VersionedRegionId::default(),
+        region_id: DEFAULT_SHARD_ID as u64,
     };
     let iter = wal
         .scan(&env.read_ctx, &scan_request)


### PR DESCRIPTION
# Which issue does this PR close?

Part of #663

# Rationale for this change
 Remove the useless cluster version in the WAL location, which is introduced by #442 to solve the problems mentioned in #441.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Introduce the `close_region` in the `WalManager` trait;
- Solve the #441 by doing `close_region` instead of using different cluster version; 
- Refactor the setup procedure to obtain the different `Wal`s in the top level structs;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
