### PR TITLE
fix: can't recognize aliyun oss NotFoundError when load manifest

### DIFF
--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -435,7 +435,7 @@ impl MetaUpdateSnapshotStore for ObjectStoreBasedSnapshotStore {
         // is not thrown as [object_store::ObjectStoreError::NotFound].
         if let Err(err) = &get_res {
             let err_msg = err.to_string().to_lowercase();
-            if err_msg.contains("404") | err_msg.contains("not found") {
+            if err_msg.contains("404") || err_msg.contains("not found") {
                 warn!("Current snapshot file doesn't exist, err:{}", err);
                 return Ok(None);
             }

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -431,6 +431,16 @@ impl MetaUpdateSnapshotStore for ObjectStoreBasedSnapshotStore {
             return Ok(None);
         };
 
+        // TODO: currently, this is just a workaround to handle the case where the error
+        // is not thrown as [object_store::ObjectStoreError::NotFound].
+        if let Err(err) = &get_res {
+            let err_msg = err.to_string().to_lowercase();
+            if err_msg.contains("404") | err_msg.contains("not found") {
+                warn!("Current snapshot file doesn't exist, err:{}", err);
+                return Ok(None);
+            }
+        }
+
         let payload = get_res
             .context(FetchSnapshot)?
             .bytes()


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 Currently, the not found error won't be thrown when access an object file in the aliyun oss by oss sdk, leading to possible panic when restarting.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Take a workaround way (check whether the error message contains '404' or 'not found') to detect the not found error.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Manual test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
