### PR TITLE
fix: nightly docker image name

### DIFF
--- a/.github/workflows/dockerhub-publish-nightly.yml
+++ b/.github/workflows/dockerhub-publish-nightly.yml
@@ -30,14 +30,9 @@ jobs:
       - name: Set Environment Variables
         run: |
             echo "BUILD_DATE=$(TZ=':Asia/Shanghai' date '+%Y%m%d')" >> $GITHUB_ENV
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Build and Push CeresDB Server Docker Image
+      - name: Build and Push Docker Image
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: nightly-${{ env.BUILD_DATE }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:nightly-${{ env.BUILD_DATE }}

--- a/.github/workflows/dockerhub-publish-nightly.yml
+++ b/.github/workflows/dockerhub-publish-nightly.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   docker:
-    # if: github.repository_owner == 'CeresDB'
+    if: github.repository_owner == 'CeresDB'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dockerhub-publish-nightly.yml
+++ b/.github/workflows/dockerhub-publish-nightly.yml
@@ -7,10 +7,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker:
-    if: github.repository_owner == 'CeresDB'
+    # if: github.repository_owner == 'CeresDB'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,9 +30,14 @@ jobs:
       - name: Set Environment Variables
         run: |
             echo "BUILD_DATE=$(TZ=':Asia/Shanghai' date '+%Y%m%d')" >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and Push CeresDB Server Docker Image
         uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: ceresdb/ceresdb-server:nightly-${{ env.BUILD_DATE }}
+          tags: nightly-${{ env.BUILD_DATE }}


### PR DESCRIPTION
# Which issue does this PR close?

Fix https://github.com/CeresDB/ceresdb/actions/runs/4310351950

# Rationale for this change
 
After #684, image publish has errors
```
ceresdb/ceresdb-server:nightly-20230302: server message: insufficient_scope: authorization failed
```
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
- https://github.com/jiacai2050/ceresdb/actions/runs/4311415390
- https://github.com/jiacai2050/ceresdb/pkgs/container/ceresdb
Ref
- https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages

