### PR TITLE
refactor: replace tokio lock with std lock in some sync scenarios

### DIFF
--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -10,7 +10,7 @@ use std::{
     hash::{Hash, Hasher},
     num::NonZeroUsize,
     ops::Range,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use async_trait::async_trait;
@@ -18,7 +18,7 @@ use bytes::Bytes;
 use clru::{CLruCache, CLruCacheConfig, WeightScale};
 use futures::stream::BoxStream;
 use snafu::{OptionExt, Snafu};
-use tokio::{io::AsyncWrite, sync::Mutex};
+use tokio::io::AsyncWrite;
 use upstream::{path::Path, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, Result};
 
 use crate::ObjectStoreRef;
@@ -52,26 +52,26 @@ impl Partition {
 }
 
 impl Partition {
-    async fn get(&self, key: &str) -> Option<Bytes> {
-        let mut guard = self.inner.lock().await;
+    fn get(&self, key: &str) -> Option<Bytes> {
+        let mut guard = self.inner.lock().unwrap();
         guard.get(key).cloned()
     }
 
-    async fn peek(&self, key: &str) -> Option<Bytes> {
+    fn peek(&self, key: &str) -> Option<Bytes> {
         // FIXME: actually, here write lock is not necessary.
-        let guard = self.inner.lock().await;
+        let guard = self.inner.lock().unwrap();
         guard.peek(key).cloned()
     }
 
-    async fn insert(&self, key: String, value: Bytes) {
-        let mut guard = self.inner.lock().await;
+    fn insert(&self, key: String, value: Bytes) {
+        let mut guard = self.inner.lock().unwrap();
         // don't care error now.
         _ = guard.put_with_weight(key, value);
     }
 
     #[cfg(test)]
-    async fn keys(&self) -> Vec<String> {
-        let guard = self.inner.lock().await;
+    fn keys(&self) -> Vec<String> {
+        let guard = self.inner.lock().unwrap();
         guard
             .iter()
             .map(|(key, _)| key)
@@ -115,34 +115,32 @@ impl MemCache {
         self.partitions[hasher.finish() as usize & self.partition_mask].clone()
     }
 
-    async fn get(&self, key: &str) -> Option<Bytes> {
+    fn get(&self, key: &str) -> Option<Bytes> {
         let partition = self.locate_partition(key);
-        partition.get(key).await
+        partition.get(key)
     }
 
-    async fn peek(&self, key: &str) -> Option<Bytes> {
+    fn peek(&self, key: &str) -> Option<Bytes> {
         let partition = self.locate_partition(key);
-        partition.peek(key).await
+        partition.peek(key)
     }
 
-    async fn insert(&self, key: String, value: Bytes) {
+    fn insert(&self, key: String, value: Bytes) {
         let partition = self.locate_partition(&key);
-        partition.insert(key, value).await;
+        partition.insert(key, value);
     }
 
+    /// Give a description of the cache state.
     #[cfg(test)]
-    async fn to_string(&self) -> String {
-        futures::future::join_all(
-            self.partitions
-                .iter()
-                .map(|part| async { part.keys().await.join(",") }),
-        )
-        .await
-        .into_iter()
-        .enumerate()
-        .map(|(part_no, keys)| format!("{part_no}: [{keys}]"))
-        .collect::<Vec<_>>()
-        .join("\n")
+    fn state_desc(&self) -> String {
+        self.partitions
+            .iter()
+            .map(|part| part.keys().join(","))
+            .into_iter()
+            .enumerate()
+            .map(|(part_no, keys)| format!("{part_no}: [{keys}]"))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }
 
@@ -195,21 +193,21 @@ impl MemCacheStore {
         // TODO(chenxiang): What if there are some overlapping range in cache?
         // A request with range [5, 10) can also use [0, 20) cache
         let cache_key = Self::cache_key(location, &range);
-        if let Some(bytes) = self.cache.get(&cache_key).await {
+        if let Some(bytes) = self.cache.get(&cache_key) {
             return Ok(bytes);
         }
 
         // TODO(chenxiang): What if two threads reach here? It's better to
         // pend one thread, and only let one to fetch data from underlying store.
         let bytes = self.underlying_store.get_range(location, range).await?;
-        self.cache.insert(cache_key, bytes.clone()).await;
+        self.cache.insert(cache_key, bytes.clone());
 
         Ok(bytes)
     }
 
     async fn get_range_with_ro_cache(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
         let cache_key = Self::cache_key(location, &range);
-        if let Some(bytes) = self.cache.peek(&cache_key).await {
+        if let Some(bytes) = self.cache.peek(&cache_key) {
             return Ok(bytes);
         }
 
@@ -297,7 +295,7 @@ mod test {
 
     use super::*;
 
-    async fn prepare_store(bits: usize, mem_cap: usize) -> MemCacheStore {
+    fn prepare_store(bits: usize, mem_cap: usize) -> MemCacheStore {
         let local_path = tempdir().unwrap();
         let local_store = Arc::new(LocalFileSystem::new_with_prefix(local_path.path()).unwrap());
 
@@ -309,7 +307,7 @@ mod test {
     #[tokio::test]
     async fn test_mem_cache_evict() {
         // single partition
-        let store = prepare_store(0, 13).await;
+        let store = prepare_store(0, 13);
 
         // write date
         let location = Path::from("1.sst");
@@ -324,7 +322,6 @@ mod test {
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range0_5))
-            .await
             .is_some());
 
         // get bytes from [5, 10), insert to cache
@@ -333,12 +330,10 @@ mod test {
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range0_5))
-            .await
             .is_some());
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range5_10))
-            .await
             .is_some());
 
         // get bytes from [10, 15), insert to cache
@@ -351,24 +346,21 @@ mod test {
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range0_5))
-            .await
             .is_none());
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range5_10))
-            .await
             .is_some());
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range10_15))
-            .await
             .is_some());
     }
 
     #[tokio::test]
     async fn test_mem_cache_partition() {
         // 4 partitions
-        let store = prepare_store(2, 100).await;
+        let store = prepare_store(2, 100);
         let location = Path::from("partition.sst");
         store
             .put(&location, Bytes::from_static(&[1; 1024]))
@@ -388,18 +380,16 @@ mod test {
 1: [partition.sst-100-105]
 2: []
 3: [partition.sst-0-5]"#,
-            store.cache.as_ref().to_string().await
+            store.cache.as_ref().state_desc()
         );
 
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range0_5))
-            .await
             .is_some());
         assert!(store
             .cache
             .get(&MemCacheStore::cache_key(&location, &range100_105))
-            .await
             .is_some());
     }
 }

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -136,7 +136,6 @@ impl MemCache {
         self.partitions
             .iter()
             .map(|part| part.keys().join(","))
-            .into_iter()
             .enumerate()
             .map(|(part_no, keys)| format!("{part_no}: [{keys}]"))
             .collect::<Vec<_>>()

--- a/remote_engine_client/src/channel.rs
+++ b/remote_engine_client/src/channel.rs
@@ -2,11 +2,10 @@
 
 //! Channel pool
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::RwLock};
 
 use router::endpoint::Endpoint;
 use snafu::ResultExt;
-use tokio::sync::RwLock;
 use tonic::transport::{Channel, Endpoint as TonicEndpoint};
 
 use crate::{config::Config, error::*};
@@ -30,7 +29,7 @@ impl ChannelPool {
 
     pub async fn get(&self, endpoint: &Endpoint) -> Result<Channel> {
         {
-            let inner = self.channels.read().await;
+            let inner = self.channels.read().unwrap();
             if let Some(channel) = inner.get(endpoint) {
                 return Ok(channel.clone());
             }
@@ -40,7 +39,7 @@ impl ChannelPool {
             .builder
             .build(endpoint.clone().to_string().as_str())
             .await?;
-        let mut inner = self.channels.write().await;
+        let mut inner = self.channels.write().unwrap();
         // Double check here.
         if let Some(channel) = inner.get(endpoint) {
             return Ok(channel.clone());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 The tokio lock has performance issues when hot contention occurs, which may leading to yielding by tokio runtime schedule. That is to say, we should use std lock if the critical section is short or doesn't run across await point.

And the [api docs](https://docs.rs/tokio/1.26.0/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use) of tokio has made a explanation for the choice between tokio lock and std lock.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Replace the tokio lock with std lock as much as possible.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
