### PR TITLE
fix: avoid file purge when they are used in queries

### DIFF
--- a/analytic_engine/src/row_iter/chain.rs
+++ b/analytic_engine/src/row_iter/chain.rs
@@ -163,7 +163,7 @@ impl<'a> Builder<'a> {
             request_id: self.config.request_id,
             schema: self.config.projected_schema.to_record_schema_with_key(),
             streams,
-            _ssts: self.ssts,
+            ssts: self.ssts,
             next_stream_idx: 0,
             inited: false,
             metrics: Metrics::new(self.memtables.len(), total_sst_streams),
@@ -226,7 +226,8 @@ pub struct ChainIterator {
     schema: RecordSchemaWithKey,
     streams: Vec<SequencedRecordBatchStream>,
     /// ssts are kept here to avoid them from being purged.
-    _ssts: Vec<Vec<FileHandle>>,
+    #[allow(dead_code)]
+    ssts: Vec<Vec<FileHandle>>,
     /// The range of the index is [0, streams.len()] and the iterator is
     /// exhausted if it reaches `streams.len()`.
     next_stream_idx: usize,
@@ -325,7 +326,7 @@ mod tests {
             request_id: RequestId::next_id(),
             schema: schema.to_record_schema_with_key(),
             streams,
-            _ssts: Vec::new(),
+            ssts: Vec::new(),
             next_stream_idx: 0,
             inited: false,
             metrics: Metrics::new(0, 0),

--- a/analytic_engine/src/row_iter/chain.rs
+++ b/analytic_engine/src/row_iter/chain.rs
@@ -163,6 +163,7 @@ impl<'a> Builder<'a> {
             request_id: self.config.request_id,
             schema: self.config.projected_schema.to_record_schema_with_key(),
             streams,
+            _ssts: self.ssts,
             next_stream_idx: 0,
             inited: false,
             metrics: Metrics::new(self.memtables.len(), total_sst_streams),
@@ -224,6 +225,8 @@ pub struct ChainIterator {
     request_id: RequestId,
     schema: RecordSchemaWithKey,
     streams: Vec<SequencedRecordBatchStream>,
+    /// ssts are kept here to avoid them from being purged.
+    _ssts: Vec<Vec<FileHandle>>,
     /// The range of the index is [0, streams.len()] and the iterator is
     /// exhausted if it reaches `streams.len()`.
     next_stream_idx: usize,
@@ -322,6 +325,7 @@ mod tests {
             request_id: RequestId::next_id(),
             schema: schema.to_record_schema_with_key(),
             streams,
+            _ssts: Vec::new(),
             next_stream_idx: 0,
             inited: false,
             metrics: Metrics::new(0, 0),

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -621,7 +621,8 @@ pub struct MergeIterator {
     record_batch_builder: RecordBatchWithKeyBuilder,
     origin_streams: Vec<SequencedRecordBatchStream>,
     /// ssts are kept here to avoid them from being purged.
-    _ssts: Vec<Vec<FileHandle>>,
+    #[allow(dead_code)]
+    ssts: Vec<Vec<FileHandle>>,
     /// Any [BufferedStream] in the hot heap is not empty.
     hot: BinaryHeap<HeapBufferedStream>,
     /// Any [BufferedStream] in the cold heap is not empty.
@@ -651,7 +652,7 @@ impl MergeIterator {
             request_id,
             inited: false,
             schema,
-            _ssts: ssts,
+            ssts,
             record_batch_builder,
             origin_streams: streams,
             hot: BinaryHeap::with_capacity(heap_cap),

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -23,7 +23,7 @@ use common_util::{
     metric::Meter,
     runtime::{JoinHandle, Runtime},
 };
-use log::{debug, error, info};
+use log::{error, info, warn};
 use object_store::ObjectStoreRef;
 use snafu::{ResultExt, Snafu};
 use table_engine::table::TableId;
@@ -249,7 +249,7 @@ struct FileHandleInner {
 
 impl Drop for FileHandleInner {
     fn drop(&mut self) {
-        debug!("FileHandle is dropped, meta:{:?}", self.meta);
+        info!("FileHandle is dropped, meta:{:?}", self.meta);
 
         // Push file cannot block or be async because we are in drop().
         self.purge_queue.push_file(self.meta.id);
@@ -426,6 +426,7 @@ impl FilePurgeQueue {
 
     fn push_file(&self, file_id: FileId) {
         if self.inner.closed.load(Ordering::SeqCst) {
+            warn!("Purger closed, ignore file_id:{file_id}");
             return;
         }
 

--- a/analytic_engine/src/tests/compaction_test.rs
+++ b/analytic_engine/src/tests/compaction_test.rs
@@ -11,14 +11,12 @@ use crate::{
 };
 
 #[test]
-#[ignore = "https://github.com/CeresDB/ceresdb/issues/427"]
 fn test_table_compact_current_segment_rocks() {
     let rocksdb_ctx = RocksDBEngineContext::default();
     test_table_compact_current_segment(rocksdb_ctx);
 }
 
 #[test]
-#[ignore = "https://github.com/CeresDB/ceresdb/issues/427"]
 fn test_table_compact_current_segment_mem_wal() {
     let memory_ctx = MemoryEngineContext::default();
     test_table_compact_current_segment(memory_ctx);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #427 #534

# Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Hold sst reference in merge/chain iterator, so sst cannot be pushed to purge queue when there are queries.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

CI
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

