### PR TITLE
chore: add concrete tag to log when write failed

### DIFF
--- a/server/src/grpc/storage_service/write.rs
+++ b/server/src/grpc/storage_service/write.rs
@@ -391,7 +391,7 @@ fn write_entry_to_rows(
             ErrNoCause {
                 code: StatusCode::BAD_REQUEST,
                 msg: format!(
-                    "tag index {name_index} is not found in tag_names:{tag_names:?}, table:{table_name}",
+                    "tag {tag:?} is not found in tag_names:{tag_names:?}, table:{table_name}",
                 ),
             }
         );

--- a/sql/src/planner.rs
+++ b/sql/src/planner.rs
@@ -382,9 +382,9 @@ fn build_schema_from_write_table_request(
             let name_index = tag.name_index as usize;
             ensure!(
                 name_index < tag_names.len(),
-                InvalidWriteEntry{
+                InvalidWriteEntry {
                     msg: format!(
-                        "tag index {name_index} is not found in tag_names:{tag_names:?}, table:{table}",
+                        "tag {tag:?} is not found in tag_names:{tag_names:?}, table:{table}",
                     ),
                 }
             );


### PR DESCRIPTION
# Which issue does this PR close?

Closes #

# Rationale for this change
 
When write to CeresDB via Prometheus remote write, I got following error

```bash
2023-03-08 06:32:48.818 ERRO [server/src/http.rs:520] handle error: Rejection(GRPCWriteError { source: ErrNoCause { code: 400, msg: "tag index 7 is not found in tag_names:[\"env\", \"instance\", \"job\", \"le\", \"space\", \"tenant\", \"type\"], table:cse_rpc_duration_seconds_bucket" } })
2023-03-08 06:32:48.818 ERRO [server/src/http.rs:520] handle error: Rejection(GRPCWriteError { source: ErrNoCause { code: 400, msg: "tag index 7 is not found in tag_names:[\"env\", \"instance\", \"job\", \"le\", \"space\", \"tenant\", \"type\"], table:cse_rpc_duration_seconds_bucket" } })
```

Tag index is hard to debug which tag cause problem.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Log concrete tag when write failed
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

# Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

# How does this change test

CI
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

