### PR TITLE
feat: new crate `trace_metric` for collecting metrics in read procedure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6342,6 +6342,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
+name = "trace_metric"
+version = "1.0.0"
+
+[[package]]
 name = "tracing"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "table_kv",
  "tempfile",
  "tokio",
+ "trace_metric",
  "wal",
  "xorfilter-rs",
 ]
@@ -656,6 +657,7 @@ dependencies = [
  "table_engine",
  "table_kv",
  "tokio",
+ "trace_metric",
  "wal",
  "zstd 0.12.1+zstd.1.5.2",
 ]
@@ -5869,6 +5871,7 @@ dependencies = [
  "snafu 0.6.10",
  "table_engine",
  "tokio",
+ "trace_metric",
 ]
 
 [[package]]
@@ -5894,6 +5897,7 @@ dependencies = [
  "smallvec",
  "snafu 0.6.10",
  "tokio",
+ "trace_metric",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6344,6 +6344,25 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "trace_metric"
 version = "1.0.0"
+dependencies = [
+ "trace_metric_derive",
+]
+
+[[package]]
+name = "trace_metric_derive"
+version = "1.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "trace_metric_derive_tests"
+version = "1.0.0"
+dependencies = [
+ "trace_metric",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ members = [
     "components/skiplist",
     "components/table_kv",
     "components/trace_metric",
+    "components/trace_metric_derive",
+    "components/trace_metric_derive_tests",
     "components/tracing_util",
     "df_operator",
     "integration_tests",
@@ -113,6 +115,9 @@ table_engine = { path = "table_engine" }
 table_kv = { path = "components/table_kv" }
 tempfile = "3.1.0"
 tracing_util = { path = "components/tracing_util" }
+trace_metric = { path = "components/trace_metric" }
+trace_metric_derive = { path = "components/trace_metric_derive" }
+trace_metric_derive_tests = { path = "components/trace_metric_derive_tests" }
 tonic = "0.8.1"
 tokio = { version = "1.25", features = ["full"] }
 wal = { path = "wal" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "components/profile",
     "components/skiplist",
     "components/table_kv",
+    "components/trace_metric",
     "components/tracing_util",
     "df_operator",
     "integration_tests",

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -46,6 +46,7 @@ table_engine = { workspace = true }
 table_kv = { workspace = true }
 tempfile = { workspace = true, optional = true }
 tokio = { workspace = true }
+trace_metric = { workspace = true }
 wal = { workspace = true }
 xorfilter-rs = { workspace = true }
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -28,6 +28,7 @@ use log::{debug, error, info};
 use snafu::{Backtrace, ResultExt, Snafu};
 use table_engine::{predicate::Predicate, table::Result as TableResult};
 use tokio::sync::oneshot;
+use trace_metric::Collector;
 use wal::manager::WalLocation;
 
 use crate::{
@@ -855,7 +856,7 @@ impl SpaceStore {
             let sequence = table_data.last_sequence();
             let mut builder = MergeBuilder::new(MergeConfig {
                 request_id,
-                metrics_collector: None,
+                metrics_collector: Collector::new("compaction".to_string()),
                 // no need to set deadline for compaction
                 deadline: None,
                 space_id,

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -855,6 +855,7 @@ impl SpaceStore {
             let sequence = table_data.last_sequence();
             let mut builder = MergeBuilder::new(MergeConfig {
                 request_id,
+                metrics_collector: None,
                 // no need to set deadline for compaction
                 deadline: None,
                 space_id,

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -1054,6 +1054,7 @@ fn build_mem_table_iter(memtable: MemTableRef, table_data: &TableData) -> Result
         projected_schema: ProjectedSchema::no_projection(table_data.schema()),
         need_dedup: table_data.dedup(),
         reverse: false,
+        metrics_collector: None,
     };
     memtable
         .scan(scan_ctx, scan_req)

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -28,7 +28,6 @@ use log::{debug, error, info};
 use snafu::{Backtrace, ResultExt, Snafu};
 use table_engine::{predicate::Predicate, table::Result as TableResult};
 use tokio::sync::oneshot;
-use trace_metric::Collector;
 use wal::manager::WalLocation;
 
 use crate::{
@@ -856,7 +855,7 @@ impl SpaceStore {
             let sequence = table_data.last_sequence();
             let mut builder = MergeBuilder::new(MergeConfig {
                 request_id,
-                metrics_collector: Collector::new("compaction".to_string()),
+                metrics_collector: None,
                 // no need to set deadline for compaction
                 deadline: None,
                 space_id,

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -14,7 +14,6 @@ pub mod flush_compaction;
 pub(crate) mod mem_collector;
 pub mod open;
 mod read;
-pub(crate) mod read_metrics;
 pub(crate) mod write;
 pub mod write_worker;
 

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -14,6 +14,7 @@ pub mod flush_compaction;
 pub(crate) mod mem_collector;
 pub mod open;
 mod read;
+pub(crate) mod read_metrics;
 pub(crate) mod write;
 pub mod write_worker;
 

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -181,7 +181,7 @@ impl Instance {
         for (idx, read_view) in read_views.into_iter().enumerate() {
             let metrics_collector = request
                 .metrics_collector
-                .span(format!("{MERGE_ITER_COLLECTOR_NAME_PREFIX}_{idx}"));
+                .span(format!("{MERGE_ITER_METRICS_COLLECTOR_NAME_PREFIX}_{idx}"));
             let merge_config = MergeConfig {
                 request_id: request.request_id,
                 metrics_collector: Some(metrics_collector),

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -177,10 +177,11 @@ impl Instance {
         let read_views = self.partition_ssts_and_memtables(time_range, version, table_options);
 
         let mut iters = Vec::with_capacity(read_views.len());
-        for read_view in read_views {
+        for (idx, read_view) in read_views.into_iter().enumerate() {
+            let metrics_collector = request.metrics_collector.span(format!("merge_{idx}");
             let merge_config = MergeConfig {
                 request_id: request.request_id,
-                metrics_collector: Some(request.metrics_collector.clone()),
+                metrics_collector: Some(metrics_collector),
                 deadline: request.opts.deadline,
                 space_id: table_data.space_id,
                 table_id: table_data.id,

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -69,6 +69,7 @@ define_result!(Error);
 const RECORD_BATCH_READ_BUF_SIZE: usize = 1000;
 const MERGE_SORT_METRIC_NAME: &str = "do_merge_sort";
 const ITER_NUM_METRIC_NAME: &str = "iter_num";
+const MERGE_ITER_METRICS_COLLECTOR_NAME_PREFIX: &str = "merge_iter";
 
 /// Check whether it needs to apply merge sorting when reading the table with
 /// the `table_options` by the `read_request`.
@@ -178,7 +179,9 @@ impl Instance {
 
         let mut iters = Vec::with_capacity(read_views.len());
         for (idx, read_view) in read_views.into_iter().enumerate() {
-            let metrics_collector = request.metrics_collector.span(format!("merge_{idx}");
+            let metrics_collector = request
+                .metrics_collector
+                .span(format!("{MERGE_ITER_COLLECTOR_NAME_PREFIX}_{idx}"));
             let merge_config = MergeConfig {
                 request_id: request.request_id,
                 metrics_collector: Some(metrics_collector),

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -67,8 +67,8 @@ pub enum Error {
 define_result!(Error);
 
 const RECORD_BATCH_READ_BUF_SIZE: usize = 1000;
-const READ_METRIC_MERGE_SORT: &str = "do_merge_sort";
-const READ_METRIC_ITER_NUM: &str = "iter_num";
+const MERGE_SORT_METRIC_NAME: &str = "do_merge_sort";
+const ITER_NUM_METRIC_NAME: &str = "iter_num";
 
 /// Check whether it needs to apply merge sorting when reading the table with
 /// the `table_options` by the `read_request`.
@@ -101,7 +101,7 @@ impl Instance {
         table_data.metrics.on_read_request_begin();
         let need_merge_sort = need_merge_sort_streams(&table_options, &request);
         request.metrics_collector.collect(Metric::boolean(
-            READ_METRIC_MERGE_SORT.to_string(),
+            MERGE_SORT_METRIC_NAME.to_string(),
             need_merge_sort,
         ));
 
@@ -211,7 +211,7 @@ impl Instance {
         }
 
         request.metrics_collector.collect(Metric::counter(
-            READ_METRIC_ITER_NUM.to_string(),
+            ITER_NUM_METRIC_NAME.to_string(),
             iters.len(),
         ));
 

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -20,9 +20,10 @@ use table_engine::{
     stream::{
         self, ErrWithSource, PartitionedStreams, RecordBatchStream, SendableRecordBatchStream,
     },
-    table::{Metric, ReadRequest},
+    table::ReadRequest,
 };
 use tokio::sync::mpsc::{self, Receiver};
+use trace_metric::Metric;
 
 use crate::{
     instance::Instance,
@@ -179,7 +180,7 @@ impl Instance {
         for read_view in read_views {
             let merge_config = MergeConfig {
                 request_id: request.request_id,
-                metrics_collector: Some(request.metrics_collector.clone()),
+                metrics_collector: request.metrics_collector.clone(),
                 deadline: request.opts.deadline,
                 space_id: table_data.space_id,
                 table_id: table_data.id,

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -214,7 +214,7 @@ impl Instance {
             iters.push(dedup_iter);
         }
 
-        request.metrics_collector.collect(Metric::counter(
+        request.metrics_collector.collect(Metric::number(
             ITER_NUM_METRIC_NAME.to_string(),
             iters.len(),
         ));

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -180,7 +180,7 @@ impl Instance {
         for read_view in read_views {
             let merge_config = MergeConfig {
                 request_id: request.request_id,
-                metrics_collector: request.metrics_collector.clone(),
+                metrics_collector: Some(request.metrics_collector.clone()),
                 deadline: request.opts.deadline,
                 space_id: table_data.space_id,
                 table_id: table_data.id,

--- a/analytic_engine/src/instance/read_metrics.rs
+++ b/analytic_engine/src/instance/read_metrics.rs
@@ -1,0 +1,2 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+

--- a/analytic_engine/src/instance/read_metrics.rs
+++ b/analytic_engine/src/instance/read_metrics.rs
@@ -1,2 +1,0 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
-

--- a/analytic_engine/src/memtable/mod.rs
+++ b/analytic_engine/src/memtable/mod.rs
@@ -18,7 +18,7 @@ use common_types::{
 };
 use common_util::{define_result, error::GenericError};
 use snafu::{Backtrace, Snafu};
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use crate::memtable::key::KeySequence;
 
@@ -131,7 +131,7 @@ pub struct ScanRequest {
     pub need_dedup: bool,
     pub reverse: bool,
     /// Collector for scan metrics.
-    pub metrics_collector: Option<Collector>,
+    pub metrics_collector: Option<MetricsCollector>,
 }
 
 /// In memory storage for table's data.

--- a/analytic_engine/src/memtable/mod.rs
+++ b/analytic_engine/src/memtable/mod.rs
@@ -18,6 +18,7 @@ use common_types::{
 };
 use common_util::{define_result, error::GenericError};
 use snafu::{Backtrace, Snafu};
+use trace_metric::Collector;
 
 use crate::memtable::key::KeySequence;
 
@@ -129,14 +130,16 @@ pub struct ScanRequest {
     pub projected_schema: ProjectedSchema,
     pub need_dedup: bool,
     pub reverse: bool,
+    /// Collector for scan metrics.
+    pub metrics_collector: Option<Collector>,
 }
 
 /// In memory storage for table's data.
 ///
 /// # Concurrency
-/// The memtable is designed for single-writer and mutltiple-reader usage, so
+/// The memtable is designed for single-writer and multiple-reader usage, so
 /// not all function supports concurrent writer, the caller should guarantee not
-/// writing to the memtable concurrrently.
+/// writing to the memtable concurrently.
 // All operation is done in memory, no need to use async trait
 pub trait MemTable {
     /// Schema of this memtable

--- a/analytic_engine/src/memtable/skiplist/mod.rs
+++ b/analytic_engine/src/memtable/skiplist/mod.rs
@@ -204,6 +204,7 @@ mod tests {
                     projected_schema: projected_schema.clone(),
                     need_dedup: true,
                     reverse: false,
+                    metrics_collector: None,
                 },
                 vec![
                     build_row(b"a", 1, 10.0, "v1", 1000, 1_000_000),
@@ -223,6 +224,7 @@ mod tests {
                     projected_schema: projected_schema.clone(),
                     need_dedup: true,
                     reverse: false,
+                    metrics_collector: None,
                 },
                 vec![
                     build_row(b"a", 1, 10.0, "v1", 1000, 1_000_000),
@@ -241,6 +243,7 @@ mod tests {
                     projected_schema,
                     need_dedup: true,
                     reverse: false,
+                    metrics_collector: None,
                 },
                 vec![
                     build_row(b"a", 1, 10.0, "v1", 1000, 1_000_000),
@@ -272,6 +275,7 @@ mod tests {
                 projected_schema,
                 need_dedup: true,
                 reverse: false,
+                metrics_collector: None,
             },
             vec![
                 build_row_for_two_column(b"a", 1),

--- a/analytic_engine/src/row_iter/chain.rs
+++ b/analytic_engine/src/row_iter/chain.rs
@@ -116,6 +116,7 @@ impl<'a> Builder<'a> {
                 false,
                 self.config.predicate.as_ref(),
                 self.config.deadline,
+                None,
             )
             .context(BuildStreamFromMemtable)?;
             streams.push(stream);
@@ -131,6 +132,7 @@ impl<'a> Builder<'a> {
                 false,
                 self.config.predicate.as_ref(),
                 self.config.deadline,
+                None,
             )
             .context(BuildStreamFromMemtable)?;
             streams.push(stream);
@@ -145,6 +147,7 @@ impl<'a> Builder<'a> {
                     self.config.sst_factory,
                     &self.config.sst_read_options,
                     self.config.store_picker,
+                    None,
                 )
                 .await
                 .context(BuildStreamFromSst)?;

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -23,7 +23,7 @@ use futures::{future::try_join_all, StreamExt};
 use log::{debug, trace};
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use table_engine::{predicate::PredicateRef, table::TableId};
-use trace_metric::{Collector, TracedMetrics};
+use trace_metric::{MetricsCollector, TracedMetrics};
 
 use crate::{
     row_iter::{
@@ -84,7 +84,7 @@ define_result!(Error);
 #[derive(Debug)]
 pub struct MergeConfig<'a> {
     pub request_id: RequestId,
-    pub metrics_collector: Option<Collector>,
+    pub metrics_collector: Option<MetricsCollector>,
     /// None for background jobs, such as: compaction
     pub deadline: Option<Instant>,
     pub space_id: SpaceId,
@@ -591,11 +591,11 @@ pub struct Metrics {
     #[metric(counter)]
     scan_count: usize,
     #[metric(collector)]
-    metrics_collector: Option<Collector>,
+    metrics_collector: Option<MetricsCollector>,
 }
 
 impl Metrics {
-    fn new(num_memtables: usize, num_ssts: usize, collector: Option<Collector>) -> Self {
+    fn new(num_memtables: usize, num_ssts: usize, collector: Option<MetricsCollector>) -> Self {
         Self {
             num_memtables,
             num_ssts,

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -23,7 +23,7 @@ use futures::{future::try_join_all, StreamExt};
 use log::{debug, trace};
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use table_engine::{predicate::PredicateRef, table::TableId};
-use trace_metric::{MetricsCollector, TracedMetrics};
+use trace_metric::{MetricsCollector, TraceMetricWhenDrop};
 
 use crate::{
     row_iter::{
@@ -566,7 +566,7 @@ impl Ord for HeapBufferedStream {
 }
 
 /// Metrics for merge iterator.
-#[derive(TracedMetrics)]
+#[derive(TraceMetricWhenDrop)]
 pub struct Metrics {
     #[metric(counter)]
     num_memtables: usize,

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -568,27 +568,27 @@ impl Ord for HeapBufferedStream {
 /// Metrics for merge iterator.
 #[derive(TraceMetricWhenDrop)]
 pub struct Metrics {
-    #[metric(counter)]
+    #[metric(number)]
     num_memtables: usize,
-    #[metric(counter)]
+    #[metric(number)]
     num_ssts: usize,
     /// Total rows collected using fetch_rows_from_one_stream().
-    #[metric(counter)]
+    #[metric(number)]
     total_rows_fetch_from_one: usize,
     /// Times to fetch rows from one stream.
-    #[metric(counter)]
+    #[metric(number)]
     times_fetch_rows_from_one: usize,
     /// Times to fetch one row from multiple stream.
-    #[metric(counter)]
+    #[metric(number)]
     times_fetch_row_from_multiple: usize,
     /// Init time cost of the metrics.
-    #[metric(elapsed)]
+    #[metric(duration)]
     init_duration: Duration,
     /// Scan time cost of the metrics.
-    #[metric(elapsed)]
+    #[metric(duration)]
     scan_duration: Duration,
     /// Scan count
-    #[metric(counter)]
+    #[metric(number)]
     scan_count: usize,
     #[metric(collector)]
     metrics_collector: Option<MetricsCollector>,

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -184,6 +184,7 @@ impl<'a> MergeBuilder<'a> {
                 self.config.reverse,
                 self.config.predicate.as_ref(),
                 self.config.deadline,
+                self.config.metrics_collector.clone(),
             )
             .context(BuildStreamFromMemtable)?;
             streams.push(stream);
@@ -197,6 +198,7 @@ impl<'a> MergeBuilder<'a> {
                 self.config.reverse,
                 self.config.predicate.as_ref(),
                 self.config.deadline,
+                self.config.metrics_collector.clone(),
             )
             .context(BuildStreamFromMemtable)?;
             streams.push(stream);
@@ -212,6 +214,7 @@ impl<'a> MergeBuilder<'a> {
                     self.config.sst_factory,
                     &self.config.sst_read_options,
                     self.config.store_picker,
+                    self.config.metrics_collector.clone(),
                 )
                 .await
                 .context(BuildStreamFromSst)?;

--- a/analytic_engine/src/row_iter/record_batch_stream.rs
+++ b/analytic_engine/src/row_iter/record_batch_stream.rs
@@ -27,7 +27,7 @@ use datafusion::{
 use futures::stream::{self, Stream, StreamExt};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::{predicate::Predicate, table::TableId};
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use crate::{
     memtable::{MemTableRef, ScanContext, ScanRequest},
@@ -209,7 +209,7 @@ pub fn filtered_stream_from_memtable(
     reverse: bool,
     predicate: &Predicate,
     deadline: Option<Instant>,
-    metrics_collector: Option<Collector>,
+    metrics_collector: Option<MetricsCollector>,
 ) -> Result<SequencedRecordBatchStream> {
     stream_from_memtable(
         projected_schema.clone(),
@@ -237,7 +237,7 @@ pub fn stream_from_memtable(
     memtable: &MemTableRef,
     reverse: bool,
     deadline: Option<Instant>,
-    metrics_collector: Option<Collector>,
+    metrics_collector: Option<MetricsCollector>,
 ) -> Result<SequencedRecordBatchStream> {
     let scan_ctx = ScanContext {
         deadline,
@@ -277,7 +277,7 @@ pub async fn filtered_stream_from_sst_file(
     sst_factory: &SstFactoryRef,
     sst_read_options: &SstReadOptions,
     store_picker: &ObjectStorePickerRef,
-    metrics_collector: Option<Collector>,
+    metrics_collector: Option<MetricsCollector>,
 ) -> Result<SequencedRecordBatchStream> {
     stream_from_sst_file(
         space_id,
@@ -309,7 +309,7 @@ pub async fn stream_from_sst_file(
     sst_factory: &SstFactoryRef,
     sst_read_options: &SstReadOptions,
     store_picker: &ObjectStorePickerRef,
-    metrics_collector: Option<Collector>,
+    metrics_collector: Option<MetricsCollector>,
 ) -> Result<SequencedRecordBatchStream> {
     sst_file.read_meter().mark();
     let path = sst_util::new_sst_file_path(space_id, table_id, sst_file.id());

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -10,7 +10,7 @@ use common_util::{define_result, runtime::Runtime};
 use object_store::{ObjectStoreRef, Path};
 use snafu::{ResultExt, Snafu};
 use table_engine::predicate::PredicateRef;
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use crate::{
     sst::{
@@ -66,7 +66,7 @@ pub trait Factory: Send + Sync + Debug {
         options: &SstReadOptions,
         hint: SstReadHint,
         store_picker: &'a ObjectStorePickerRef,
-        metrics_collector: Option<Collector>,
+        metrics_collector: Option<MetricsCollector>,
     ) -> Result<Box<dyn SstReader + Send + 'a>>;
 
     async fn create_writer<'a>(
@@ -129,7 +129,7 @@ impl Factory for FactoryImpl {
         options: &SstReadOptions,
         hint: SstReadHint,
         store_picker: &'a ObjectStorePickerRef,
-        metrics_collector: Option<Collector>,
+        metrics_collector: Option<MetricsCollector>,
     ) -> Result<Box<dyn SstReader + Send + 'a>> {
         let storage_format = match hint.file_format {
             Some(v) => v,

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -10,6 +10,7 @@ use common_util::{define_result, runtime::Runtime};
 use object_store::{ObjectStoreRef, Path};
 use snafu::{ResultExt, Snafu};
 use table_engine::predicate::PredicateRef;
+use trace_metric::Collector;
 
 use crate::{
     sst::{
@@ -65,6 +66,7 @@ pub trait Factory: Send + Sync + Debug {
         options: &SstReadOptions,
         hint: SstReadHint,
         store_picker: &'a ObjectStorePickerRef,
+        metrics_collector: Option<Collector>,
     ) -> Result<Box<dyn SstReader + Send + 'a>>;
 
     async fn create_writer<'a>(
@@ -127,6 +129,7 @@ impl Factory for FactoryImpl {
         options: &SstReadOptions,
         hint: SstReadHint,
         store_picker: &'a ObjectStorePickerRef,
+        metrics_collector: Option<Collector>,
     ) -> Result<Box<dyn SstReader + Send + 'a>> {
         let storage_format = match hint.file_format {
             Some(v) => v,
@@ -138,7 +141,13 @@ impl Factory for FactoryImpl {
 
         match storage_format {
             StorageFormat::Columnar | StorageFormat::Hybrid => {
-                let reader = AsyncParquetReader::new(path, options, hint.file_size, store_picker);
+                let reader = AsyncParquetReader::new(
+                    path,
+                    options,
+                    hint.file_size,
+                    store_picker,
+                    metrics_collector,
+                );
                 let reader = ThreadedReader::new(
                     reader,
                     options.runtime.clone(),

--- a/analytic_engine/src/sst/meta_data/mod.rs
+++ b/analytic_engine/src/sst/meta_data/mod.rs
@@ -149,7 +149,7 @@ impl SstMetaReader {
             };
             let mut reader = self
                 .factory
-                .create_reader(&path, &self.read_opts, read_hint, &self.store_picker)
+                .create_reader(&path, &self.read_opts, read_hint, &self.store_picker, None)
                 .await
                 .context(CreateSstReader)?;
             let meta_data = reader.meta_data().await.context(ReadMetaData)?;

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -77,7 +77,7 @@ pub struct Reader<'a> {
     metrics: Metrics,
 }
 
-#[derive(Debug, Clone, TraceMetricWhenDrop)]
+#[derive(Default, Debug, Clone, TraceMetricWhenDrop)]
 pub(crate) struct Metrics {
     #[metric(boolean)]
     pub meta_data_cache_hit: bool,
@@ -103,10 +103,8 @@ impl<'a> Reader<'a> {
         let store = store_picker.pick_by_freq(options.frequency);
 
         let metrics = Metrics {
-            meta_data_cache_hit: false,
-            read_meta_data_duration: Duration::from_secs(0),
-            parallelism: 0,
             metrics_collector,
+            ..Default::default()
         };
 
         Self {

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -34,7 +34,7 @@ use prometheus::local::LocalHistogram;
 use snafu::ResultExt;
 use table_engine::predicate::PredicateRef;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use trace_metric::{Collector, TracedMetrics};
+use trace_metric::{MetricsCollector, TracedMetrics};
 
 use crate::sst::{
     factory::{ObjectStorePickerRef, ReadFrequency, SstReadOptions},
@@ -85,7 +85,7 @@ pub(crate) struct Metrics {
     #[metric(counter)]
     pub parallelism: usize,
     #[metric(collector)]
-    pub metrics_collector: Option<Collector>,
+    pub metrics_collector: Option<MetricsCollector>,
 }
 
 impl<'a> Reader<'a> {
@@ -94,7 +94,7 @@ impl<'a> Reader<'a> {
         options: &SstReadOptions,
         file_size_hint: Option<usize>,
         store_picker: &'a ObjectStorePickerRef,
-        metrics_collector: Option<Collector>,
+        metrics_collector: Option<MetricsCollector>,
     ) -> Self {
         let batch_size = options.read_batch_row_num;
         let parallelism_options =

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -51,6 +51,7 @@ use crate::sst::{
     reader::{error::*, Result, SstReader},
 };
 
+const PRUNE_ROW_GROUPS_COLLECTOR_NAME: &str = "prune_row_groups";
 type SendableRecordBatchStream = Pin<Box<dyn Stream<Item = Result<ArrowRecordBatch>> + Send>>;
 
 pub struct Reader<'a> {
@@ -176,7 +177,7 @@ impl<'a> Reader<'a> {
             .metrics
             .metrics_collector
             .as_ref()
-            .map(|v| v.span("prune_row_groups".to_string()));
+            .map(|v| v.span(PRUNE_ROW_GROUPS_COLLECTOR_NAME.to_string()));
         let mut pruner = RowGroupPruner::try_new(
             &schema,
             row_groups,

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -7,7 +7,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use arrow::{datatypes::SchemaRef, record_batch::RecordBatch as ArrowRecordBatch};
@@ -34,6 +34,7 @@ use prometheus::local::LocalHistogram;
 use snafu::ResultExt;
 use table_engine::predicate::PredicateRef;
 use tokio::sync::mpsc::{self, Receiver, Sender};
+use trace_metric::{Collector, TracedMetrics};
 
 use crate::sst::{
     factory::{ObjectStorePickerRef, ReadFrequency, SstReadOptions},
@@ -72,6 +73,19 @@ pub struct Reader<'a> {
 
     /// Options for `read_parallelly`
     parallelism_options: ParallelismOptions,
+    metrics: Metrics,
+}
+
+#[derive(Debug, Clone, TracedMetrics)]
+pub(crate) struct Metrics {
+    #[metric(boolean)]
+    pub meta_data_cache_hit: bool,
+    #[metric(elapsed)]
+    pub read_meta_data_duration: Duration,
+    #[metric(counter)]
+    pub parallelism: usize,
+    #[metric(collector)]
+    pub metrics_collector: Option<Collector>,
 }
 
 impl<'a> Reader<'a> {
@@ -80,11 +94,19 @@ impl<'a> Reader<'a> {
         options: &SstReadOptions,
         file_size_hint: Option<usize>,
         store_picker: &'a ObjectStorePickerRef,
+        metrics_collector: Option<Collector>,
     ) -> Self {
         let batch_size = options.read_batch_row_num;
         let parallelism_options =
             ParallelismOptions::new(options.read_batch_row_num, options.num_rows_per_row_group);
         let store = store_picker.pick_by_freq(options.frequency);
+
+        let metrics = Metrics {
+            meta_data_cache_hit: false,
+            read_meta_data_duration: Duration::from_secs(0),
+            parallelism: 0,
+            metrics_collector,
+        };
 
         Self {
             path,
@@ -98,6 +120,7 @@ impl<'a> Reader<'a> {
             meta_data: None,
             row_projector: None,
             parallelism_options,
+            metrics,
         }
     }
 
@@ -149,8 +172,18 @@ impl<'a> Reader<'a> {
         row_groups: &[RowGroupMetaData],
         parquet_filter: Option<&ParquetFilter>,
     ) -> Result<Vec<usize>> {
-        let pruner =
-            RowGroupPruner::try_new(&schema, row_groups, parquet_filter, self.predicate.exprs())?;
+        let metrics_collector = self
+            .metrics
+            .metrics_collector
+            .as_ref()
+            .map(|v| v.span("prune_row_groups".to_string()));
+        let mut pruner = RowGroupPruner::try_new(
+            &schema,
+            row_groups,
+            parquet_filter,
+            self.predicate.exprs(),
+            metrics_collector,
+        )?;
 
         Ok(pruner.prune())
     }
@@ -191,10 +224,12 @@ impl<'a> Reader<'a> {
         // adjust it when supporting it other situations.
         let chunks_num = read_parallelism;
         let chunk_size = target_row_groups.len() / read_parallelism + 1;
+        self.metrics.parallelism = read_parallelism;
         info!(
             "Reader fetch record batches parallelly, parallelism suggest:{}, real:{}, chunk_size:{}",
             suggest_read_parallelism, read_parallelism, chunk_size
         );
+
         let mut target_row_group_chunks = vec![Vec::with_capacity(chunk_size); chunks_num];
         for (row_group_idx, row_group) in target_row_groups.into_iter().enumerate() {
             let chunk_idx = row_group_idx % chunks_num;
@@ -232,7 +267,12 @@ impl<'a> Reader<'a> {
             return Ok(());
         }
 
-        let meta_data = self.read_sst_meta().await?;
+        let meta_data = {
+            let start = Instant::now();
+            let meta_data = self.read_sst_meta().await?;
+            self.metrics.read_meta_data_duration = start.elapsed();
+            meta_data
+        };
 
         let row_projector = self
             .projected_schema
@@ -280,9 +320,10 @@ impl<'a> Reader<'a> {
         }
     }
 
-    async fn read_sst_meta(&self) -> Result<MetaData> {
+    async fn read_sst_meta(&mut self) -> Result<MetaData> {
         if let Some(cache) = &self.meta_cache {
             if let Some(meta_data) = cache.get(self.path.as_ref()) {
+                self.metrics.meta_data_cache_hit = true;
                 return Ok(meta_data);
             }
         }
@@ -356,7 +397,7 @@ impl ParallelismOptions {
 }
 
 #[derive(Clone, Debug)]
-struct ReaderMetrics {
+struct ObjectReaderMetrics {
     bytes_scanned: usize,
     sst_get_range_length_histogram: LocalHistogram,
 }
@@ -366,7 +407,7 @@ struct ObjectStoreReader {
     storage: ObjectStoreRef,
     path: Path,
     meta_data: MetaData,
-    metrics: ReaderMetrics,
+    metrics: ObjectReaderMetrics,
 }
 
 impl ObjectStoreReader {
@@ -375,7 +416,7 @@ impl ObjectStoreReader {
             storage,
             path,
             meta_data,
-            metrics: ReaderMetrics {
+            metrics: ObjectReaderMetrics {
                 bytes_scanned: 0,
                 sst_get_range_length_histogram: metrics::SST_GET_RANGE_HISTOGRAM.local(),
             },

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -81,9 +81,9 @@ pub struct Reader<'a> {
 pub(crate) struct Metrics {
     #[metric(boolean)]
     pub meta_data_cache_hit: bool,
-    #[metric(elapsed)]
+    #[metric(duration)]
     pub read_meta_data_duration: Duration,
-    #[metric(counter)]
+    #[metric(number)]
     pub parallelism: usize,
     #[metric(collector)]
     pub metrics_collector: Option<MetricsCollector>,

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -34,7 +34,7 @@ use prometheus::local::LocalHistogram;
 use snafu::ResultExt;
 use table_engine::predicate::PredicateRef;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use trace_metric::{MetricsCollector, TracedMetrics};
+use trace_metric::{MetricsCollector, TraceMetricWhenDrop};
 
 use crate::sst::{
     factory::{ObjectStorePickerRef, ReadFrequency, SstReadOptions},
@@ -76,7 +76,7 @@ pub struct Reader<'a> {
     metrics: Metrics,
 }
 
-#[derive(Debug, Clone, TracedMetrics)]
+#[derive(Debug, Clone, TraceMetricWhenDrop)]
 pub(crate) struct Metrics {
     #[metric(boolean)]
     pub meta_data_cache_hit: bool,

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -51,7 +51,7 @@ use crate::sst::{
     reader::{error::*, Result, SstReader},
 };
 
-const PRUNE_ROW_GROUPS_COLLECTOR_NAME: &str = "prune_row_groups";
+const PRUNE_ROW_GROUPS_METRICS_COLLECTOR_NAME: &str = "prune_row_groups";
 type SendableRecordBatchStream = Pin<Box<dyn Stream<Item = Result<ArrowRecordBatch>> + Send>>;
 
 pub struct Reader<'a> {
@@ -175,7 +175,7 @@ impl<'a> Reader<'a> {
             .metrics
             .metrics_collector
             .as_ref()
-            .map(|v| v.span(PRUNE_ROW_GROUPS_COLLECTOR_NAME.to_string()));
+            .map(|v| v.span(PRUNE_ROW_GROUPS_METRICS_COLLECTOR_NAME.to_string()));
         let mut pruner = RowGroupPruner::try_new(
             &schema,
             row_groups,

--- a/analytic_engine/src/sst/parquet/row_group_pruner.rs
+++ b/analytic_engine/src/sst/parquet/row_group_pruner.rs
@@ -14,7 +14,7 @@ use parquet_ext::prune::{
     min_max,
 };
 use snafu::ensure;
-use trace_metric::{Collector, TracedMetrics};
+use trace_metric::{MetricsCollector, TracedMetrics};
 
 use crate::sst::{
     parquet::meta_data::ParquetFilter,
@@ -34,7 +34,7 @@ struct Metrics {
     #[metric(counter)]
     pruned_by_min_max: usize,
     #[metric(collector)]
-    collector: Option<Collector>,
+    collector: Option<MetricsCollector>,
 }
 
 /// RowGroupPruner is used to prune row groups according to the provided
@@ -56,7 +56,7 @@ impl<'a> RowGroupPruner<'a> {
         row_groups: &'a [RowGroupMetaData],
         parquet_filter: Option<&'a ParquetFilter>,
         predicates: &'a [Expr],
-        metrics_collector: Option<Collector>,
+        metrics_collector: Option<MetricsCollector>,
     ) -> Result<Self> {
         if let Some(f) = parquet_filter {
             ensure!(f.len() == row_groups.len(), OtherNoCause {

--- a/analytic_engine/src/sst/parquet/row_group_pruner.rs
+++ b/analytic_engine/src/sst/parquet/row_group_pruner.rs
@@ -14,14 +14,14 @@ use parquet_ext::prune::{
     min_max,
 };
 use snafu::ensure;
-use trace_metric::{MetricsCollector, TracedMetrics};
+use trace_metric::{MetricsCollector, TraceMetricWhenDrop};
 
 use crate::sst::{
     parquet::meta_data::ParquetFilter,
     reader::error::{OtherNoCause, Result},
 };
 
-#[derive(Debug, Clone, TracedMetrics)]
+#[derive(Debug, Clone, TraceMetricWhenDrop)]
 struct Metrics {
     #[metric(boolean)]
     use_bloom_filter: bool,

--- a/analytic_engine/src/sst/parquet/row_group_pruner.rs
+++ b/analytic_engine/src/sst/parquet/row_group_pruner.rs
@@ -25,13 +25,13 @@ use crate::sst::{
 struct Metrics {
     #[metric(boolean)]
     use_custom_filter: bool,
-    #[metric(counter)]
+    #[metric(number)]
     total_row_groups: usize,
-    #[metric(counter)]
+    #[metric(number)]
     row_groups_after_prune: usize,
-    #[metric(counter)]
+    #[metric(number)]
     pruned_by_custom_filter: usize,
-    #[metric(counter)]
+    #[metric(number)]
     pruned_by_min_max: usize,
     #[metric(collector)]
     collector: Option<MetricsCollector>,

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -381,8 +381,13 @@ mod tests {
             };
 
             let mut reader: Box<dyn SstReader + Send> = {
-                let mut reader =
-                    AsyncParquetReader::new(&sst_file_path, &sst_read_options, None, &store_picker);
+                let mut reader = AsyncParquetReader::new(
+                    &sst_file_path,
+                    &sst_read_options,
+                    None,
+                    &store_picker,
+                    None,
+                );
                 let mut sst_meta_readback = reader
                     .meta_data()
                     .await

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -22,7 +22,7 @@ use table_engine::{
     },
 };
 use tokio::sync::oneshot;
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use self::data::TableDataRef;
 use crate::{
@@ -180,7 +180,7 @@ impl Table for TableImpl {
             projected_schema: request.projected_schema,
             predicate,
             order: ReadOrder::None,
-            metrics_collector: Collector::new("".to_string()),
+            metrics_collector: MetricsCollector::new("".to_string()),
         };
         let mut batch_stream = self
             .read(read_request)

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -17,8 +17,8 @@ use table_engine::{
     stream::{PartitionedStreams, SendableRecordBatchStream},
     table::{
         AlterOptions, AlterSchema, AlterSchemaRequest, Compact, Flush, FlushRequest, Get,
-        GetInvalidPrimaryKey, GetNullPrimaryKey, GetRequest, ReadOptions, ReadOrder, ReadRequest,
-        Result, Scan, Table, TableId, TableStats, Write, WriteRequest,
+        GetInvalidPrimaryKey, GetNullPrimaryKey, GetRequest, ReadMetricsCollector, ReadOptions,
+        ReadOrder, ReadRequest, Result, Scan, Table, TableId, TableStats, Write, WriteRequest,
     },
 };
 use tokio::sync::oneshot;
@@ -179,6 +179,7 @@ impl Table for TableImpl {
             projected_schema: request.projected_schema,
             predicate,
             order: ReadOrder::None,
+            metrics_collector: ReadMetricsCollector::new(),
         };
         let mut batch_stream = self
             .read(read_request)

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -37,6 +37,8 @@ pub mod sst_util;
 pub mod version;
 pub mod version_edit;
 
+const GET_METRICS_COLLECTOR_NAME: &str = "get";
+
 /// Table trait implementation
 pub struct TableImpl {
     space_table: SpaceAndTable,
@@ -180,7 +182,7 @@ impl Table for TableImpl {
             projected_schema: request.projected_schema,
             predicate,
             order: ReadOrder::None,
-            metrics_collector: MetricsCollector::new("".to_string()),
+            metrics_collector: MetricsCollector::new(GET_METRICS_COLLECTOR_NAME.to_string()),
         };
         let mut batch_stream = self
             .read(read_request)

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -17,11 +17,12 @@ use table_engine::{
     stream::{PartitionedStreams, SendableRecordBatchStream},
     table::{
         AlterOptions, AlterSchema, AlterSchemaRequest, Compact, Flush, FlushRequest, Get,
-        GetInvalidPrimaryKey, GetNullPrimaryKey, GetRequest, ReadMetricsCollector, ReadOptions,
-        ReadOrder, ReadRequest, Result, Scan, Table, TableId, TableStats, Write, WriteRequest,
+        GetInvalidPrimaryKey, GetNullPrimaryKey, GetRequest, ReadOptions, ReadOrder, ReadRequest,
+        Result, Scan, Table, TableId, TableStats, Write, WriteRequest,
     },
 };
 use tokio::sync::oneshot;
+use trace_metric::Collector;
 
 use self::data::TableDataRef;
 use crate::{
@@ -179,7 +180,7 @@ impl Table for TableImpl {
             projected_schema: request.projected_schema,
             predicate,
             order: ReadOrder::None,
-            metrics_collector: ReadMetricsCollector::new(),
+            metrics_collector: Collector::new("".to_string()),
         };
         let mut batch_stream = self
             .read(read_request)

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -22,7 +22,7 @@ use table_engine::{
     predicate::Predicate,
     table::{GetRequest, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId, TableSeq},
 };
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use crate::{table_options, tests::row_util};
 
@@ -186,7 +186,7 @@ pub fn new_read_all_request_with_order(
         projected_schema: ProjectedSchema::no_projection(schema),
         predicate: Arc::new(Predicate::empty()),
         order,
-        metrics_collector: Collector::new("".to_string()),
+        metrics_collector: MetricsCollector::new("".to_string()),
     }
 }
 

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -20,11 +20,9 @@ use table_engine::{
     self,
     engine::{CreateTableRequest, TableState},
     predicate::Predicate,
-    table::{
-        GetRequest, ReadMetricsCollector, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId,
-        TableSeq,
-    },
+    table::{GetRequest, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId, TableSeq},
 };
+use trace_metric::Collector;
 
 use crate::{table_options, tests::row_util};
 
@@ -188,7 +186,7 @@ pub fn new_read_all_request_with_order(
         projected_schema: ProjectedSchema::no_projection(schema),
         predicate: Arc::new(Predicate::empty()),
         order,
-        metrics_collector: ReadMetricsCollector::new(),
+        metrics_collector: Collector::new("".to_string()),
     }
 }
 

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -186,7 +186,7 @@ pub fn new_read_all_request_with_order(
         projected_schema: ProjectedSchema::no_projection(schema),
         predicate: Arc::new(Predicate::empty()),
         order,
-        metrics_collector: MetricsCollector::new("".to_string()),
+        metrics_collector: MetricsCollector::default(),
     }
 }
 

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -20,7 +20,10 @@ use table_engine::{
     self,
     engine::{CreateTableRequest, TableState},
     predicate::Predicate,
-    table::{GetRequest, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId, TableSeq},
+    table::{
+        GetRequest, ReadMetricsCollector, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId,
+        TableSeq,
+    },
 };
 
 use crate::{table_options, tests::row_util};
@@ -185,6 +188,7 @@ pub fn new_read_all_request_with_order(
         projected_schema: ProjectedSchema::no_projection(schema),
         predicate: Arc::new(Predicate::empty()),
         order,
+        metrics_collector: ReadMetricsCollector::new(),
     }
 }
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -32,6 +32,7 @@ snafu = { workspace = true }
 table_engine = { workspace = true }
 table_kv = { workspace = true }
 tokio = { workspace = true }
+trace_metric = { workspace = true }
 wal = { workspace = true }
 zstd = { workspace = true }
 

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -90,7 +90,7 @@ impl MergeMemTableBench {
             ));
 
             info!(
-                "\nMergeMemTableBench memtable loaded, memory used: {}",
+                "MergeMemTableBench memtable loaded, memory used:{}",
                 memtable.approximate_memory_usage()
             );
 
@@ -182,7 +182,7 @@ impl MergeMemTableBench {
             }
 
             info!(
-                "\nMergeMemTableBench total rows of sst: {}, total batch num: {}, cost: {:?}",
+                "MergeMemTableBench total rows of sst:{}, total batch num:{}, cost:{:?}",
                 total_rows,
                 batch_num,
                 begin_instant.elapsed(),

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -142,6 +142,7 @@ impl MergeMemTableBench {
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
+            metrics_collector: None,
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -35,6 +35,7 @@ use common_util::runtime::Runtime;
 use log::info;
 use object_store::{LocalFileSystem, ObjectStoreRef};
 use table_engine::{predicate::Predicate, table::TableId};
+use trace_metric::Collector;
 
 use crate::{config::MergeMemTableBenchConfig, util};
 
@@ -142,7 +143,7 @@ impl MergeMemTableBench {
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
-            metrics_collector: None,
+            metrics_collector: Collector::new("".to_string()),
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -35,7 +35,6 @@ use common_util::runtime::Runtime;
 use log::info;
 use object_store::{LocalFileSystem, ObjectStoreRef};
 use table_engine::{predicate::Predicate, table::TableId};
-use trace_metric::Collector;
 
 use crate::{config::MergeMemTableBenchConfig, util};
 
@@ -143,7 +142,7 @@ impl MergeMemTableBench {
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
-            metrics_collector: Collector::new("".to_string()),
+            metrics_collector: None,
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -125,6 +125,7 @@ impl MergeSstBench {
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
+            metrics_collector: None,
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -29,7 +29,6 @@ use log::info;
 use object_store::{LocalFileSystem, ObjectStoreRef};
 use table_engine::{predicate::Predicate, table::TableId};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
-use trace_metric::Collector;
 
 use crate::{config::MergeSstBenchConfig, util};
 
@@ -126,7 +125,7 @@ impl MergeSstBench {
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
-            metrics_collector: Collector::new("".to_string()),
+            metrics_collector: None,
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -29,6 +29,7 @@ use log::info;
 use object_store::{LocalFileSystem, ObjectStoreRef};
 use table_engine::{predicate::Predicate, table::TableId};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
+use trace_metric::Collector;
 
 use crate::{config::MergeSstBenchConfig, util};
 
@@ -125,7 +126,7 @@ impl MergeSstBench {
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
-            metrics_collector: None,
+            metrics_collector: Collector::new("".to_string()),
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/scan_memtable_bench.rs
+++ b/benchmarks/src/scan_memtable_bench.rs
@@ -86,6 +86,7 @@ impl ScanMemTableBench {
             projected_schema: self.projected_schema.clone(),
             need_dedup: true,
             reverse: false,
+            metrics_collector: None,
         };
 
         let iter = self.memtable.scan(scan_ctx, scan_req).unwrap();

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -87,6 +87,7 @@ impl SstBench {
                     &self.sst_read_options,
                     SstReadHint::default(),
                     &store_picker,
+                    None,
                 )
                 .await
                 .unwrap();

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -33,7 +33,6 @@ use object_store::{LocalFileSystem, ObjectStoreRef, Path};
 use serde::Deserialize;
 use table_engine::{predicate::Predicate, table::TableId};
 use tokio::sync::mpsc;
-use trace_metric::Collector;
 
 use crate::{config::BenchPredicate, util};
 
@@ -221,7 +220,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
 
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
-            metrics_collector: Collector::new("".to_string()),
+            metrics_collector: None,
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -220,6 +220,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
 
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
+            metrics_collector: None,
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -136,6 +136,7 @@ async fn sst_to_record_batch_stream(
             sst_read_options,
             SstReadHint::default(),
             &store_picker,
+            None,
         )
         .await
         .unwrap();

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -33,6 +33,7 @@ use object_store::{LocalFileSystem, ObjectStoreRef, Path};
 use serde::Deserialize;
 use table_engine::{predicate::Predicate, table::TableId};
 use tokio::sync::mpsc;
+use trace_metric::Collector;
 
 use crate::{config::BenchPredicate, util};
 
@@ -220,7 +221,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
 
         let mut builder = MergeBuilder::new(MergeConfig {
             request_id,
-            metrics_collector: None,
+            metrics_collector: Collector::new("".to_string()),
             deadline: None,
             space_id,
             table_id,

--- a/benchmarks/src/util.rs
+++ b/benchmarks/src/util.rs
@@ -119,6 +119,7 @@ pub async fn load_sst_to_memtable(
             &sst_read_options,
             SstReadHint::default(),
             &store_picker,
+            None,
         )
         .await
         .unwrap();

--- a/components/trace_metric/Cargo.toml
+++ b/components/trace_metric/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "trace_metric"
+
+[package.version]
+workspace = true
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
+
+[dependencies]

--- a/components/trace_metric/Cargo.toml
+++ b/components/trace_metric/Cargo.toml
@@ -9,5 +9,3 @@ workspace = true
 
 [package.edition]
 workspace = true
-
-[dependencies]

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -47,7 +47,7 @@ impl Collector {
 
     /// Visit all metrics in the collector, excluding the metrics belonging to
     /// the children.
-    pub fn visit_metrics(&self, f: &mut dyn FnMut(&Metric)) {
+    pub fn visit_metrics(&self, f: &mut impl FnMut(&Metric)) {
         let metrics = self.metrics.lock().unwrap();
         for metric in metrics.iter() {
             f(metric);
@@ -55,7 +55,7 @@ impl Collector {
     }
 
     /// Visit all the collectors including itself and its children.
-    pub fn visit(&self, f: &mut dyn FnMut(&Collector)) {
+    pub fn visit(&self, f: &mut impl FnMut(&Collector)) {
         f(self);
         let children = self.children.lock().unwrap();
         for child in children.iter() {

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -7,7 +7,7 @@ use crate::metric::Metric;
 /// A collector for metrics of a single read request.
 ///
 /// It can be cloned and shared among threads.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct MetricsCollector {
     name: String,
     metrics: Arc<Mutex<Vec<Metric>>>,

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -83,7 +83,7 @@ impl FormatCollectorVisitor {
     }
 
     fn indent(level: usize) -> String {
-        " ".repeat(level * 2)
+        " ".repeat(level * 4)
     }
 
     fn append_line(&mut self, indent: &str, line: &str) {
@@ -111,8 +111,8 @@ mod tests {
     #[test]
     fn test_metrics_collector() {
         let collector = MetricsCollector::new("root".to_string());
-        collector.collect(Metric::counter("counter".to_string(), 1));
-        collector.collect(Metric::elapsed(
+        collector.collect(Metric::number("counter".to_string(), 1));
+        collector.collect(Metric::duration(
             "elapsed".to_string(),
             Duration::from_millis(100),
         ));
@@ -120,8 +120,8 @@ mod tests {
         child_1_0.collect(Metric::boolean("boolean".to_string(), false));
 
         let child_2_0 = child_1_0.span("child_2_0".to_string());
-        child_2_0.collect(Metric::counter("counter".to_string(), 1));
-        child_2_0.collect(Metric::elapsed(
+        child_2_0.collect(Metric::number("counter".to_string(), 1));
+        child_2_0.collect(Metric::duration(
             "elapsed".to_string(),
             Duration::from_millis(100),
         ));
@@ -133,16 +133,16 @@ mod tests {
         let mut visitor = FormatCollectorVisitor::default();
         collector.visit(&mut visitor);
         let expect_output = r#"root:
-  counter=1
-  elapsed=100ms
-  child_1_0:
-    boolean=false
-    child_2_0:
-      counter=1
-      elapsed=100ms
-  child_1_1:
-    boolean=false
-  child_1_2:
+    counter=1
+    elapsed=100ms
+    child_1_0:
+        boolean=false
+        child_2_0:
+            counter=1
+            elapsed=100ms
+    child_1_1:
+        boolean=false
+    child_1_2:
 "#;
         assert_eq!(expect_output, &visitor.into_string());
     }

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -1,0 +1,65 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::sync::{Arc, Mutex};
+
+use crate::metric::Metric;
+
+/// A collector for metrics of a single read request.
+///
+/// It can be cloned and shared among threads.
+#[derive(Clone, Debug)]
+pub struct Collector {
+    name: String,
+    metrics: Arc<Mutex<Vec<Metric>>>,
+    children: Arc<Mutex<Vec<Collector>>>,
+}
+
+impl Collector {
+    /// Create a new collector with the given name.
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            metrics: Arc::new(Mutex::new(vec![])),
+            children: Arc::new(Mutex::new(vec![])),
+        }
+    }
+
+    /// Collect a metric.
+    pub fn collect(&self, metric: Metric) {
+        let mut metrics = self.metrics.lock().unwrap();
+        metrics.push(metric);
+    }
+
+    /// Span a child collector with a given name.
+    pub fn span(&self, name: String) -> Collector {
+        let mut children = self.children.lock().unwrap();
+        let child = Self::new(name);
+        children.push(child.clone());
+        child
+    }
+
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Visit all metrics in the collector, excluding the metrics belonging to
+    /// the children.
+    pub fn visit_metrics(&self, f: &mut dyn FnMut(&Metric)) {
+        let metrics = self.metrics.lock().unwrap();
+        for metric in metrics.iter() {
+            f(metric);
+        }
+    }
+
+    /// Visit all the collectors including itself and its children.
+    pub fn visit(&self, f: &mut dyn FnMut(&Collector)) {
+        f(self);
+        let children = self.children.lock().unwrap();
+        for child in children.iter() {
+            child.visit(f);
+        }
+    }
+}

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -8,13 +8,13 @@ use crate::metric::Metric;
 ///
 /// It can be cloned and shared among threads.
 #[derive(Clone, Debug)]
-pub struct Collector {
+pub struct MetricsCollector {
     name: String,
     metrics: Arc<Mutex<Vec<Metric>>>,
-    children: Arc<Mutex<Vec<Collector>>>,
+    children: Arc<Mutex<Vec<MetricsCollector>>>,
 }
 
-impl Collector {
+impl MetricsCollector {
     /// Create a new collector with the given name.
     pub fn new(name: String) -> Self {
         Self {
@@ -31,7 +31,7 @@ impl Collector {
     }
 
     /// Span a child collector with a given name.
-    pub fn span(&self, name: String) -> Collector {
+    pub fn span(&self, name: String) -> MetricsCollector {
         let mut children = self.children.lock().unwrap();
         let child = Self::new(name);
         children.push(child.clone());
@@ -53,7 +53,7 @@ impl Collector {
     }
 
     /// Visit all the collectors including itself and its children.
-    pub fn visit(&self, f: &mut impl FnMut(&Collector)) {
+    pub fn visit(&self, f: &mut impl FnMut(&MetricsCollector)) {
         f(self);
         let children = self.children.lock().unwrap();
         for child in children.iter() {

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -43,9 +43,8 @@ impl MetricsCollector {
         &self.name
     }
 
-    /// Visit all metrics in the collector, excluding the metrics belonging to
-    /// the children.
-    pub fn visit_metrics(&self, f: &mut impl FnMut(&Metric)) {
+    /// Calls a closure on each top-level metrics of this collector.
+    pub fn for_each_metric(&self, f: &mut impl FnMut(&Metric)) {
         let metrics = self.metrics.lock().unwrap();
         for metric in metrics.iter() {
             f(metric);
@@ -97,7 +96,7 @@ impl CollectorVisitor for FormatCollectorVisitor {
         let collector_indent = Self::indent(level);
         self.append_line(&collector_indent, &format!("{}:", collector.name()));
         let metric_indent = Self::indent(level + 1);
-        collector.visit_metrics(&mut |metric| {
+        collector.for_each_metric(&mut |metric| {
             self.append_line(&metric_indent, &format!("{metric:?}"));
         });
     }

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -95,7 +95,7 @@ impl FormatCollectorVisitor {
 impl CollectorVisitor for FormatCollectorVisitor {
     fn visit(&mut self, level: usize, collector: &MetricsCollector) {
         let collector_indent = Self::indent(level);
-        self.append_line(&collector_indent, &format!("<{}>", collector.name()));
+        self.append_line(&collector_indent, &format!("{}:", collector.name()));
         let metric_indent = Self::indent(level + 1);
         collector.visit_metrics(&mut |metric| {
             self.append_line(&metric_indent, &format!("{metric:?}"));
@@ -133,6 +133,18 @@ mod tests {
 
         let mut visitor = FormatCollectorVisitor::default();
         collector.visit(&mut visitor);
-        println!("{}", visitor.into_string());
+        let expect_output = r#"root:
+  counter=1
+  elapsed=100ms
+  child_1_0:
+    boolean=false
+    child_2_0:
+      counter=1
+      elapsed=100ms
+  child_1_1:
+    boolean=false
+  child_1_2:
+"#;
+        assert_eq!(expect_output, &visitor.into_string());
     }
 }

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -53,11 +53,86 @@ impl MetricsCollector {
     }
 
     /// Visit all the collectors including itself and its children.
-    pub fn visit(&self, f: &mut impl FnMut(&MetricsCollector)) {
-        f(self);
-        let children = self.children.lock().unwrap();
-        for child in children.iter() {
-            child.visit(f);
+    pub fn visit(&self, visitor: &mut impl CollectorVisitor) {
+        self.visit_with_level(0, visitor);
+    }
+
+    /// Visit all the collectors including itself and its children.
+    fn visit_with_level(&self, level: usize, visitor: &mut impl CollectorVisitor) {
+        visitor.visit(level, self);
+        // Clone the children to avoid holding the lock, which may cause deadlocks
+        // because the lock order is not guaranteed.
+        let children = self.children.lock().unwrap().clone();
+        for child in children {
+            child.visit_with_level(level + 1, visitor);
         }
+    }
+}
+
+pub trait CollectorVisitor {
+    fn visit(&mut self, level: usize, collector: &MetricsCollector);
+}
+
+#[derive(Default)]
+pub struct FormatCollectorVisitor {
+    buffer: String,
+}
+
+impl FormatCollectorVisitor {
+    pub fn into_string(self) -> String {
+        self.buffer
+    }
+
+    fn indent(level: usize) -> String {
+        " ".repeat(level * 2)
+    }
+
+    fn append_line(&mut self, indent: &str, line: &str) {
+        self.buffer.push_str(&format!("{indent}{line}\n"));
+    }
+}
+
+impl CollectorVisitor for FormatCollectorVisitor {
+    fn visit(&mut self, level: usize, collector: &MetricsCollector) {
+        let collector_indent = Self::indent(level);
+        self.append_line(&collector_indent, &format!("<{}>", collector.name()));
+        let metric_indent = Self::indent(level + 1);
+        collector.visit_metrics(&mut |metric| {
+            self.append_line(&metric_indent, &format!("{metric:?}"));
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn test_metrics_collector() {
+        let collector = MetricsCollector::new("root".to_string());
+        collector.collect(Metric::counter("counter".to_string(), 1));
+        collector.collect(Metric::elapsed(
+            "elapsed".to_string(),
+            Duration::from_millis(100),
+        ));
+        let child_1_0 = collector.span("child_1_0".to_string());
+        child_1_0.collect(Metric::boolean("boolean".to_string(), false));
+
+        let child_2_0 = child_1_0.span("child_2_0".to_string());
+        child_2_0.collect(Metric::counter("counter".to_string(), 1));
+        child_2_0.collect(Metric::elapsed(
+            "elapsed".to_string(),
+            Duration::from_millis(100),
+        ));
+
+        let child_1_1 = collector.span("child_1_1".to_string());
+        child_1_1.collect(Metric::boolean("boolean".to_string(), false));
+        let _child_1_2 = collector.span("child_1_2".to_string());
+
+        let mut visitor = FormatCollectorVisitor::default();
+        collector.visit(&mut visitor);
+        println!("{}", visitor.into_string());
     }
 }

--- a/components/trace_metric/src/collector.rs
+++ b/components/trace_metric/src/collector.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
-
 use std::sync::{Arc, Mutex};
 
 use crate::metric::Metric;

--- a/components/trace_metric/src/lib.rs
+++ b/components/trace_metric/src/lib.rs
@@ -5,4 +5,4 @@ pub mod metric;
 
 pub use collector::MetricsCollector;
 pub use metric::Metric;
-pub use trace_metric_derive::TracedMetrics;
+pub use trace_metric_derive::TraceMetricWhenDrop;

--- a/components/trace_metric/src/lib.rs
+++ b/components/trace_metric/src/lib.rs
@@ -7,3 +7,4 @@ pub mod metric;
 
 pub use collector::Collector;
 pub use metric::Metric;
+pub use trace_metric_derive::TracedMetrics;

--- a/components/trace_metric/src/lib.rs
+++ b/components/trace_metric/src/lib.rs
@@ -4,3 +4,6 @@
 
 pub mod collector;
 pub mod metric;
+
+pub use collector::Collector;
+pub use metric::Metric;

--- a/components/trace_metric/src/lib.rs
+++ b/components/trace_metric/src/lib.rs
@@ -3,6 +3,6 @@
 pub mod collector;
 pub mod metric;
 
-pub use collector::Collector;
+pub use collector::MetricsCollector;
 pub use metric::Metric;
 pub use trace_metric_derive::TracedMetrics;

--- a/components/trace_metric/src/lib.rs
+++ b/components/trace_metric/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+pub mod collector;
+pub mod metric;

--- a/components/trace_metric/src/lib.rs
+++ b/components/trace_metric/src/lib.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
-
 pub mod collector;
 pub mod metric;
 

--- a/components/trace_metric/src/metric.rs
+++ b/components/trace_metric/src/metric.rs
@@ -11,19 +11,19 @@ pub struct MetricValue<T: Clone + fmt::Debug> {
 #[derive(Clone)]
 pub enum Metric {
     Boolean(MetricValue<bool>),
-    Counter(MetricValue<usize>),
-    Elapsed(MetricValue<Duration>),
+    Number(MetricValue<usize>),
+    Duration(MetricValue<Duration>),
 }
 
 impl Metric {
     #[inline]
-    pub fn counter(name: String, val: usize) -> Self {
-        Metric::Counter(MetricValue { name, val })
+    pub fn number(name: String, val: usize) -> Self {
+        Metric::Number(MetricValue { name, val })
     }
 
     #[inline]
-    pub fn elapsed(name: String, val: Duration) -> Self {
-        Metric::Elapsed(MetricValue { name, val })
+    pub fn duration(name: String, val: Duration) -> Self {
+        Metric::Duration(MetricValue { name, val })
     }
 
     #[inline]
@@ -42,8 +42,8 @@ impl fmt::Debug for Metric {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Metric::Boolean(v) => write!(f, "{}={:?}", v.name, v.val),
-            Metric::Counter(v) => write!(f, "{}={:?}", v.name, v.val),
-            Metric::Elapsed(v) => write!(f, "{}={:?}", v.name, v.val),
+            Metric::Number(v) => write!(f, "{}={:?}", v.name, v.val),
+            Metric::Duration(v) => write!(f, "{}={:?}", v.name, v.val),
         }
     }
 }

--- a/components/trace_metric/src/metric.rs
+++ b/components/trace_metric/src/metric.rs
@@ -1,7 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
-
 use std::{fmt, time::Duration};
 
 #[derive(Clone)]

--- a/components/trace_metric/src/metric.rs
+++ b/components/trace_metric/src/metric.rs
@@ -1,0 +1,41 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::{fmt, time::Duration};
+
+#[derive(Clone)]
+pub struct MetricValue<T: Clone + fmt::Debug> {
+    pub name: String,
+    pub val: T,
+}
+
+#[derive(Clone, Debug)]
+pub enum Metric {
+    Boolean(MetricValue<bool>),
+    Counter(MetricValue<usize>),
+    Elapsed(MetricValue<Duration>),
+}
+
+impl Metric {
+    #[inline]
+    pub fn counter(name: String, val: usize) -> Self {
+        Metric::Counter(MetricValue { name, val })
+    }
+
+    #[inline]
+    pub fn elapsed(name: String, val: Duration) -> Self {
+        Metric::Elapsed(MetricValue { name, val })
+    }
+
+    #[inline]
+    pub fn boolean(name: String, val: bool) -> Self {
+        Metric::Boolean(MetricValue { name, val })
+    }
+}
+
+impl<T: Clone + fmt::Debug> fmt::Debug for MetricValue<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}={:?}", self.name, self.val)
+    }
+}

--- a/components/trace_metric/src/metric.rs
+++ b/components/trace_metric/src/metric.rs
@@ -8,7 +8,7 @@ pub struct MetricValue<T: Clone + fmt::Debug> {
     pub val: T,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum Metric {
     Boolean(MetricValue<bool>),
     Counter(MetricValue<usize>),
@@ -35,5 +35,15 @@ impl Metric {
 impl<T: Clone + fmt::Debug> fmt::Debug for MetricValue<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}={:?}", self.name, self.val)
+    }
+}
+
+impl fmt::Debug for Metric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Metric::Boolean(v) => write!(f, "{}={:?}", v.name, v.val),
+            Metric::Counter(v) => write!(f, "{}={:?}", v.name, v.val),
+            Metric::Elapsed(v) => write!(f, "{}={:?}", v.name, v.val),
+        }
     }
 }

--- a/components/trace_metric_derive/Cargo.toml
+++ b/components/trace_metric_derive/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "trace_metric_derive"
+
+[package.version]
+workspace = true
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version="1.0", features=["full"] }
+trace_metric = { workspace = true }

--- a/components/trace_metric_derive/Cargo.toml
+++ b/components/trace_metric_derive/Cargo.toml
@@ -16,5 +16,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version="1.0", features=["full"] }
-trace_metric = { workspace = true }
+syn = { version = "1.0", features = ["full"] }

--- a/components/trace_metric_derive/src/builder.rs
+++ b/components/trace_metric_derive/src/builder.rs
@@ -106,10 +106,10 @@ impl Builder {
                 }
                 (
                     metric_fields,
-                    collector_field.expect("TracedMetrics must have a collector field"),
+                    collector_field.expect("TraceMetricWhenDrop must have a collector field"),
                 )
             }
-            _ => panic!("TracedMetrics only supports struct with named fields"),
+            _ => panic!("TraceMetricWhenDrop only supports struct with named fields"),
         };
 
         Self {

--- a/components/trace_metric_derive/src/builder.rs
+++ b/components/trace_metric_derive/src/builder.rs
@@ -126,13 +126,13 @@ impl Builder {
             let field_name = &metric_field.field_name;
             let metric = match metric_field.metric_type {
                 MetricType::Counter => {
-                    quote! { trace_metric::Metric::counter("#field_name".to_string(), self.#field_name) }
+                    quote! { ::trace_metric::Metric::counter(stringify!(#field_name).to_string(), self.#field_name) }
                 }
                 MetricType::Elapsed => {
-                    quote! { trace_metric::Metric::elapsed("#field_name".to_string(), self.#field_name) }
+                    quote! { ::trace_metric::Metric::elapsed(stringify!(#field_name).to_string(), self.#field_name) }
                 }
                 MetricType::Boolean => {
-                    quote! { trace_metric::Metric::boolean("#field_name".to_string(), self.#field_name) }
+                    quote! { ::trace_metric::Metric::boolean(stringify!(#field_name).to_string(), self.#field_name) }
                 }
             };
             let statement = quote! {
@@ -147,7 +147,7 @@ impl Builder {
         let collector_field_name = &self.collector_field.field_name;
         let stream = if self.collector_field.optional {
             quote! {
-                impl #generics Drop for #struct_name #generics #where_clause {
+                impl #generics ::core::ops::Drop for #struct_name #generics #where_clause {
                     fn drop(&mut self) {
                         if let Some(collector) = &self.#collector_field_name {
                             #(#collect_statements)*
@@ -157,7 +157,7 @@ impl Builder {
             }
         } else {
             quote! {
-                impl #generics Drop for #struct_name #generics #where_clause {
+                impl #generics ::core::ops::Drop for #struct_name #generics #where_clause {
                     fn drop(&mut self) {
                         let collector = &self.#collector_field_name;
                         #(#collect_statements)*

--- a/components/trace_metric_derive/src/builder.rs
+++ b/components/trace_metric_derive/src/builder.rs
@@ -5,22 +5,22 @@ use quote::{quote, ToTokens};
 use syn::{DeriveInput, Field, Generics, Ident};
 
 const COLLECTOR_FIELD_TOKENS: &str = "(collector)";
-const COUNTER_FIELD_TOKENS: &str = "(counter)";
-const ELAPSED_FIELD_TOKENS: &str = "(elapsed)";
+const NUMBER_FIELD_TOKENS: &str = "(number)";
+const DURATION_FIELD_TOKENS: &str = "(duration)";
 const BOOLEAN_FIELD_TOKENS: &str = "(boolean)";
 
 enum MetricType {
-    Counter,
-    Elapsed,
+    Number,
+    Duration,
     Boolean,
 }
 
 impl MetricType {
     fn try_from_tokens(s: &str) -> Option<Self> {
-        if s == COUNTER_FIELD_TOKENS {
-            Some(Self::Counter)
-        } else if s == ELAPSED_FIELD_TOKENS {
-            Some(Self::Elapsed)
+        if s == NUMBER_FIELD_TOKENS {
+            Some(Self::Number)
+        } else if s == DURATION_FIELD_TOKENS {
+            Some(Self::Duration)
         } else if s == BOOLEAN_FIELD_TOKENS {
             Some(Self::Boolean)
         } else {
@@ -125,11 +125,11 @@ impl Builder {
         for metric_field in self.metric_fields.iter() {
             let field_name = &metric_field.field_name;
             let metric = match metric_field.metric_type {
-                MetricType::Counter => {
-                    quote! { ::trace_metric::Metric::counter(stringify!(#field_name).to_string(), self.#field_name) }
+                MetricType::Number => {
+                    quote! { ::trace_metric::Metric::number(stringify!(#field_name).to_string(), self.#field_name) }
                 }
-                MetricType::Elapsed => {
-                    quote! { ::trace_metric::Metric::elapsed(stringify!(#field_name).to_string(), self.#field_name) }
+                MetricType::Duration => {
+                    quote! { ::trace_metric::Metric::duration(stringify!(#field_name).to_string(), self.#field_name) }
                 }
                 MetricType::Boolean => {
                     quote! { ::trace_metric::Metric::boolean(stringify!(#field_name).to_string(), self.#field_name) }

--- a/components/trace_metric_derive/src/builder.rs
+++ b/components/trace_metric_derive/src/builder.rs
@@ -1,0 +1,144 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Field, Generics, Ident};
+
+const COLLECTOR_FIELD_TOKENS: &str = "(collector)";
+const COUNTER_FIELD_TOKENS: &str = "(counter)";
+const ELAPSED_FIELD_TOKENS: &str = "(elapsed)";
+const BOOLEAN_FIELD_TOKENS: &str = "(boolean)";
+
+enum MetricType {
+    Counter,
+    Elapsed,
+    Boolean,
+}
+
+impl MetricType {
+    fn try_from_tokens(s: &str) -> Option<Self> {
+        if s == COUNTER_FIELD_TOKENS {
+            Some(Self::Counter)
+        } else if s == ELAPSED_FIELD_TOKENS {
+            Some(Self::Elapsed)
+        } else if s == BOOLEAN_FIELD_TOKENS {
+            Some(Self::Boolean)
+        } else {
+            None
+        }
+    }
+}
+
+struct MetricField {
+    metric_type: MetricType,
+    field_name: Ident,
+}
+
+impl MetricField {
+    fn try_from_field(field: Field) -> Option<Self> {
+        for attr in field.attrs.iter() {
+            if !attr.path.is_ident("metric") {
+                continue;
+            }
+
+            let field_name = field.ident.expect("Metric field must have a name");
+            let metric_type_tokens = attr.tokens.to_string();
+            let metric_type =
+                MetricType::try_from_tokens(&metric_type_tokens).expect("Unknown metric type");
+            return Some(Self {
+                metric_type,
+                field_name,
+            });
+        }
+
+        None
+    }
+}
+
+pub struct Builder {
+    struct_name: Ident,
+    metric_fields: Vec<MetricField>,
+    collector_field: Ident,
+    generics: Generics,
+}
+
+impl Builder {
+    pub fn parse_from_ast(ast: DeriveInput) -> Self {
+        let struct_name = ast.ident;
+        let (metric_fields, collector_field) = match ast.data {
+            syn::Data::Struct(syn::DataStruct {
+                fields: syn::Fields::Named(syn::FieldsNamed { named, .. }),
+                ..
+            }) => {
+                let mut metric_fields = Vec::new();
+                let mut collector_field = None;
+                for field in named {
+                    if Self::is_collector_field(&field) {
+                        collector_field = Some(field);
+                        continue;
+                    }
+                    if let Some(metric_field) = MetricField::try_from_field(field) {
+                        metric_fields.push(metric_field);
+                    }
+                }
+                (
+                    metric_fields,
+                    collector_field
+                        .expect("TracedMetrics must have a collector field")
+                        .ident
+                        .expect("TracedMetrics collector field must be named"),
+                )
+            }
+            _ => panic!("TracedMetrics only supports struct with named fields"),
+        };
+
+        Self {
+            struct_name,
+            metric_fields,
+            collector_field,
+            generics: ast.generics,
+        }
+    }
+
+    pub fn build(&self) -> TokenStream {
+        let mut collect_statements = Vec::with_capacity(self.metric_fields.len());
+        let collector_field = &self.collector_field;
+        for metric_field in self.metric_fields.iter() {
+            let field_name = &metric_field.field_name;
+            let metric = match metric_field.metric_type {
+                MetricType::Counter => {
+                    quote! { trace_metric::Metric::counter("#field_name".to_string(), self.#field_name) }
+                }
+                MetricType::Elapsed => {
+                    quote! { trace_metric::Metric::elapsed("#field_name".to_string(), self.#field_name) }
+                }
+                MetricType::Boolean => {
+                    quote! { trace_metric::Metric::boolean("#field_name".to_string(), self.#field_name) }
+                }
+            };
+            let statement = quote! {
+                self.#collector_field.collect(#metric);
+            };
+            collect_statements.push(statement);
+        }
+
+        let where_clause = &self.generics.where_clause;
+        let generics = &self.generics;
+        let struct_name = &self.struct_name;
+        quote! {
+            impl #generics Drop for #struct_name #generics #where_clause {
+                fn drop(&mut self) {
+                    #(#collect_statements)*
+                }
+            }
+        }
+        .into()
+    }
+
+    fn is_collector_field(field: &Field) -> bool {
+        field.attrs.iter().any(|attr| {
+            attr.path.is_ident("metric")
+                && attr.tokens.to_string().as_str() == COLLECTOR_FIELD_TOKENS
+        })
+    }
+}

--- a/components/trace_metric_derive/src/lib.rs
+++ b/components/trace_metric_derive/src/lib.rs
@@ -1,0 +1,2 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+

--- a/components/trace_metric_derive/src/lib.rs
+++ b/components/trace_metric_derive/src/lib.rs
@@ -1,2 +1,14 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
+
+mod builder;
+
+use builder::Builder;
+
+#[proc_macro_derive(TracedMetrics, attributes(metric))]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    Builder::parse_from_ast(ast).build()
+}

--- a/components/trace_metric_derive/src/lib.rs
+++ b/components/trace_metric_derive/src/lib.rs
@@ -7,7 +7,7 @@ mod builder;
 
 use builder::Builder;
 
-#[proc_macro_derive(TracedMetrics, attributes(metric))]
+#[proc_macro_derive(TraceMetricWhenDrop, attributes(metric))]
 pub fn derive(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     Builder::parse_from_ast(ast).build()

--- a/components/trace_metric_derive_tests/Cargo.toml
+++ b/components/trace_metric_derive_tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "trace_metric"
+name = "trace_metric_derive_tests"
 
 [package.version]
 workspace = true
@@ -11,4 +11,4 @@ workspace = true
 workspace = true
 
 [dependencies]
-trace_metric_derive = { workspace = true }
+trace_metric = { workspace = true }

--- a/components/trace_metric_derive_tests/src/lib.rs
+++ b/components/trace_metric_derive_tests/src/lib.rs
@@ -1,0 +1,45 @@
+// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::time::Duration;
+
+use trace_metric::{Collector, TracedMetrics};
+
+#[derive(Debug, Clone, TracedMetrics)]
+pub struct ExampleMetrics {
+    #[metric(counter)]
+    pub counter: usize,
+    #[metric(elapsed)]
+    pub elapsed: Duration,
+    #[metric(boolean)]
+    pub boolean: bool,
+    pub foo: String,
+
+    #[metric(collector)]
+    pub collector: Collector,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let collector = Collector::new("test".to_string());
+        {
+            let _ = ExampleMetrics {
+                counter: 1,
+                elapsed: Duration::from_secs(1),
+                boolean: true,
+                foo: "bar".to_owned(),
+                collector: collector.clone(),
+            };
+        }
+
+        let mut metric_num = 0;
+        collector.visit_metrics(&mut |_| {
+            metric_num += 1;
+        });
+
+        assert_eq!(metric_num, 3)
+    }
+}

--- a/components/trace_metric_derive_tests/src/lib.rs
+++ b/components/trace_metric_derive_tests/src/lib.rs
@@ -2,9 +2,9 @@
 
 use std::time::Duration;
 
-use trace_metric::{MetricsCollector, TracedMetrics};
+use trace_metric::{MetricsCollector, TraceMetricWhenDrop};
 
-#[derive(Debug, Clone, TracedMetrics)]
+#[derive(Debug, Clone, TraceMetricWhenDrop)]
 pub struct ExampleMetrics {
     #[metric(counter)]
     pub counter: usize,

--- a/components/trace_metric_derive_tests/src/lib.rs
+++ b/components/trace_metric_derive_tests/src/lib.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use trace_metric::{Collector, TracedMetrics};
+use trace_metric::{MetricsCollector, TracedMetrics};
 
 #[derive(Debug, Clone, TracedMetrics)]
 pub struct ExampleMetrics {
@@ -15,7 +15,7 @@ pub struct ExampleMetrics {
     pub foo: String,
 
     #[metric(collector)]
-    pub collector: Collector,
+    pub collector: MetricsCollector,
 }
 
 #[cfg(test)]
@@ -24,7 +24,7 @@ mod test {
 
     #[test]
     fn basic() {
-        let collector = Collector::new("test".to_string());
+        let collector = MetricsCollector::new("test".to_string());
         {
             let _ = ExampleMetrics {
                 counter: 1,

--- a/components/trace_metric_derive_tests/src/lib.rs
+++ b/components/trace_metric_derive_tests/src/lib.rs
@@ -6,9 +6,9 @@ use trace_metric::{MetricsCollector, TraceMetricWhenDrop};
 
 #[derive(Debug, Clone, TraceMetricWhenDrop)]
 pub struct ExampleMetrics {
-    #[metric(counter)]
+    #[metric(number)]
     pub counter: usize,
-    #[metric(elapsed)]
+    #[metric(duration)]
     pub elapsed: Duration,
     #[metric(boolean)]
     pub boolean: bool,
@@ -39,9 +39,9 @@ mod test {
         let mut formatter = FormatCollectorVisitor::default();
         collector.visit(&mut formatter);
         let expect_output = r#"test:
-  counter=1
-  elapsed=1s
-  boolean=true
+    counter=1
+    elapsed=1s
+    boolean=true
 "#;
 
         assert_eq!(expect_output, &formatter.into_string());

--- a/components/trace_metric_derive_tests/src/lib.rs
+++ b/components/trace_metric_derive_tests/src/lib.rs
@@ -20,6 +20,8 @@ pub struct ExampleMetrics {
 
 #[cfg(test)]
 mod test {
+    use trace_metric::collector::FormatCollectorVisitor;
+
     use super::*;
 
     #[test]
@@ -34,12 +36,14 @@ mod test {
                 collector: collector.clone(),
             };
         }
+        let mut formatter = FormatCollectorVisitor::default();
+        collector.visit(&mut formatter);
+        let expect_output = r#"test:
+  counter=1
+  elapsed=1s
+  boolean=true
+"#;
 
-        let mut metric_num = 0;
-        collector.visit_metrics(&mut |_| {
-            metric_num += 1;
-        });
-
-        assert_eq!(metric_num, 3)
+        assert_eq!(expect_output, &formatter.into_string());
     }
 }

--- a/system_catalog/Cargo.toml
+++ b/system_catalog/Cargo.toml
@@ -24,3 +24,4 @@ prost = { workspace = true }
 snafu = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }
+trace_metric = { workspace = true }

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -35,8 +35,8 @@ use table_engine::{
     },
     predicate::PredicateBuilder,
     table::{
-        GetRequest, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId, TableInfo, TableRef,
-        WriteRequest,
+        GetRequest, ReadMetricsCollector, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId,
+        TableInfo, TableRef, WriteRequest,
     },
 };
 use tokio::sync::Mutex;
@@ -533,6 +533,7 @@ impl SysCatalogTable {
             projected_schema: ProjectedSchema::no_projection(self.table.schema()),
             predicate: PredicateBuilder::default().build(),
             order: ReadOrder::None,
+            metrics_collector: ReadMetricsCollector::new(),
         };
         let mut batch_stream = self.table.read(read_request).await.context(ReadTable)?;
 

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -40,7 +40,7 @@ use table_engine::{
     },
 };
 use tokio::sync::Mutex;
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use crate::{SYSTEM_SCHEMA_ID, SYS_CATALOG_TABLE_ID, SYS_CATALOG_TABLE_NAME};
 
@@ -534,7 +534,7 @@ impl SysCatalogTable {
             projected_schema: ProjectedSchema::no_projection(self.table.schema()),
             predicate: PredicateBuilder::default().build(),
             order: ReadOrder::None,
-            metrics_collector: Collector::new("open_sys_catalog_table".to_string()),
+            metrics_collector: MetricsCollector::new("open_sys_catalog_table".to_string()),
         };
         let mut batch_stream = self.table.read(read_request).await.context(ReadTable)?;
 

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -534,7 +534,7 @@ impl SysCatalogTable {
             projected_schema: ProjectedSchema::no_projection(self.table.schema()),
             predicate: PredicateBuilder::default().build(),
             order: ReadOrder::None,
-            metrics_collector: MetricsCollector::new("open_sys_catalog_table".to_string()),
+            metrics_collector: MetricsCollector::default(),
         };
         let mut batch_stream = self.table.read(read_request).await.context(ReadTable)?;
 

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -35,11 +35,12 @@ use table_engine::{
     },
     predicate::PredicateBuilder,
     table::{
-        GetRequest, ReadMetricsCollector, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId,
-        TableInfo, TableRef, WriteRequest,
+        GetRequest, ReadOptions, ReadOrder, ReadRequest, SchemaId, TableId, TableInfo, TableRef,
+        WriteRequest,
     },
 };
 use tokio::sync::Mutex;
+use trace_metric::Collector;
 
 use crate::{SYSTEM_SCHEMA_ID, SYS_CATALOG_TABLE_ID, SYS_CATALOG_TABLE_NAME};
 
@@ -533,7 +534,7 @@ impl SysCatalogTable {
             projected_schema: ProjectedSchema::no_projection(self.table.schema()),
             predicate: PredicateBuilder::default().build(),
             order: ReadOrder::None,
-            metrics_collector: ReadMetricsCollector::new(),
+            metrics_collector: Collector::new("open_sys_catalog_table".to_string()),
         };
         let mut batch_stream = self.table.read(read_request).await.context(ReadTable)?;
 

--- a/table_engine/Cargo.toml
+++ b/table_engine/Cargo.toml
@@ -30,6 +30,7 @@ serde = { workspace = true }
 smallvec = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
+trace_metric = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/table_engine/src/provider.rs
+++ b/table_engine/src/provider.rs
@@ -35,6 +35,8 @@ use crate::{
     table::{self, ReadOptions, ReadOrder, ReadRequest, TableRef},
 };
 
+const SCAN_TABLE_METRICS_COLLECTOR_NAME: &str = "scan_table";
+
 #[derive(Clone, Debug)]
 pub struct CeresdbOptions {
     pub request_id: u64,
@@ -171,7 +173,7 @@ impl TableProviderAdapter {
             predicate,
             deadline,
             stream_state: Mutex::new(ScanStreamState::default()),
-            metrics_collector: MetricsCollector::new("scan_table".to_string()),
+            metrics_collector: MetricsCollector::new(SCAN_TABLE_METRICS_COLLECTOR_NAME.to_string()),
         };
         scan_table.maybe_init_stream(state).await?;
 

--- a/table_engine/src/provider.rs
+++ b/table_engine/src/provider.rs
@@ -398,7 +398,7 @@ impl ExecutionPlan for ScanTable {
         let metrics_desc = format_visitor.into_string();
 
         let metric_value = MetricValue::Count {
-            name: metrics_desc.into(),
+            name: format!("\n{metrics_desc}").into(),
             count: Count::new(),
         };
         let metric = Metric::new(metric_value, None);

--- a/table_engine/src/provider.rs
+++ b/table_engine/src/provider.rs
@@ -26,7 +26,7 @@ use datafusion::{
 use datafusion_expr::{Expr, TableSource, TableType};
 use df_operator::visitor;
 use log::debug;
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use crate::{
     predicate::{PredicateBuilder, PredicateRef},
@@ -170,7 +170,7 @@ impl TableProviderAdapter {
             predicate,
             deadline,
             stream_state: Mutex::new(ScanStreamState::default()),
-            metrics_collector: Collector::new("scan_table".to_string()),
+            metrics_collector: MetricsCollector::new("scan_table".to_string()),
         };
         scan_table.maybe_init_stream(state).await?;
 
@@ -297,7 +297,7 @@ struct ScanTable {
     read_parallelism: usize,
     predicate: PredicateRef,
     deadline: Option<Instant>,
-    metrics_collector: Collector,
+    metrics_collector: MetricsCollector,
 
     stream_state: Mutex<ScanStreamState>,
 }

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -451,7 +451,7 @@ impl TryFrom<ceresdbproto::remote_engine::TableReadRequest> for ReadRequest {
             projected_schema,
             predicate,
             order,
-            metrics_collector: MetricsCollector::new("".to_string()),
+            metrics_collector: MetricsCollector::default(),
         })
     }
 }

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -25,7 +25,7 @@ use common_types::{
 use common_util::error::{BoxError, GenericError};
 use serde::Deserialize;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
-use trace_metric::Collector;
+use trace_metric::MetricsCollector;
 
 use crate::{
     engine::TableState,
@@ -390,7 +390,7 @@ pub struct ReadRequest {
     /// Read the rows in reverse order.
     pub order: ReadOrder,
     /// Collector for metrics of this read request.
-    pub metrics_collector: Collector,
+    pub metrics_collector: MetricsCollector,
 }
 
 impl TryFrom<ReadRequest> for ceresdbproto::remote_engine::TableReadRequest {
@@ -451,7 +451,7 @@ impl TryFrom<ceresdbproto::remote_engine::TableReadRequest> for ReadRequest {
             projected_schema,
             predicate,
             order,
-            metrics_collector: Collector::new("".to_string()),
+            metrics_collector: MetricsCollector::new("".to_string()),
         })
     }
 }

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -92,6 +92,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
             &reader_opts,
             SstReadHint::default(),
             &store_picker,
+            None,
         )
         .await
         .expect("no sst reader found");


### PR DESCRIPTION
## Which issue does this PR close?

Closes #696 

## Rationale for this change
 Refer to #696
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Add `trace_metric` crate for collecting the metrics during the codebase;
- Add a proc macro to simplify the metrics collecting;
- Feed the collected metrics during the scan procedure to datafusion analyze framework;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
When using `explain analyze [sql]`, it will output the metrics about the scan table. Here is an example:
```
2023-03-14 18:14:47.699 INFO [query_engine/src/executor.rs:120] Executor executed plan, request_id:3, cost:9889ms, plan_and_metrics: AnalyzeExec verbose=false, metrics=[]
  CoalescePartitionsExec, metrics=[output_rows=7200000, elapsed_compute=463.779µs, spill_count=0, spilled_bytes=0, mem_used=0]
    ProjectionExec: expr=[timestamp@0 as timestamp, tsid@1 as tsid, hostname@2 as hostname, region@3 as region, datacenter@4 as datacenter, rack@5 as rack, os@6 as os, arch@7 as arch, team@8 as team, service@9 as service, service_version@10 as service_version, service_environment@11 as service_environment, usage_user@12 as usage_user, usage_system@13 as usage_system, usage_idle@14 as usage_idle, usage_nice@15 as usage_nice, usage_iowait@16 as usage_iowait, usage_irq@17 as usage_irq, usage_softirq@18 as usage_softirq, usage_steal@19 as usage_steal, usage_guest@20 as usage_guest, usage_guest_nice@21 as usage_guest_nice], metrics=[output_rows=7200000, elapsed_compute=231.975134ms, spill_count=0, spilled_bytes=0, mem_used=0]
      ScanTable: table=cpu, parallelism=8, order=None, , metrics=[
scan_table:
    do_merge_sort=true
    iter_num=6
    merge_iter_0:
        num_memtables=0
        num_ssts=1
        total_rows_fetch_from_one=1200000
        times_fetch_rows_from_one=2490
        times_fetch_row_from_multiple=0
        init_duration=70.616µs
        scan_duration=2.585217663s
        scan_count=148
        scan_sst_311:
            meta_data_cache_hit=false
            read_meta_data_duration=131.260455ms
            parallelism=8
            prune_row_groups:
                use_custom_filter=true
                total_row_groups=147
                row_groups_after_prune=147
                pruned_by_custom_filter=0
                pruned_by_min_max=0
    merge_iter_1:
        num_memtables=0
        num_ssts=1
        total_rows_fetch_from_one=1200000
        times_fetch_rows_from_one=2490
        times_fetch_row_from_multiple=0
        init_duration=41.87µs
        scan_duration=3.035329703s
        scan_count=148
        scan_sst_339:
            meta_data_cache_hit=false
            read_meta_data_duration=158.434246ms
            parallelism=8
            prune_row_groups:
                use_custom_filter=true
                total_row_groups=147
                row_groups_after_prune=147
                pruned_by_custom_filter=0
                pruned_by_min_max=0
    merge_iter_2:
        num_memtables=0
        num_ssts=1
        total_rows_fetch_from_one=1200000
        times_fetch_rows_from_one=2490
        times_fetch_row_from_multiple=0
        init_duration=52.026µs
        scan_duration=2.954758353s
        scan_count=148
        scan_sst_367:
            meta_data_cache_hit=false
            read_meta_data_duration=140.372347ms
            parallelism=8
            prune_row_groups:
                use_custom_filter=true
                total_row_groups=147
                row_groups_after_prune=147
                pruned_by_custom_filter=0
                pruned_by_min_max=0
    merge_iter_3:
        num_memtables=0
        num_ssts=1
        total_rows_fetch_from_one=1200000
        times_fetch_rows_from_one=2490
        times_fetch_row_from_multiple=0
        init_duration=40.135µs
        scan_duration=3.756076722s
        scan_count=148
        scan_sst_397:
            meta_data_cache_hit=false
            read_meta_data_duration=153.09233ms
            parallelism=8
            prune_row_groups:
                use_custom_filter=true
                total_row_groups=147
                row_groups_after_prune=147
                pruned_by_custom_filter=0
                pruned_by_min_max=0
    merge_iter_4:
        num_memtables=0
        num_ssts=1
        total_rows_fetch_from_one=1200000
        times_fetch_rows_from_one=2490
        times_fetch_row_from_multiple=0
        init_duration=38.686µs
        scan_duration=3.495850882s
        scan_count=148
        scan_sst_424:
            meta_data_cache_hit=false
            read_meta_data_duration=197.153733ms
            parallelism=8
            prune_row_groups:
                use_custom_filter=true
                total_row_groups=147
                row_groups_after_prune=147
                pruned_by_custom_filter=0
                pruned_by_min_max=0
    merge_iter_5:
        num_memtables=1
        num_ssts=2
        total_rows_fetch_from_one=1097729
        times_fetch_rows_from_one=2279
        times_fetch_row_from_multiple=202271
        init_duration=638.566019ms
        scan_duration=3.570071905s
        scan_count=181
        scan_memtable_2160:
        scan_sst_438:
            meta_data_cache_hit=false
            read_meta_data_duration=188.863397ms
            parallelism=8
            prune_row_groups:
                use_custom_filter=true
                total_row_groups=147
                row_groups_after_prune=147
                pruned_by_custom_filter=0
                pruned_by_min_max=0
        scan_sst_439:
            meta_data_cache_hit=false
            read_meta_data_duration=11.038658ms
            parallelism=8
            prune_row_groups:
                use_custom_filter=true
                total_row_groups=11
                row_groups_after_prune=11
                pruned_by_custom_filter=0
                pruned_by_min_max=0
=0]
```
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
