### PR TITLE
refactor: remove custom oss impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
- "object_store 0.5.3",
+ "object_store 0.5.5",
  "parking_lot 0.12.1",
  "parquet",
  "paste 1.0.8",
@@ -1782,7 +1782,7 @@ dependencies = [
  "arrow 32.0.0",
  "chrono",
  "num_cpus",
- "object_store 0.5.3",
+ "object_store 0.5.5",
  "parquet",
  "sqlparser",
 ]
@@ -1859,7 +1859,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
- "object_store 0.5.3",
+ "object_store 0.5.5",
  "parking_lot 0.12.1",
  "pbjson-build",
  "prost",
@@ -3734,17 +3734,24 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.5.3"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4201837dc4c27a8670f0363b1255cd3845a4f0c521211cced1ed14c1d0cc6d2"
+checksum = "e1ea8f683b4f89a64181393742c041520a1a87e9775e6b4c0dd5a3281af05fc6"
 dependencies = [
  "async-trait",
+ "base64 0.21.0",
  "bytes 1.2.1",
  "chrono",
  "futures 0.3.25",
  "itertools",
  "parking_lot 0.12.1",
  "percent-encoding",
+ "quick-xml 0.27.1",
+ "rand 0.8.5",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
  "snafu 0.7.1",
  "tokio",
  "tracing",
@@ -3767,7 +3774,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru",
- "object_store 0.5.3",
+ "object_store 0.5.5",
  "oss-rust-sdk",
  "prometheus 0.12.0",
  "prometheus-static-metric",
@@ -4562,6 +4569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -4928,6 +4936,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -30,7 +30,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
-upstream = { package = "object_store", version = "0.5.3" }
+upstream = { package = "object_store", version = "0.5.5", features = [ "aws" ] }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/components/object_store/src/aliyun.rs
+++ b/components/object_store/src/aliyun.rs
@@ -1,259 +1,28 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use std::{collections::HashMap, fmt::Display, ops::Range, time::Duration};
+use std::time::Duration;
 
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::{
-    stream::{self, BoxStream},
-    StreamExt,
-};
-use oss_rust_sdk::{
-    async_object::AsyncObjectAPI, errors::Error as AliyunError, oss::Options, prelude::OSS,
-};
-use snafu::{ResultExt, Snafu};
-use tokio::io::AsyncWrite;
 use upstream::{
-    path::Path, Error as OssError, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore,
-    Result,
+    aws::{AmazonS3, AmazonS3Builder},
+    ClientOptions,
 };
 
-#[derive(Debug, Snafu)]
-enum Error {
-    #[snafu(display("Failed to put object at path:{}, err:{}", path, source))]
-    PutObject { path: String, source: AliyunError },
-
-    #[snafu(display("Failed to get object at path:{}, err:{}", path, source))]
-    GetObject { path: String, source: AliyunError },
-
-    #[snafu(display("Failed to get range of object at path:{}, err:{}", path, source))]
-    GetRangeObject {
-        path: String,
-        range: Range<usize>,
-        source: AliyunError,
-    },
-
-    #[snafu(display("Failed to head object at path:{}, err:{}", path, source))]
-    HeadObject { path: String, source: AliyunError },
-
-    #[snafu(display("Failed to delete object at path:{}, err:{}", path, source))]
-    DeleteObject { path: String, source: AliyunError },
-
-    #[snafu(display("Operation {} is not implemented", op))]
-    Unimplemented { op: String },
-}
-
-impl From<Error> for OssError {
-    fn from(source: Error) -> Self {
-        Self::Generic {
-            store: "Aliyun",
-            source: Box::new(source),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct AliyunOSS {
-    oss: OSS<'static>,
-}
-
-impl AliyunOSS {
-    const RANGE_KEY: &str = "Range";
-
-    pub fn new(
-        key_id: impl Into<String>,
-        key_secret: impl Into<String>,
-        endpoint: impl Into<String>,
-        bucket: impl Into<String>,
-        pool_max_idle_per_host: impl Into<usize>,
-        timeout: impl Into<Duration>,
-    ) -> Self {
-        let oss = OSS::new_with_opts(
-            key_id.into(),
-            key_secret.into(),
-            endpoint.into(),
-            bucket.into(),
-            Options {
-                pool_max_idle_per_host: Some(pool_max_idle_per_host.into()),
-                timeout: Some(timeout.into()),
-            },
-        );
-        Self { oss }
-    }
-
-    fn make_range_header(range: &Range<usize>, headers: &mut HashMap<String, String>) {
-        assert!(!range.is_empty());
-        let range_value = format!("bytes={}-{}", range.start, range.end - 1);
-
-        headers.insert(Self::RANGE_KEY.to_string(), range_value);
-    }
-}
-
-#[async_trait]
-impl ObjectStore for AliyunOSS {
-    async fn put(&self, location: &Path, bytes: Bytes) -> Result<()> {
-        self.oss
-            .put_object(
-                &bytes,
-                &location.to_string(),
-                None::<HashMap<String, String>>,
-                None,
-            )
-            .await
-            .with_context(|| PutObject {
-                path: location.to_string(),
-            })?;
-
-        Ok(())
-    }
-
-    async fn put_multipart(
-        &self,
-        _location: &Path,
-    ) -> Result<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
-        Err(Error::Unimplemented {
-            op: "put_multipart".to_string(),
-        }
-        .into())
-    }
-
-    async fn abort_multipart(&self, _location: &Path, _multipart_id: &MultipartId) -> Result<()> {
-        Err(Error::Unimplemented {
-            op: "abort_multipart".to_string(),
-        }
-        .into())
-    }
-
-    async fn get(&self, location: &Path) -> Result<GetResult> {
-        let bytes = self
-            .oss
-            .get_object(&location.to_string(), None::<HashMap<String, String>>, None)
-            .await
-            .with_context(|| GetObject {
-                path: location.to_string(),
-            })?;
-
-        Ok(GetResult::Stream(stream::once(async { Ok(bytes) }).boxed()))
-    }
-
-    async fn get_range(&self, location: &Path, range: Range<usize>) -> Result<Bytes> {
-        if range.is_empty() {
-            return Ok(Bytes::new());
-        }
-
-        let mut headers = HashMap::new();
-        Self::make_range_header(&range, &mut headers);
-
-        let bytes = self
-            .oss
-            .get_object(&location.to_string(), Some(headers), None)
-            .await
-            .with_context(|| GetRangeObject {
-                path: location.to_string(),
-                range,
-            })?;
-
-        Ok(bytes)
-    }
-
-    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
-        let head = self
-            .oss
-            .head_object(&location.to_string())
-            .await
-            .with_context(|| HeadObject {
-                path: location.to_string(),
-            })?;
-
-        Ok(ObjectMeta {
-            last_modified: head.last_modified.into(),
-            size: head.size,
-            location: location.clone(),
-        })
-    }
-
-    async fn delete(&self, location: &Path) -> Result<()> {
-        self.oss
-            .delete_object(&location.to_string())
-            .await
-            .with_context(|| DeleteObject {
-                path: location.to_string(),
-            })?;
-
-        Ok(())
-    }
-
-    async fn list(&self, _prefix: Option<&Path>) -> Result<BoxStream<'_, Result<ObjectMeta>>> {
-        Err(Error::Unimplemented {
-            op: "list".to_string(),
-        }
-        .into())
-    }
-
-    async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> Result<ListResult> {
-        Err(Error::Unimplemented {
-            op: "list_with_delimiter".to_string(),
-        }
-        .into())
-    }
-
-    async fn copy(&self, _from: &Path, _to: &Path) -> Result<()> {
-        Err(Error::Unimplemented {
-            op: "copy".to_string(),
-        }
-        .into())
-    }
-
-    async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> Result<()> {
-        Err(Error::Unimplemented {
-            op: "copy_if_not_exists".to_string(),
-        }
-        .into())
-    }
-}
-
-impl Display for AliyunOSS {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "AliyunOSS({})", self.oss.bucket())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_range_header() {
-        let testcases = vec![
-            ((0..500), "bytes=0-499"),
-            ((1000..1001), "bytes=1000-1000"),
-            ((200..1000), "bytes=200-999"),
-        ];
-
-        for (input_range, expect_value) in testcases {
-            let mut headers = HashMap::new();
-            AliyunOSS::make_range_header(&input_range, &mut headers);
-
-            assert_eq!(headers.len(), 1);
-            let range_value = headers
-                .get(AliyunOSS::RANGE_KEY)
-                .expect("should have range key");
-            assert_eq!(range_value, expect_value);
-        }
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_panic_invalid_range_header() {
-        let mut headers = HashMap::new();
-        #[allow(clippy::reversed_empty_ranges)]
-        AliyunOSS::make_range_header(&(500..499), &mut headers);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_panic_empty_range_header() {
-        let mut headers = HashMap::new();
-        AliyunOSS::make_range_header(&(500..500), &mut headers);
-    }
+pub fn try_new(
+    key_id: impl Into<String>,
+    key_secret: impl Into<String>,
+    endpoint: impl Into<String>,
+    bucket: impl Into<String>,
+    pool_max_idle_per_host: impl Into<usize>,
+    timeout: Duration,
+) -> upstream::Result<AmazonS3> {
+    let cli_opt = ClientOptions::new()
+        .with_pool_max_idle_per_host(pool_max_idle_per_host.into())
+        .with_timeout(timeout);
+    AmazonS3Builder::new()
+        .with_access_key_id(key_id)
+        .with_secret_access_key(key_secret)
+        .with_bucket_name(bucket)
+        .with_url(endpoint)
+        .with_client_options(cli_opt)
+        .build()
 }

--- a/components/object_store/src/aliyun.rs
+++ b/components/object_store/src/aliyun.rs
@@ -4,8 +4,20 @@ use std::time::Duration;
 
 use upstream::{
     aws::{AmazonS3, AmazonS3Builder},
-    ClientOptions,
+    ClientOptions, RetryConfig,
 };
+
+fn normalize_endpoint(endpoint: &str, bucket: &str) -> String {
+    if endpoint.starts_with("https") {
+        format!(
+            "https://{}.{}",
+            bucket,
+            endpoint.replacen("https://", "", 1)
+        )
+    } else {
+        format!("http://{}.{}", bucket, endpoint.replacen("http://", "", 1))
+    }
+}
 
 pub fn try_new(
     key_id: impl Into<String>,
@@ -16,13 +28,55 @@ pub fn try_new(
     timeout: Duration,
 ) -> upstream::Result<AmazonS3> {
     let cli_opt = ClientOptions::new()
+        .with_allow_http(true)
         .with_pool_max_idle_per_host(pool_max_idle_per_host.into())
         .with_timeout(timeout);
+    let retry_config = RetryConfig {
+        // TODO: add to config
+        max_retries: 3,
+        ..Default::default()
+    };
+
+    let endpoint = endpoint.into();
+    let bucket = bucket.into();
+    let endpoint = normalize_endpoint(&endpoint, &bucket);
     AmazonS3Builder::new()
+        .with_virtual_hosted_style_request(true)
+        // region is not used when virtual_hosted_style is true,
+        // but is required, so dummy is used here
+        .with_region("dummy")
         .with_access_key_id(key_id)
         .with_secret_access_key(key_secret)
+        .with_endpoint(endpoint)
         .with_bucket_name(bucket)
-        .with_url(endpoint)
         .with_client_options(cli_opt)
+        .with_retry(retry_config)
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_endpoint() {
+        let testcase = [
+            (
+                "https://oss.aliyun.com",
+                "test",
+                "https://test.oss.aliyun.com",
+            ),
+            (
+                "http://oss.aliyun.com",
+                "test",
+                "http://test.oss.aliyun.com",
+            ),
+            ("no-scheme.com", "test", "http://test.no-scheme.com"),
+        ];
+
+        for (endpoint, bucket, expected) in testcase {
+            let actual = normalize_endpoint(endpoint, bucket);
+            assert_eq!(expected, actual);
+        }
+    }
 }

--- a/components/object_store/src/aliyun.rs
+++ b/components/object_store/src/aliyun.rs
@@ -44,6 +44,7 @@ pub fn try_new(
         .with_virtual_hosted_style_request(true)
         // region is not used when virtual_hosted_style is true,
         // but is required, so dummy is used here
+        // https://github.com/apache/arrow-rs/issues/3827
         .with_region("dummy")
         .with_access_key_id(key_id)
         .with_secret_access_key(key_secret)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #608, close #396

## Rationale for this change
 
Since OSS is S3-compatible, so we can access OSS via S3 client directly.
- https://www.alibabacloud.com/help/en/object-storage-service/latest/use-aws-s3-sdk-to-access-oss
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Use S3 client in object_store crate to access OSS
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

Manually 

