### PR TITLE
fix: failure to open a single table does not interrupt the shard's opening process

### DIFF
--- a/server/src/grpc/meta_event_service/error.rs
+++ b/server/src/grpc/meta_event_service/error.rs
@@ -22,9 +22,6 @@ pub enum Error {
         msg: String,
         source: GenericError,
     },
-
-    #[snafu(display("Open shard error, code:{:?}, message:{}", code, msg))]
-    OpenShardErr { code: StatusCode, msg: String },
 }
 
 impl Error {
@@ -32,7 +29,6 @@ impl Error {
         match *self {
             Error::ErrNoCause { code, .. } => code,
             Error::ErrWithCause { code, .. } => code,
-            Error::OpenShardErr { code, .. } => code,
         }
     }
 
@@ -46,8 +42,6 @@ impl Error {
                 let first_line = error_util::remove_backtrace_from_err(&err_string);
                 format!("{msg}. Caused by: {first_line}")
             }
-
-            Error::OpenShardErr { msg, .. } => msg.clone(),
         }
     }
 }

--- a/server/src/grpc/meta_event_service/error.rs
+++ b/server/src/grpc/meta_event_service/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
         msg: String,
         source: GenericError,
     },
+
+    #[snafu(display("Open shard error, code:{:?}, message:{}", code, msg))]
+    OpenShardErr { code: StatusCode, msg: String },
 }
 
 impl Error {
@@ -29,6 +32,7 @@ impl Error {
         match *self {
             Error::ErrNoCause { code, .. } => code,
             Error::ErrWithCause { code, .. } => code,
+            Error::OpenShardErr { code, .. } => code,
         }
     }
 
@@ -42,6 +46,8 @@ impl Error {
                 let first_line = error_util::remove_backtrace_from_err(&err_string);
                 format!("{msg}. Caused by: {first_line}")
             }
+
+            Error::OpenShardErr { msg, .. } => msg.clone(),
         }
     }
 }

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -256,8 +256,8 @@ async fn handle_open_shard(ctx: HandlerContext, request: OpenShardRequest) -> Re
         }
 
         match result.err() {
-            Some(e) => warn!("fail to open table, open_request:{open_request:?}, error:{e:?}"),
-            None => warn!("no table is opened, open_request:{open_request:?}"),
+            Some(e) => warn!("Failed to open table, open_request:{open_request:?}, error:{e:?}"),
+            None => warn!("No table is opened, open_request:{open_request:?}"),
         }
         // box_result
         //     .with_context(|| ErrWithCause {

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -259,15 +259,6 @@ async fn handle_open_shard(ctx: HandlerContext, request: OpenShardRequest) -> Re
             Some(e) => warn!("Failed to open table, open_request:{open_request:?}, error:{e:?}"),
             None => warn!("No table is opened, open_request:{open_request:?}"),
         }
-        // box_result
-        //     .with_context(|| ErrWithCause {
-        //         code: StatusCode::Internal,
-        //         msg: format!("fail to open table,
-        // open_request:{open_request:?}"),     })?
-        //     .with_context(|| ErrNoCause {
-        //         code: StatusCode::Internal,
-        //         msg: format!("no table is opened,
-        // open_request:{open_request:?}"),     })?;
     }
 
     Ok(())

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -25,7 +25,7 @@ use ceresdbproto::meta_event::{
 use cluster::ClusterRef;
 use common_types::schema::SchemaEncoder;
 use common_util::{error::BoxError, runtime::Runtime, time::InstantExt};
-use log::{error, info, warn};
+use log::{error, info};
 use paste::paste;
 use query_engine::executor::Executor as QueryExecutor;
 use snafu::{OptionExt, ResultExt};
@@ -237,7 +237,7 @@ async fn handle_open_shard(ctx: HandlerContext, request: OpenShardRequest) -> Re
     };
 
     let mut success = 0;
-    let mut cfail = 0;
+    let mut fail = 0;
     for table in tables_of_shard.tables {
         let schema = find_schema(default_catalog.clone(), &table.schema_name)?;
 

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -284,7 +284,7 @@ async fn handle_open_shard(ctx: HandlerContext, request: OpenShardRequest) -> Re
         Err(Error::ErrNoCause {
             code: StatusCode::Internal,
             msg: format!(
-                "Failed to open shard:{},  because of failed tables:{err_map:?}",
+                "Failed to open shard:{}, because of failed tables:{err_map:?}",
                 shard_info.id
             ),
         })

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -251,13 +251,10 @@ async fn handle_open_shard(ctx: HandlerContext, request: OpenShardRequest) -> Re
         };
         let result = schema.open_table(open_request.clone(), opts.clone()).await;
 
-        if result.is_ok() {
-            continue;
-        }
-
-        match result.err() {
-            Some(e) => warn!("Failed to open table, open_request:{open_request:?}, error:{e:?}"),
-            None => warn!("No table is opened, open_request:{open_request:?}"),
+        match result {
+            Ok(Some(_)) => {},
+            Ok(None) => error!("No table is opened, open_request:{open_request:?}"),
+            Err(e) => error!("Failed to open table, open_request:{open_request:?}, err:{e}"),
         }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #721 

## Rationale for this change
 
 The shard will stop opening if opening a table fails, and no other normal tables will be opened in that shard.
 Access to these tables will fail.

## What changes are included in this PR?


* Print warn log if opening a table fails
* Continue to open shard

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
