### PR TITLE
fix: Panicked when OceanBase table client is initialing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "obkv-table-client-rs"
 version = "0.1.0"
-source = "git+https://github.com/oceanbase/obkv-table-client-rs.git?rev=f823d35880022402e816dc3d4a4cb64056f39bff#f823d35880022402e816dc3d4a4cb64056f39bff"
+source = "git+https://github.com/oceanbase/obkv-table-client-rs.git?rev=5f3240ed82309640056333d980ca7a177006966e#5f3240ed82309640056333d980ca7a177006966e"
 dependencies = [
  "byteorder",
  "bytes 0.4.12",

--- a/components/table_kv/Cargo.toml
+++ b/components/table_kv/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 common_util = { workspace = true }
 log = { workspace = true }
-obkv-table-client-rs = { git = "https://github.com/oceanbase/obkv-table-client-rs.git", rev = "f823d35880022402e816dc3d4a4cb64056f39bff" }
+obkv-table-client-rs = { git = "https://github.com/oceanbase/obkv-table-client-rs.git", rev = "5f3240ed82309640056333d980ca7a177006966e" }
 serde = { workspace = true }
 
 snafu = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
related with https://github.com/oceanbase/obkv-table-client-rs/pull/21

Table client will init timeout when one OB server is invalid, eg, OUT_OF_MEM, SERVER_IS_INIT.


## What changes are included in this PR?

Update OceanBase rust client

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

Integration test
