### PR TITLE
feat: http debug api for config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,11 +1042,11 @@ dependencies = [
  "query_engine",
  "router",
  "serde",
- "serde_json",
  "server",
  "signal-hook",
  "sort",
  "table_engine",
+ "toml 0.7.3",
  "tracing_util",
  "vergen",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
  "time 0.1.44",
  "tokio",
  "tokio-test",
- "toml",
+ "toml 0.7.3",
 ]
 
 [[package]]
@@ -4343,9 +4343,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -5254,9 +5254,9 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
@@ -5282,9 +5282,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5299,6 +5299,15 @@ checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
  "serde",
 ]
 
@@ -5679,7 +5688,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
- "toml",
+ "toml 0.5.9",
  "walkdir",
 ]
 
@@ -5840,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6238,6 +6247,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -6987,6 +7030,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winnow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,7 @@ dependencies = [
  "query_engine",
  "router",
  "serde",
+ "serde_json",
  "server",
  "signal-hook",
  "sort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ system_catalog = { path = "system_catalog" }
 table_engine = { path = "table_engine" }
 table_kv = { path = "components/table_kv" }
 tempfile = "3.1.0"
+toml = "0.7"
 tracing_util = { path = "components/tracing_util" }
 tonic = "0.8.1"
 tokio = { version = "1.25", features = ["full"] }
@@ -133,11 +134,11 @@ meta_client = { workspace = true }
 query_engine = { workspace = true }
 router = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 server = { workspace = true }
 signal-hook = "0.3"
 sort = "0.8.5"
 table_engine = { workspace = true }
+toml = { workspace = true }
 tracing_util = { workspace = true }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ meta_client = { workspace = true }
 query_engine = { workspace = true }
 router = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 server = { workspace = true }
 signal-hook = "0.3"
 sort = "0.8.5"

--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use common_util::config::{ReadableSize, TimeUnit};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{ensure, Backtrace, GenerateBacktrace, ResultExt, Snafu};
 use tokio::sync::oneshot;
 
@@ -57,7 +57,7 @@ pub enum Error {
     InvalidOption { error: String, backtrace: Backtrace },
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, Deserialize, Default, PartialEq, Serialize)]
 pub enum CompactionStrategy {
     #[default]
     Default,
@@ -65,7 +65,7 @@ pub enum CompactionStrategy {
     SizeTiered(SizeTieredCompactionOptions),
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 pub struct SizeTieredCompactionOptions {
     pub bucket_low: f32,
     pub bucket_high: f32,
@@ -75,7 +75,7 @@ pub struct SizeTieredCompactionOptions {
     pub max_input_sstable_size: ReadableSize,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
 pub struct TimeWindowCompactionOptions {
     pub size_tiered: SizeTieredCompactionOptions,
     // TODO(boyan) In fact right now we only supports TimeUnit::Milliseconds resolution.

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -21,7 +21,7 @@ use common_util::{
     time::DurationExt,
 };
 use log::{debug, error, info, warn};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use table_engine::table::TableId;
 use tokio::{
@@ -54,7 +54,7 @@ pub enum Error {
 
 define_result!(Error);
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct SchedulerConfig {
     pub schedule_channel_len: usize,

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -36,7 +36,7 @@ use wal::{
 pub use crate::{compaction::scheduler::SchedulerConfig, table_options::TableOptions};
 
 /// Config of analytic engine
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     /// Storage options of the engine
@@ -115,7 +115,7 @@ impl Default for Config {
 }
 
 /// Config of wal based on obkv
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ObkvWalConfig {
     /// Obkv client config
@@ -222,7 +222,7 @@ impl From<WalNamespaceConfig> for NamespaceConfig {
 }
 
 /// Config of wal based on obkv
-#[derive(Debug, Default, Clone, Deserialize)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct KafkaWalConfig {
     /// Kafka client config
@@ -235,7 +235,7 @@ pub struct KafkaWalConfig {
 }
 
 /// Config for wal based on RocksDB
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RocksDBConfig {
     /// Data directory used by RocksDB.
@@ -250,7 +250,7 @@ impl Default for RocksDBConfig {
     }
 }
 /// Options for wal storage backend
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum WalStorageConfig {
     RocksDB(Box<RocksDBConfig>),

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -22,7 +22,7 @@ use log::{debug, info, warn};
 use object_store::{ObjectStoreRef, Path};
 use parquet::data_type::AsBytes;
 use prost::Message;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{Backtrace, ResultExt, Snafu};
 use table_engine::table::TableId;
 use tokio::sync::Mutex;
@@ -157,7 +157,7 @@ impl MetaUpdateLogEntryIterator for MetaUpdateReaderImpl {
 }
 
 /// Options for manifest
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Options {
     /// Steps to do snapshot
     pub snapshot_every_n_updates: usize,

--- a/analytic_engine/src/storage_options.rs
+++ b/analytic_engine/src/storage_options.rs
@@ -3,9 +3,9 @@
 use std::time::Duration;
 
 use common_util::config::{ReadableDuration, ReadableSize};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 /// Options for storage backend
 pub struct StorageOptions {
@@ -37,19 +37,19 @@ impl Default for StorageOptions {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum ObjectStoreOptions {
     Local(LocalOptions),
     Aliyun(AliyunOptions),
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocalOptions {
     pub data_dir: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AliyunOptions {
     pub key_id: String,
     pub key_secret: String,

--- a/analytic_engine/src/table_options.rs
+++ b/analytic_engine/src/table_options.rs
@@ -12,7 +12,7 @@ use common_util::{
     time::DurationExt,
 };
 use datafusion::parquet::basic::Compression as ParquetCompression;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{Backtrace, GenerateBacktrace, OptionExt, ResultExt, Snafu};
 use table_engine::OPTION_KEY_ENABLE_TTL;
 
@@ -125,7 +125,7 @@ pub enum Error {
 
 define_result!(Error);
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Deserialize, Eq, PartialEq, Serialize)]
 pub enum UpdateMode {
     Overwrite,
     Append,
@@ -152,7 +152,7 @@ impl ToString for UpdateMode {
     }
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Compression {
     Uncompressed,
     Lz4,
@@ -221,7 +221,7 @@ impl From<Compression> for ParquetCompression {
 }
 
 /// A hint for building sst.
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub enum StorageFormatHint {
     /// Which storage format is chosen to encode one sst depends on the data
     /// pattern.
@@ -231,7 +231,7 @@ pub enum StorageFormatHint {
 }
 
 /// StorageFormat specify how records are saved in persistent storage
-#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Serialize)]
 pub enum StorageFormat {
     /// Traditional columnar format, every column is saved in one exact one
     /// column, for example:
@@ -375,7 +375,7 @@ impl Default for StorageFormat {
 }
 
 /// Options for a table.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
 pub struct TableOptions {
     // The following options are immutable once table was created.

--- a/cluster/src/config.rs
+++ b/cluster/src/config.rs
@@ -2,7 +2,7 @@
 
 use common_types::schema::TIMESTAMP_COLUMN;
 use meta_client::meta_impl::MetaClientConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use table_engine::ANALYTIC_ENGINE_TYPE;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -22,7 +22,7 @@ impl Default for SchemaConfig {
     }
 }
 
-#[derive(Default, Clone, Deserialize, Debug)]
+#[derive(Default, Clone, Deserialize, Debug, Serialize)]
 #[serde(default)]
 pub struct ClusterConfig {
     pub cmd_channel_buffer_size: usize,

--- a/common_util/Cargo.toml
+++ b/common_util/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 time = "0.1"
 tokio = { workspace = true }
-toml = "0.5"
+toml = { workspace = true }
 
 [dev-dependencies.slog-global]
 version = "0.1"

--- a/common_util/src/config.rs
+++ b/common_util/src/config.rs
@@ -106,7 +106,7 @@ impl FromStr for TimeUnit {
             "minutes" => Ok(TimeUnit::Minutes),
             "hours" => Ok(TimeUnit::Hours),
             "days" => Ok(TimeUnit::Days),
-            _ => Err(format!("unexpect TimeUnit: {tu_str}")),
+            _ => Err(format!("unexpected TimeUnit: {tu_str}")),
         }
     }
 }

--- a/common_util/src/toml.rs
+++ b/common_util/src/toml.rs
@@ -50,9 +50,9 @@ define_result!(Error);
 
 /// Read toml file from given `path` to `toml_buf`, then parsed it to `T` and
 /// return.
-pub fn parse_toml_from_path<'a, T>(path: &str, toml_buf: &'a mut String) -> Result<T>
+pub fn parse_toml_from_path<T>(path: &str, toml_buf: &mut String) -> Result<T>
 where
-    T: de::Deserialize<'a>,
+    T: de::DeserializeOwned,
 {
     let mut file = File::open(path).context(OpenFile { path })?;
     file.read_to_string(toml_buf).context(ReadToml { path })?;

--- a/components/logger/src/lib.rs
+++ b/components/logger/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use log::{info, SetLoggerError};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 pub use slog::Level;
 use slog::{slog_o, Drain, Key, OwnedKVList, Record, KV};
 use slog_async::{Async, OverflowStrategy};
@@ -100,7 +100,7 @@ where
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 /// The config for logger.
 pub struct Config {

--- a/components/tracing_util/src/logging.rs
+++ b/components/tracing_util/src/logging.rs
@@ -22,7 +22,7 @@ use std::{
 
 use fmt::format::FmtSpan;
 use lazy_static::lazy_static;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tracing::Subscriber;
 use tracing_appender::{
     non_blocking::WorkerGuard,
@@ -80,7 +80,7 @@ fn init_tracing_stdout() {
         .expect("error setting global tracing subscriber");
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 /// The configurations for tracing.
 pub struct Config {

--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -9,7 +9,7 @@ use ceresdbproto::{
 };
 use common_util::{config::ReadableDuration, error::BoxError};
 use log::{debug, info};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
 
 type MetaServiceGrpcClient = CeresmetaRpcServiceClient<tonic::transport::Channel>;
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Serialize)]
 #[serde(default)]
 pub struct MetaClientConfig {
     pub cluster_name: String,

--- a/query_engine/src/config.rs
+++ b/query_engine/src/config.rs
@@ -1,11 +1,11 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 // FIXME: Use cpu number as the default parallelism
 const DEFAULT_READ_PARALLELISM: usize = 8;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub read_parallelism: usize,

--- a/remote_engine_client/src/config.rs
+++ b/remote_engine_client/src/config.rs
@@ -5,9 +5,9 @@
 use std::str::FromStr;
 
 use common_util::config::ReadableDuration;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub connect_timeout: ReadableDuration,

--- a/router/src/endpoint.rs
+++ b/router/src/endpoint.rs
@@ -6,9 +6,9 @@ use std::str::FromStr;
 
 use ceresdbproto::storage;
 use common_util::error::GenericError;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Hash, Serialize)]
 pub struct Endpoint {
     pub addr: String,
     pub port: u16,

--- a/router/src/rule_based.rs
+++ b/router/src/rule_based.rs
@@ -9,7 +9,7 @@ use ceresdbproto::storage::{self, Route, RouteRequest};
 use cluster::config::SchemaConfig;
 use log::info;
 use meta_client::types::ShardId;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{ensure, OptionExt};
 
 use crate::{endpoint::Endpoint, hash, Result, RouteNotFound, Router, ShardNotFound};
@@ -22,7 +22,7 @@ pub struct ClusterView {
     pub schema_configs: HashMap<String, SchemaConfig>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PrefixRule {
     /// Schema name of the prefix.
     pub schema: String,
@@ -32,7 +32,7 @@ pub struct PrefixRule {
     pub shard: ShardId,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HashRule {
     /// Schema name of the prefix.
     pub schema: String,
@@ -40,7 +40,7 @@ pub struct HashRule {
     pub shards: Vec<ShardId>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RuleList {
     pub prefix_rules: Vec<PrefixRule>,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -12,25 +12,25 @@ use router::{
     endpoint::Endpoint,
     rule_based::{ClusterView, RuleList},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use table_engine::ANALYTIC_ENGINE_TYPE;
 
 use crate::{grpc::forward, http::DEFAULT_MAX_BODY_SIZE};
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct StaticRouteConfig {
     pub rules: RuleList,
     pub topology: StaticTopologyConfig,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ShardView {
     pub shard_id: ShardId,
     pub endpoint: Endpoint,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Serialize)]
 #[serde(default)]
 pub struct SchemaShardView {
     pub schema: String,
@@ -59,7 +59,7 @@ impl From<SchemaShardView> for SchemaConfig {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Clone)]
+#[derive(Debug, Default, Deserialize, Clone, Serialize)]
 #[serde(default)]
 pub struct StaticTopologyConfig {
     pub schema_shards: Vec<SchemaShardView>,
@@ -89,7 +89,7 @@ impl From<&StaticTopologyConfig> for ClusterView {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ServerConfig {
     /// The address to listen.

--- a/server/src/grpc/forward.rs
+++ b/server/src/grpc/forward.rs
@@ -14,7 +14,7 @@ use ceresdbproto::storage::{
 };
 use log::{debug, error, warn};
 use router::{endpoint::Endpoint, RouterRef};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use tonic::{
     metadata::errors::InvalidMetadataValue,
@@ -74,7 +74,7 @@ define_result!(Error);
 
 pub type ForwarderRef = Arc<Forwarder<DefaultClientBuilder>>;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct Config {
     pub enable: bool,

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -128,7 +128,7 @@ pub struct Service<Q> {
 
 impl<Q> Service<Q> {
     pub fn stop(self) {
-        if let Err(_) = self.tx.send(()) {
+        if self.tx.send(()).is_err() {
             error!("Failed to send http service stop message");
         }
     }
@@ -435,13 +435,6 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
     }
 
     fn with_log_runtime(
-        &self,
-    ) -> impl Filter<Extract = (Arc<RuntimeLevel>,), Error = Infallible> + Clone {
-        let log_runtime = self.log_runtime.clone();
-        warp::any().map(move || log_runtime.clone())
-    }
-
-    fn with_server_config_content(
         &self,
     ) -> impl Filter<Extract = (Arc<RuntimeLevel>,), Error = Infallible> + Clone {
         let log_runtime = self.log_runtime.clone();

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -64,6 +64,12 @@ pub enum Error {
     #[snafu(display("Missing instance to build service.\nBacktrace:\n{}", backtrace))]
     MissingInstance { backtrace: Backtrace },
 
+    #[snafu(display(
+        "Missing server config content to build service.\nBacktrace:\n{}",
+        backtrace
+    ))]
+    MissingServerConfigContent { backtrace: Backtrace },
+
     #[snafu(display("Missing schema config provider.\nBacktrace:\n{}", backtrace))]
     MissingSchemaConfigProvider { backtrace: Backtrace },
 
@@ -117,12 +123,14 @@ pub struct Service<Q> {
     influxdb: Arc<InfluxDb<Q>>,
     tx: Sender<()>,
     config: HttpConfig,
+    server_config_content: String,
 }
 
 impl<Q> Service<Q> {
-    // TODO(yingwen): Maybe log error or return error
     pub fn stop(self) {
-        let _ = self.tx.send(());
+        if let Err(_) = self.tx.send(()) {
+            error!("Failed to send http service stop message");
+        }
     }
 }
 
@@ -142,6 +150,7 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
             .or(self.flush_memtable())
             .or(self.update_log_level())
             .or(self.heap_profile())
+            .or(self.server_config())
     }
 
     /// Expose `/prom/v1/read` and `/prom/v1/write` to serve Prometheus remote
@@ -310,6 +319,16 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
             )
     }
 
+    // GET /debug/config
+    fn server_config(
+        &self,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        let server_config_content = self.server_config_content.clone();
+        warp::path!("debug" / "config")
+            .and(warp::get())
+            .map(move || server_config_content.clone())
+    }
+
     // PUT /debug/log_level/{level}
     fn update_log_level(
         &self,
@@ -421,6 +440,13 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
         let log_runtime = self.log_runtime.clone();
         warp::any().map(move || log_runtime.clone())
     }
+
+    fn with_server_config_content(
+        &self,
+    ) -> impl Filter<Extract = (Arc<RuntimeLevel>,), Error = Infallible> + Clone {
+        let log_runtime = self.log_runtime.clone();
+        warp::any().map(move || log_runtime.clone())
+    }
 }
 
 /// Service builder
@@ -430,6 +456,7 @@ pub struct Builder<Q> {
     log_runtime: Option<Arc<RuntimeLevel>>,
     instance: Option<InstanceRef<Q>>,
     schema_config_provider: Option<SchemaConfigProviderRef>,
+    server_config_content: Option<String>,
 }
 
 impl<Q> Builder<Q> {
@@ -440,6 +467,7 @@ impl<Q> Builder<Q> {
             log_runtime: None,
             instance: None,
             schema_config_provider: None,
+            server_config_content: None,
         }
     }
 
@@ -462,6 +490,11 @@ impl<Q> Builder<Q> {
         self.schema_config_provider = Some(provider);
         self
     }
+
+    pub fn server_config_content(mut self, content: String) -> Self {
+        self.server_config_content = Some(content);
+        self
+    }
 }
 
 impl<Q: QueryExecutor + 'static> Builder<Q> {
@@ -470,6 +503,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
         let engine_runtime = self.engine_runtimes.context(MissingEngineRuntimes)?;
         let log_runtime = self.log_runtime.context(MissingLogRuntime)?;
         let instance = self.instance.context(MissingInstance)?;
+        let server_config_content = self.server_config_content.context(MissingInstance)?;
         let schema_config_provider = self
             .schema_config_provider
             .context(MissingSchemaConfigProvider)?;
@@ -489,6 +523,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             profiler: Arc::new(Profiler::default()),
             tx,
             config: self.config.clone(),
+            server_config_content,
         };
 
         info!(
@@ -537,6 +572,7 @@ fn error_to_status_code(err: &Error) -> StatusCode {
         | Error::MissingEngineRuntimes { .. }
         | Error::MissingLogRuntime { .. }
         | Error::MissingInstance { .. }
+        | Error::MissingServerConfigContent { .. }
         | Error::MissingSchemaConfigProvider { .. }
         | Error::ParseIpAddr { .. }
         | Error::ProfileHeap { .. }

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -123,7 +123,7 @@ pub struct Service<Q> {
     influxdb: Arc<InfluxDb<Q>>,
     tx: Sender<()>,
     config: HttpConfig,
-    server_config_content: String,
+    config_content: String,
 }
 
 impl<Q> Service<Q> {
@@ -323,7 +323,7 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
     fn server_config(
         &self,
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-        let server_config_content = self.server_config_content.clone();
+        let server_config_content = self.config_content.clone();
         warp::path!("debug" / "config")
             .and(warp::get())
             .map(move || server_config_content.clone())
@@ -449,7 +449,7 @@ pub struct Builder<Q> {
     log_runtime: Option<Arc<RuntimeLevel>>,
     instance: Option<InstanceRef<Q>>,
     schema_config_provider: Option<SchemaConfigProviderRef>,
-    server_config_content: Option<String>,
+    config_content: Option<String>,
 }
 
 impl<Q> Builder<Q> {
@@ -460,7 +460,7 @@ impl<Q> Builder<Q> {
             log_runtime: None,
             instance: None,
             schema_config_provider: None,
-            server_config_content: None,
+            config_content: None,
         }
     }
 
@@ -484,8 +484,8 @@ impl<Q> Builder<Q> {
         self
     }
 
-    pub fn server_config_content(mut self, content: String) -> Self {
-        self.server_config_content = Some(content);
+    pub fn config_content(mut self, content: String) -> Self {
+        self.config_content = Some(content);
         self
     }
 }
@@ -496,7 +496,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
         let engine_runtime = self.engine_runtimes.context(MissingEngineRuntimes)?;
         let log_runtime = self.log_runtime.context(MissingLogRuntime)?;
         let instance = self.instance.context(MissingInstance)?;
-        let server_config_content = self.server_config_content.context(MissingInstance)?;
+        let config_content = self.config_content.context(MissingInstance)?;
         let schema_config_provider = self
             .schema_config_provider
             .context(MissingSchemaConfigProvider)?;
@@ -516,7 +516,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             profiler: Arc::new(Profiler::default()),
             tx,
             config: self.config.clone(),
-            server_config_content,
+            config_content,
         };
 
         info!(

--- a/server/src/limiter.rs
+++ b/server/src/limiter.rs
@@ -31,7 +31,7 @@ pub enum BlockRule {
     QueryWithoutPredicate,
 }
 
-#[derive(Default, Clone, Deserialize, Debug)]
+#[derive(Default, Clone, Deserialize, Debug, Serialize)]
 #[serde(default)]
 pub struct LimiterConfig {
     pub write_block_list: Vec<String>,

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -167,8 +167,9 @@ impl<Q: QueryExecutor + 'static> Server<Q> {
 
 #[must_use]
 pub struct Builder<Q> {
-    config: ServerConfig,
+    server_config: ServerConfig,
     node_addr: String,
+    config_content: Option<String>,
     engine_runtimes: Option<Arc<EngineRuntimes>>,
     log_runtime: Option<Arc<RuntimeLevel>>,
     catalog_manager: Option<ManagerRef>,
@@ -187,8 +188,9 @@ pub struct Builder<Q> {
 impl<Q: QueryExecutor + 'static> Builder<Q> {
     pub fn new(config: ServerConfig) -> Self {
         Self {
-            config,
+            server_config: config,
             node_addr: "".to_string(),
+            config_content: None,
             engine_runtimes: None,
             log_runtime: None,
             catalog_manager: None,
@@ -207,6 +209,11 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
 
     pub fn node_addr(mut self, node_addr: String) -> Self {
         self.node_addr = node_addr;
+        self
+    }
+
+    pub fn config_content(mut self, config_content: String) -> Self {
+        self.config_content = Some(config_content);
         self
     }
 
@@ -302,19 +309,20 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
 
         // Create http config
         let endpoint = Endpoint {
-            addr: self.config.bind_addr.clone(),
-            port: self.config.http_port,
+            addr: self.server_config.bind_addr.clone(),
+            port: self.server_config.http_port,
         };
 
         let http_config = HttpConfig {
             endpoint,
-            max_body_size: self.config.http_max_body_size,
-            timeout: self.config.timeout.map(|v| v.0),
+            max_body_size: self.server_config.http_max_body_size,
+            timeout: self.server_config.timeout.map(|v| v.0),
         };
 
         // Start http service
         let engine_runtimes = self.engine_runtimes.context(MissingEngineRuntimes)?;
         let log_runtime = self.log_runtime.context(MissingLogRuntime)?;
+        let config_content = self.config_content.expect("Missing config content");
         let provider = self
             .schema_config_provider
             .context(MissingSchemaConfigProvider)?;
@@ -323,14 +331,14 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .log_runtime(log_runtime)
             .instance(instance.clone())
             .schema_config_provider(provider.clone())
-            .server_config_content(format!("{:?}", self.config))
+            .config_content(config_content)
             .build()
             .context(StartHttpService)?;
 
         let mysql_config = mysql::MysqlConfig {
-            ip: self.config.bind_addr.clone(),
-            port: self.config.mysql_port,
-            timeout: self.config.timeout.map(|v| v.0),
+            ip: self.server_config.bind_addr.clone(),
+            port: self.server_config.mysql_port,
+            timeout: self.server_config.timeout.map(|v| v.0),
         };
 
         let mysql_service = mysql::Builder::new(mysql_config)
@@ -341,18 +349,23 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
 
         let router = self.router.context(MissingRouter)?;
         let rpc_services = grpc::Builder::new()
-            .endpoint(Endpoint::new(self.config.bind_addr, self.config.grpc_port).to_string())
-            .local_endpoint(Endpoint::new(self.node_addr, self.config.grpc_port).to_string())
-            .resp_compress_min_length(self.config.resp_compress_min_length.as_bytes() as usize)
+            .endpoint(
+                Endpoint::new(self.server_config.bind_addr, self.server_config.grpc_port)
+                    .to_string(),
+            )
+            .local_endpoint(Endpoint::new(self.node_addr, self.server_config.grpc_port).to_string())
+            .resp_compress_min_length(
+                self.server_config.resp_compress_min_length.as_bytes() as usize
+            )
             .runtimes(engine_runtimes)
             .instance(instance.clone())
             .router(router)
             .cluster(self.cluster.clone())
             .opened_wals(opened_wals)
             .schema_config_provider(provider)
-            .forward_config(self.config.forward)
-            .timeout(self.config.timeout.map(|v| v.0))
-            .auto_create_table(self.config.auto_create_table)
+            .forward_config(self.server_config.forward)
+            .timeout(self.server_config.timeout.map(|v| v.0))
+            .auto_create_table(self.server_config.auto_create_table)
             .build()
             .context(BuildGrpcService)?;
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -323,6 +323,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .log_runtime(log_runtime)
             .instance(instance.clone())
             .schema_config_provider(provider.clone())
+            .server_config_content(format!("{:?}", self.config))
             .build()
             .context(StartHttpService)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,13 @@
 // Config for ceresdb server.
 
 use cluster::config::ClusterConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use server::{
     config::{ServerConfig, StaticRouteConfig},
     limiter::LimiterConfig,
 };
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct NodeInfo {
     pub addr: String,
@@ -29,7 +29,7 @@ impl Default for NodeInfo {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// The information of the host node.
@@ -67,14 +67,14 @@ pub struct Config {
 ///
 /// [ClusterDeployment::WithMeta] means to start one or multiple CeresDB
 /// instance(s) under the control of CeresMeta.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "mode")]
 pub enum ClusterDeployment {
     NoMeta(StaticRouteConfig),
     WithMeta(ClusterConfig),
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RuntimeConfig {
     // Runtime for reading data

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -118,7 +118,7 @@ async fn run_server_with_runtimes<T>(
 
     // Config limiter
     let limiter = Limiter::new(config.limiter.clone());
-    let config_content = serde_json::to_string(&config).expect("Fail to serialize config");
+    let config_content = toml::to_string(&config).expect("Fail to serialize config");
 
     let builder = Builder::new(config.server.clone())
         .node_addr(config.node.addr.clone())

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -101,7 +101,7 @@ pub fn run_server(config: Config, log_runtime: RuntimeLevel) {
 
 async fn run_server_with_runtimes<T>(
     config: Config,
-    runtimes: Arc<EngineRuntimes>,
+    engine_runtimes: Arc<EngineRuntimes>,
     log_runtime: Arc<RuntimeLevel>,
 ) where
     T: WalsOpener,
@@ -118,10 +118,12 @@ async fn run_server_with_runtimes<T>(
 
     // Config limiter
     let limiter = Limiter::new(config.limiter.clone());
+    let config_content = serde_json::to_string(&config).expect("Fail to serialize config");
 
     let builder = Builder::new(config.server.clone())
         .node_addr(config.node.addr.clone())
-        .engine_runtimes(runtimes.clone())
+        .config_content(config_content)
+        .engine_runtimes(engine_runtimes.clone())
         .log_runtime(log_runtime.clone())
         .query_executor(query_executor)
         .function_registry(function_registry)
@@ -134,20 +136,20 @@ async fn run_server_with_runtimes<T>(
                 &config,
                 &StaticRouteConfig::default(),
                 builder,
-                runtimes.clone(),
+                engine_runtimes.clone(),
                 engine_builder,
             )
             .await
         }
         Some(ClusterDeployment::NoMeta(v)) => {
-            build_without_meta(&config, v, builder, runtimes.clone(), engine_builder).await
+            build_without_meta(&config, v, builder, engine_runtimes.clone(), engine_builder).await
         }
         Some(ClusterDeployment::WithMeta(cluster_config)) => {
             build_with_meta(
                 &config,
                 cluster_config,
                 builder,
-                runtimes.clone(),
+                engine_runtimes.clone(),
                 engine_builder,
             )
             .await


### PR DESCRIPTION
## Which issue does this PR close?

Closes #693

## Rationale for this change
 Refer to #693
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Support debug api for reviewing the config when running;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Yes. Try the new api `/debug/config`, which will output the runtime config in json format.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Manually. Here is the output of the api:
```
[node]
addr = "127.0.0.1"
zone = ""
idc = ""
binary_version = ""

[server]
bind_addr = "0.0.0.0"
mysql_port = 3307
http_port = 5440
grpc_port = 8831
http_max_body_size = 65536
grpc_server_cq_count = 20
resp_compress_min_length = "4MiB"
auto_create_table = true

[server.forward]
enable = false
thread_num = 4
max_send_msg_len = 20971520
max_recv_msg_len = 1073741824
keep_alive_while_idle = true

[server.forward.keep_alive_interval]
secs = 600
nanos = 0

[server.forward.keep_alive_timeout]
secs = 3
nanos = 0

[server.forward.connect_timeout]
secs = 3
nanos = 0

[server.forward.forward_timeout]
secs = 60
nanos = 0

[runtime]
read_thread_num = 8
write_thread_num = 8
meta_thread_num = 2
background_thread_num = 8

[logger]
level = "info"
enable_async = true
async_channel_len = 102400

[tracing]
prefix = "tracing"
dir = "/tmp/ceresdb"
level = "info"

[analytic]
replay_batch_size = 500
max_replay_tables_per_batch = 64
write_group_worker_num = 8
write_group_command_channel_cap = 128
sst_meta_cache_cap = 1000
sst_data_cache_cap = 1000
space_write_buffer_size = 0
db_write_buffer_size = 0
scan_batch_size = 500
sst_background_read_parallelism = 8

[analytic.storage]
mem_cache_capacity = "512MiB"
mem_cache_partition_bits = 6
disk_cache_capacity = "0KiB"
disk_cache_page_size = "2MiB"
disk_cache_dir = "/tmp/ceresdb"

[analytic.storage.object_store]
type = "Local"
data_dir = "/tmp/ceresdb"

[analytic.table_opts]
update_mode = "Overwrite"
storage_format_hint = "Auto"
enable_ttl = true
ttl = "7d"
arena_block_size = 2097152
write_buffer_size = 33554432
compaction_strategy = "Default"
num_rows_per_row_group = 8192
compression = "Zstd"

[analytic.compaction_config]
schedule_channel_len = 16
schedule_interval = "30m"
max_ongoing_tasks = 8
max_unflushed_duration = "5h"
memory_limit = "4GiB"

[analytic.manifest]
snapshot_every_n_updates = 10000
scan_timeout = "5s"
scan_batch_size = 100
store_timeout = "5s"

[analytic.wal]
type = "RocksDB"
data_dir = "/tmp/ceresdb"

[analytic.remote_engine_client]
connect_timeout = "3s"
channel_pool_max_size_per_partition = 16
channel_pool_partition_num = 16
channel_keep_alive_while_idle = true
channel_keep_alive_timeout = "3s"
channel_keep_alive_interval = "10m"
route_cache_max_size_per_partition = 16
route_cache_partition_num = 16

[query_engine]
read_parallelism = 8

[limiter]
write_block_list = []
read_block_list = []
rules = []
```
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
