### PR TITLE
fix: start http server after table recovery finished

### DIFF
--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -103,7 +103,7 @@ pub enum Error {
         source: Box<dyn StdError + Send + Sync>,
     },
 
-    #[snafu(display("Server already started."))]
+    #[snafu(display("Server already started.\nBacktrace:\n{}", backtrace))]
     AlreadyStarted { backtrace: Backtrace },
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -136,12 +136,9 @@ impl<Q: QueryExecutor + 'static> Server<Q> {
         self.create_default_schema_if_not_exists().await;
 
         info!("Server start, start services");
-        self.http_service
-            .start()
-            .await
-            .with_context(|| HttpService {
-                msg: "start failed".to_string(),
-            })?;
+        self.http_service.start().await.context(HttpService {
+            msg: "start failed",
+        })?;
         self.mysql_service
             .start()
             .await
@@ -341,8 +338,8 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .schema_config_provider(provider.clone())
             .config_content(config_content)
             .build()
-            .with_context(|| HttpService {
-                msg: "build failed".to_string(),
+            .context(HttpService {
+                msg: "build failed",
             })?;
 
         let mysql_config = mysql::MysqlConfig {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #559

## Rationale for this change
 
If server start to serve request before table recovery finished, it may happen
panic in issue #559.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Update HTTP server start location, only start server after table recovery finished, same with gRPC/MySQL server.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

CI and manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

