### PR TITLE
feat: don't allow create table which failed when open

### DIFF
--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -12,7 +12,10 @@ use tokio::sync::oneshot;
 
 use crate::{
     instance::{
-        engine::{CreateTableData, InvalidOptions, OperateByWriteWorker, Result, WriteManifest},
+        engine::{
+            CreateOpenFailedTable, CreateTableData, InvalidOptions, OperateByWriteWorker, Result,
+            WriteManifest,
+        },
         write_worker::{self, CreateTableCommand, WorkerLocal},
         Instance,
     },
@@ -30,6 +33,13 @@ impl Instance {
         request: CreateTableRequest,
     ) -> Result<TableDataRef> {
         info!("Instance create table, request:{:?}", request);
+
+        if space.is_open_failed_table(&request.table_name) {
+            return CreateOpenFailedTable {
+                table: request.table_name,
+            }
+            .fail();
+        }
 
         let mut table_opts =
             table_options::merge_table_options_for_create(&request.options, &self.table_opts)

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -214,7 +214,7 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "{} open failed and can not be created again.\nBacktrace:\n{}",
+        "Table open failed and can not be created again, table:{}.\nBacktrace:\n{}",
         table,
         backtrace,
     ))]

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -212,6 +212,13 @@ pub enum Error {
         table: String,
         source: GenericError,
     },
+
+    #[snafu(display(
+        "{} open failed and can not be created again.\nBacktrace:\n{}",
+        table,
+        backtrace,
+    ))]
+    CreateOpenFailedTable { table: String, backtrace: Backtrace },
 }
 
 define_result!(Error);
@@ -241,6 +248,7 @@ impl From<Error> for table_engine::engine::Error {
             | Error::FlushTable { .. }
             | Error::StoreVersionEdit { .. }
             | Error::EncodePayloads { .. }
+            | Error::CreateOpenFailedTable { .. }
             | Error::DoManifestSnapshot { .. } => Self::Unexpected {
                 source: Box::new(err),
             },

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -189,19 +189,18 @@ impl Instance {
             ..Default::default()
         };
 
-        if let Err(e) = self
-            .recover_table_from_wal(
-                worker_local,
-                table_data.clone(),
-                replay_batch_size,
-                &read_ctx,
-            )
-            .await
-        {
-            error!("Recovery table failed, table_data:{table_data:?}");
+        self.recover_table_from_wal(
+            worker_local,
+            table_data.clone(),
+            replay_batch_size,
+            &read_ctx,
+        )
+        .await
+        .map_err(|e| {
+            error!("Recovery table from wal failed, table_data:{table_data:?}, err:{e}");
             space.insert_open_failed_table(table_data.name.to_string());
-            return Err(e);
-        }
+            e
+        })?;
 
         space.insert_table(table_data.clone());
         Ok(Some(table_data))

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -522,7 +522,7 @@ pub struct TableLocation {
 pub type TableDataRef = Arc<TableData>;
 
 /// Manages TableDataRef
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct TableDataSet {
     /// Name to table data
     table_datas: HashMap<String, TableDataRef>,
@@ -533,10 +533,7 @@ pub struct TableDataSet {
 impl TableDataSet {
     /// Create an empty TableDataSet
     pub fn new() -> Self {
-        Self {
-            table_datas: HashMap::new(),
-            id_to_tables: HashMap::new(),
-        }
+        Self::default()
     }
 
     /// Insert if absent, if successfully inserted, return true and return
@@ -593,12 +590,6 @@ impl TableDataSet {
         for table_data in self.table_datas.values().cloned() {
             tables.push(table_data);
         }
-    }
-}
-
-impl Default for TableDataSet {
-    fn default() -> Self {
-        Self::new()
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
Followup PR of #722

When table open failed when recovery, we should prevent user from creating table with same name, otherwise schema maybe wong, and seq will be reset to 0.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Add open failed table in Space, and check it when create new table.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

CI, but I don't test this corner case since I don't know how to mock recovery failure of one table.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

