### PR TITLE
feat: support split write request to batches for small wal logs

### DIFF
--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -172,6 +172,9 @@ pub struct Instance {
     pub(crate) replay_batch_size: usize,
     /// Write sst max buffer size
     pub(crate) write_sst_max_buffer_size: usize,
+    /// Max bytes per write request. And if it is exceeded, the request will be
+    /// splitted.
+    pub(crate) max_bytes_per_write_request: Option<usize>,
     /// Options for scanning sst
     pub(crate) iter_options: IterOptions,
     pub(crate) remote_engine: Option<RemoteEngineRef>,

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -172,9 +172,8 @@ pub struct Instance {
     pub(crate) replay_batch_size: usize,
     /// Write sst max buffer size
     pub(crate) write_sst_max_buffer_size: usize,
-    /// Max bytes per write request. And if it is exceeded, the request will be
-    /// splitted.
-    pub(crate) max_bytes_per_write_request: Option<usize>,
+    /// Max bytes per write batch
+    pub(crate) max_bytes_per_write_batch: Option<usize>,
     /// Options for scanning sst
     pub(crate) iter_options: IterOptions,
     pub(crate) remote_engine: Option<RemoteEngineRef>,

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -94,9 +94,9 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_bytes() as usize,
-            max_bytes_per_write_request: ctx
+            max_bytes_per_write_batch: ctx
                 .config
-                .max_bytes_per_write_request
+                .max_bytes_per_write_batch
                 .map(|v| v.as_bytes() as usize),
             iter_options,
             remote_engine: remote_engine_ref,

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -414,7 +414,7 @@ impl Instance {
                         worker_local,
                         table_data,
                         sequence,
-                        row_group,
+                        &row_group.into(),
                         index_in_writer,
                     )
                     .context(ApplyMemTable {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -94,6 +94,10 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_bytes() as usize,
+            max_bytes_per_write_request: ctx
+                .config
+                .max_bytes_per_write_request
+                .map(|v| v.as_bytes() as usize),
             iter_options,
             remote_engine: remote_engine_ref,
         });

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -288,7 +288,7 @@ impl Instance {
             encoded_rows,
         } = encode_ctx;
 
-        if self.max_bytes_per_write_request.is_none() {
+        if self.max_bytes_per_write_batch.is_none() {
             let row_group_slicer = RowGroupSlicer::from(&row_group);
             self.write_table_row_group(
                 worker_local,
@@ -302,7 +302,7 @@ impl Instance {
             return Ok(row_group.num_rows());
         }
 
-        let splitter = WriteRowGroupSplitter::new(self.max_bytes_per_write_request.unwrap());
+        let splitter = WriteRowGroupSplitter::new(self.max_bytes_per_write_batch.unwrap());
         match splitter.split(encoded_rows, &row_group) {
             SplitResult::Integrate {
                 encoded_rows,

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -78,6 +78,8 @@ pub struct Config {
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
     /// Max bytes per write batch.
+    ///
+    /// If this is set, the atomicity of write request will be broken.
     pub max_bytes_per_write_batch: Option<ReadableSize>,
 
     /// Wal storage config

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -77,6 +77,9 @@ pub struct Config {
     pub sst_background_read_parallelism: usize,
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
+    /// Max bytes per write request. If the encoding size of the request exceeds
+    /// the limit, the request will be splitted.
+    pub max_bytes_per_write_request: Option<ReadableSize>,
 
     /// Wal storage config
     ///
@@ -111,6 +114,7 @@ impl Default for Config {
             scan_batch_size: 500,
             sst_background_read_parallelism: 8,
             write_sst_max_buffer_size: ReadableSize::mb(10),
+            max_bytes_per_write_request: None,
             wal: WalStorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),
         }

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -77,9 +77,8 @@ pub struct Config {
     pub sst_background_read_parallelism: usize,
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
-    /// Max bytes per write request. If the encoding size of the request exceeds
-    /// the limit, the request will be splitted.
-    pub max_bytes_per_write_request: Option<ReadableSize>,
+    /// Max bytes per write batch.
+    pub max_bytes_per_write_batch: Option<ReadableSize>,
 
     /// Wal storage config
     ///
@@ -114,7 +113,7 @@ impl Default for Config {
             scan_batch_size: 500,
             sst_background_read_parallelism: 8,
             write_sst_max_buffer_size: ReadableSize::mb(10),
-            max_bytes_per_write_request: None,
+            max_bytes_per_write_batch: None,
             wal: WalStorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),
         }

--- a/common_types/src/row/mod.rs
+++ b/common_types/src/row/mod.rs
@@ -231,6 +231,11 @@ impl<'a> RowGroupSlicer<'a> {
     }
 
     #[inline]
+    pub fn slice_range(&self) -> Range<usize> {
+        self.range.clone()
+    }
+
+    #[inline]
     pub fn num_rows(&self) -> usize {
         self.range.len()
     }
@@ -390,7 +395,7 @@ pub struct RowGroupBuilder {
     schema: Schema,
     rows: Vec<Row>,
     min_timestamp: Option<Timestamp>,
-    max_timestmap: Timestamp,
+    max_timestamp: Timestamp,
 }
 
 impl RowGroupBuilder {
@@ -405,7 +410,7 @@ impl RowGroupBuilder {
             schema,
             rows: Vec::with_capacity(capacity),
             min_timestamp: None,
-            max_timestmap: Timestamp::new(0),
+            max_timestamp: Timestamp::new(0),
         }
     }
 
@@ -452,7 +457,7 @@ impl RowGroupBuilder {
             schema: self.schema,
             rows: self.rows,
             min_timestamp: self.min_timestamp.unwrap_or_else(|| Timestamp::new(0)),
-            max_timestamp: self.max_timestmap,
+            max_timestamp: self.max_timestamp,
         }
     }
 
@@ -465,7 +470,7 @@ impl RowGroupBuilder {
             Some(min_timestamp) => Some(cmp::min(min_timestamp, row_timestamp)),
             None => Some(row_timestamp),
         };
-        self.max_timestmap = cmp::max(self.max_timestmap, row_timestamp);
+        self.max_timestamp = cmp::max(self.max_timestamp, row_timestamp);
     }
 }
 

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -322,7 +322,7 @@ impl ToString for ArrowSchemaMetaKey {
 pub type Version = u32;
 
 /// Mapping column index in table schema to column index in writer schema
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct IndexInWriterSchema(Vec<Option<usize>>);
 
 impl IndexInWriterSchema {


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, one large write request may lead to one large WAL log, which is not friendly for some wal implementations.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Support split write table request to multiple batches.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
New unit tests and existing integraion tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
