### PR TITLE
fix: move table engine proxy to table_engine crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,6 @@ dependencies = [
  "common_util",
  "log",
  "meta_client",
- "server",
  "snafu 0.6.10",
  "system_catalog",
  "table_engine",

--- a/catalog_impls/Cargo.toml
+++ b/catalog_impls/Cargo.toml
@@ -25,4 +25,3 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 analytic_engine = { workspace = true, features = ["test"] }
-server = { workspace = true }

--- a/catalog_impls/src/table_based.rs
+++ b/catalog_impls/src/table_based.rs
@@ -912,9 +912,10 @@ mod tests {
         schema::{CreateOptions, CreateTableRequest, DropOptions, DropTableRequest, SchemaRef},
     };
     use common_types::table::{DEFAULT_CLUSTER_VERSION, DEFAULT_SHARD_ID};
-    use server::table_engine::{MemoryTableEngine, TableEngineProxy};
     use table_engine::{
         engine::{TableEngineRef, TableState},
+        memory::MemoryTableEngine,
+        proxy::TableEngineProxy,
         ANALYTIC_ENGINE_TYPE,
     };
 

--- a/interpreters/Cargo.toml
+++ b/interpreters/Cargo.toml
@@ -29,6 +29,7 @@ regex = "1"
 snafu = { workspace = true }
 sql = { workspace = true }
 table_engine = { workspace = true }
+
 [dev-dependencies]
 analytic_engine = { workspace = true, features = ["test"] }
 catalog_impls = { workspace = true }

--- a/server/src/handlers/influxdb.rs
+++ b/server/src/handlers/influxdb.rs
@@ -226,8 +226,6 @@ fn convert_influx_value(field_value: FieldValue) -> Value {
     Value { value: Some(v) }
 }
 
-// fn convert_query_result(output: Output)
-
 // TODO: Request and response type don't match influxdb's API now.
 pub async fn query<Q: QueryExecutor + 'static>(
     ctx: RequestContext,

--- a/server/src/handlers/influxdb.rs
+++ b/server/src/handlers/influxdb.rs
@@ -226,6 +226,8 @@ fn convert_influx_value(field_value: FieldValue) -> Value {
     Value { value: Some(v) }
 }
 
+// fn convert_query_result(output: Output)
+
 // TODO: Request and response type don't match influxdb's API now.
 pub async fn query<Q: QueryExecutor + 'static>(
     ctx: RequestContext,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -22,4 +22,3 @@ mod metrics;
 mod mysql;
 pub mod schema_config_provider;
 pub mod server;
-pub mod table_engine;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -30,9 +30,8 @@ use server::{
         cluster_based::ClusterBasedProvider, config_based::ConfigBasedProvider,
     },
     server::Builder,
-    table_engine::{MemoryTableEngine, TableEngineProxy},
 };
-use table_engine::engine::EngineRuntimes;
+use table_engine::{engine::EngineRuntimes, memory::MemoryTableEngine, proxy::TableEngineProxy};
 use tracing_util::{
     self,
     tracing_appender::{non_blocking::WorkerGuard, rolling::Rotation},

--- a/table_engine/src/lib.rs
+++ b/table_engine/src/lib.rs
@@ -10,6 +10,7 @@ pub mod memory;
 pub mod partition;
 pub mod predicate;
 pub mod provider;
+pub mod proxy;
 pub mod remote;
 pub mod stream;
 pub mod table;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Now, rust-analyzer will report cyclic dependecy like:
```
[ERROR project_model::workspace] cyclic deps: server(CrateId(478)) -> interpreters(CrateId(256)), alternative path: interpreters(CrateId(256)) -> catalog_impls(CrateId(97)) -> server(CrateId(478))
``` 
We should fix it.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Move table engine proxy to table_engine crate.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Rust-analyzer will not compare cyclic dependency now.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
