### PR TITLE
chore: fix insert-license pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: check-yaml
       - id: check-toml
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.3.1
+    rev: v1.4.2
     hooks:
       - id: insert-license
         files: \.rs$
@@ -14,6 +14,7 @@ repos:
           - scripts/license-header.txt
           - --comment-style
           - //
+          - --use-current-year
   - repo: local
     hooks:
       - id: cargo-sort
@@ -24,4 +25,3 @@ repos:
         types: [file, toml]
         files: Cargo\.toml
         pass_filenames: false
-

--- a/scripts/check-license.sh
+++ b/scripts/check-license.sh
@@ -4,7 +4,7 @@ set -eu
 
 for i in $(git ls-files --exclude-standard | grep "\.rs"); do
     # first line -> match -> print line -> quit
-    matches=$(sed -n "1{/Copyright [0-9]\{4\} CeresDB Project Authors. Licensed under Apache-2.0./p;};q;" $i)
+    matches=$(sed -n "1{/CeresDB Project Authors. Licensed under Apache-2.0./p;};q;" $i)
     if [ -z "${matches}" ]; then
         echo "License header is missing from $i."
         exit 1

--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,1 +1,1 @@
-Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

Update license insert, add `use-current-year`
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

- When edit old file, pre-commit will update license header to `2022-{current-year}`
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

Manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
This is what other project does:
- https://github.com/facebook/rocksdb/blob/main/table/format.cc
- https://github.com/tikv/tikv/blob/master/src/coprocessor_v2/raw_storage_impl.rs

It seems year format is not very strict, and we can define format used in CeresDB.

