### PR TITLE
chore: use influxdb line protocol in crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,11 +2884,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "influxdb_line_protocol"
-version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_line_protocol#14e00a3dbc99a5edff226b92e3496314b086acf4"
+name = "influxdb-line-protocol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1192416847e724d001c1f410cf348f27978a50b30f3473afbf73062cada2697a"
 dependencies = [
  "bytes 1.4.0",
+ "log",
  "nom 7.1.1",
  "smallvec",
  "snafu 0.7.1",
@@ -5581,7 +5583,7 @@ dependencies = [
  "df_operator",
  "futures 0.3.25",
  "http",
- "influxdb_line_protocol",
+ "influxdb-line-protocol",
  "interpreters",
  "lazy_static",
  "log",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,7 +26,7 @@ datafusion-expr = { workspace = true }
 df_operator = { workspace = true }
 futures = { workspace = true }
 http = "0.2"
-influxdb_line_protocol = { git = "https://github.com/jiacai2050/influxdb_line_protocol" }
+influxdb-line-protocol = "1.0"
 interpreters = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
Influxdb line protocol is published at crates.io, no need to use forked version.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

CI.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

