### PR TITLE
feat: convert the influxql result using influxdb format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,6 +3083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_pretty"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9fe3f290d2cb8660e3e051352ea55a404788d213a106a33ec8802447c4a762"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5583,6 +5589,7 @@ dependencies = [
  "http",
  "influxdb_line_protocol",
  "interpreters",
+ "json_pretty",
  "lazy_static",
  "log",
  "logger",

--- a/integration_tests/cases/env/local/influxql/basic.result
+++ b/integration_tests/cases/env/local/influxql/basic.result
@@ -27,12 +27,12 @@ affected_rows: 6
 -- SQLNESS ARG protocol=influxql
 SELECT * FROM "h2o_feet";
 
-{"rows":[{"ceresdb::measurement":"h2o_feet","time":1439827200000,"level_description":"below 3 feet","location":"santa_monica","water_level":2.064},{"ceresdb::measurement":"h2o_feet","time":1439827200000,"level_description":"between 6 and 9 feet","location":"coyote_creek","water_level":8.12},{"ceresdb::measurement":"h2o_feet","time":1439827560000,"level_description":"below 3 feet","location":"santa_monica","water_level":2.116},{"ceresdb::measurement":"h2o_feet","time":1439827560000,"level_description":"between 6 and 9 feet","location":"coyote_creek","water_level":8.005},{"ceresdb::measurement":"h2o_feet","time":1439827620000,"level_description":"below 3 feet","location":"santa_monica","water_level":2.028},{"ceresdb::measurement":"h2o_feet","time":1439827620000,"level_description":"between 6 and 9 feet","location":"coyote_creek","water_level":7.887}]}
+{"results":[{"statement_id":0,"series":[{"name":"h2o_feet","columns":["time","level_description","location","water_level"],"values":[[1439827200000,"below 3 feet","santa_monica",2.064],[1439827200000,"between 6 and 9 feet","coyote_creek",8.12],[1439827560000,"below 3 feet","santa_monica",2.116],[1439827560000,"between 6 and 9 feet","coyote_creek",8.005],[1439827620000,"below 3 feet","santa_monica",2.028],[1439827620000,"between 6 and 9 feet","coyote_creek",7.887]]}]}]}
 
 -- SQLNESS ARG protocol=influxql
 SELECT "level_description", location, water_level FROM "h2o_feet" where location = 'santa_monica';
 
-{"rows":[{"ceresdb::measurement":"h2o_feet","time":1439827200000,"level_description":"below 3 feet","location":"santa_monica","water_level":2.064},{"ceresdb::measurement":"h2o_feet","time":1439827560000,"level_description":"below 3 feet","location":"santa_monica","water_level":2.116},{"ceresdb::measurement":"h2o_feet","time":1439827620000,"level_description":"below 3 feet","location":"santa_monica","water_level":2.028}]}
+{"results":[{"statement_id":0,"series":[{"name":"h2o_feet","columns":["time","level_description","location","water_level"],"values":[[1439827200000,"below 3 feet","santa_monica",2.064],[1439827560000,"below 3 feet","santa_monica",2.116],[1439827620000,"below 3 feet","santa_monica",2.028]]}]}]}
 
 DROP TABLE IF EXISTS `h2o_feet`;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -55,4 +55,5 @@ warp = "0.3"
 zstd = { workspace = true }
 
 [dev-dependencies]
+json_pretty = "0.1.2"
 sql = { workspace = true, features = ["test"] }

--- a/server/src/handlers/error.rs
+++ b/server/src/handlers/error.rs
@@ -74,10 +74,10 @@ pub enum Error {
     },
 
     #[snafu(display("InfluxDb handler failed, msg:{}, source:{}", msg, source))]
-    InfluxDbHandler { msg: String, source: GenericError },
+    InfluxDbHandlerWithCause { msg: String, source: GenericError },
 
     #[snafu(display("InfluxDb handler failed, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
-    InfluxDbHandlerInternal { msg: String, backtrace: Backtrace },
+    InfluxDbHandlerNoCause { msg: String, backtrace: Backtrace },
 }
 
 define_result!(Error);

--- a/server/src/handlers/error.rs
+++ b/server/src/handlers/error.rs
@@ -75,6 +75,9 @@ pub enum Error {
 
     #[snafu(display("InfluxDb handler failed, msg:{}, source:{}", msg, source))]
     InfluxDbHandler { msg: String, source: GenericError },
+
+    #[snafu(display("InfluxDb handler failed, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
+    InfluxDbHandlerInternal { msg: String, backtrace: Backtrace },
 }
 
 define_result!(Error);

--- a/server/src/handlers/influxdb.rs
+++ b/server/src/handlers/influxdb.rs
@@ -10,21 +10,35 @@ use bytes::Bytes;
 use ceresdbproto::storage::{
     value, Field, FieldGroup, Tag, Value, WriteSeriesEntry, WriteTableRequest,
 };
-use common_types::{request_id::RequestId, time::Timestamp};
+use common_types::{
+    column_schema::{self, ColumnSchema},
+    datum::{Datum, DatumKind},
+    record_batch::RecordBatch,
+    request_id::RequestId,
+    schema::RecordSchema,
+    time::Timestamp,
+};
 use common_util::error::BoxError;
 use handlers::{
     error::{InfluxDbHandler, Result},
     query::QueryRequest,
 };
 use influxdb_line_protocol::FieldValue;
+use interpreters::interpreter::Output;
 use log::debug;
 use query_engine::executor::Executor as QueryExecutor;
-use snafu::ResultExt;
+use serde::{
+    ser::{SerializeMap, SerializeSeq},
+    Serialize,
+};
+use snafu::{ensure, OptionExt, ResultExt};
+use sql::influxql::planner::CERESDB_MEASUREMENT_COLUMN_NAME;
 use warp::{reject, reply, Rejection, Reply};
 
 use crate::{
     context::RequestContext,
     handlers,
+    handlers::error::InfluxDbHandlerInternal,
     instance::InstanceRef,
     proxy::grpc::write::{execute_insert_plan, write_request_to_insert_plan, WriteContext},
     schema_config_provider::SchemaConfigProviderRef,
@@ -70,6 +84,289 @@ impl From<Bytes> for WriteRequest {
 }
 
 pub type WriteResponse = ();
+
+/// One result in group(defined by group by clause)
+///
+/// Influxdb names the result set series, so name each result in the set
+/// `OneSeries` here. Its format is like:
+/// {
+// 	"results": [{
+/// 		"statement_id": 0,
+/// 		"series": [{
+/// 			"name": "home",
+/// 			"tags": {
+/// 				"room":  "Living Room"
+/// 			},
+/// 			"columns": ["time", "co", "hum", "temp"],
+/// 			"values": [["2022-01-01T08:00:00Z", 0, 35.9, 21.1], ... ]
+/// 		}, ... ]
+/// 	}, ... ]
+/// }
+#[derive(Debug, Serialize)]
+pub struct InfluxqlResponse {
+    results: Vec<InfluxqlResult>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InfluxqlResult {
+    statement_id: u32,
+    series: Vec<OneSeries>,
+}
+
+#[derive(Debug)]
+pub struct OneSeries {
+    name: String,
+    tags: Option<Tags>,
+    columns: Vec<String>,
+    values: Vec<Vec<Datum>>,
+}
+
+impl Serialize for OneSeries {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut one_series = serializer.serialize_map(Some(4))?;
+        one_series.serialize_entry("name", &self.name)?;
+        if let Some(tags) = &self.tags {
+            one_series.serialize_entry("tags", &tags)?;
+        }
+        one_series.serialize_entry("columns", &self.columns)?;
+        one_series.serialize_entry("values", &self.values)?;
+
+        one_series.end()
+    }
+}
+
+#[derive(Debug)]
+struct Tags(Vec<(String, String)>);
+
+impl Serialize for Tags {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut tags = serializer.serialize_map(Some(self.0.len()))?;
+
+        for (tagk, tagv) in &self.0 {
+            tags.serialize_entry(tagk, tagv)?;
+        }
+
+        tags.end()
+    }
+}
+
+/// Influxql response builder
+// #[derive(Serialize)]
+// #[serde(rename_all = "snake_case")]
+#[derive(Default)]
+pub struct InfluxqlResultBuilder {
+    statement_id: u32,
+
+    /// Schema of influxql query result
+    ///
+    /// Its format is like: measurement | tag_1..tag_n(defined by group by
+    /// clause) | time | value_column_1..value_column_n
+    column_schemas: Vec<ColumnSchema>,
+
+    /// Tags part in schema
+    group_by_tag_col_idxs: Vec<usize>,
+
+    /// Value columns part in schema(include `time`)
+    value_col_idxs: Vec<usize>,
+
+    /// Mapping series key(measurement + tag values) to column data
+    group_key_to_idx: HashMap<GroupKey, usize>,
+
+    /// Column datas
+    value_groups: Vec<Vec<Vec<Datum>>>,
+}
+
+impl InfluxqlResultBuilder {
+    fn new(record_schema: &RecordSchema, statement_id: u32) -> Result<Self> {
+        let column_schemas = record_schema.columns().to_owned();
+
+        // Find the tags part and columns part from schema.
+        let mut group_by_col_idxs = Vec::new();
+        let mut value_col_idxs = Vec::new();
+
+        let mut col_iter = column_schemas.iter().enumerate();
+        // The first column may be measurement column in normal.
+        ensure!(col_iter.next().unwrap().1.name == CERESDB_MEASUREMENT_COLUMN_NAME, InfluxDbHandlerInternal {
+            msg: format!("invalid schema whose first column is not measurement column, schema:{column_schemas:?}"),
+        });
+
+        // The group by tags will be placed after measurement and before time column.
+        let mut searching_group_by_tags = true;
+        while let Some((idx, col)) = col_iter.next() {
+            if col.data_type.is_timestamp() {
+                searching_group_by_tags = false;
+            }
+
+            if searching_group_by_tags {
+                group_by_col_idxs.push(idx);
+            } else {
+                value_col_idxs.push(idx);
+            }
+        }
+
+        Ok(Self {
+            statement_id,
+            column_schemas,
+            group_by_tag_col_idxs: group_by_col_idxs,
+            value_col_idxs,
+            group_key_to_idx: HashMap::new(),
+            value_groups: Vec::new(),
+        })
+    }
+
+    fn add_record_batch(mut self, record_batch: RecordBatch) -> Result<Self> {
+        // Check schema's compatibility.
+        ensure!(
+            record_batch.schema().columns() == &self.column_schemas,
+            InfluxDbHandlerInternal {
+                msg: format!(
+                    "conflict schema, origin:{:?}, new:{:?}",
+                    self.column_schemas,
+                    record_batch.schema().columns()
+                ),
+            }
+        );
+
+        let row_num = record_batch.num_rows();
+        for row_idx in 0..row_num {
+            // Get measurement + group by tags.
+            let group_key = self.extract_group_key(&record_batch, row_idx)?;
+            let value_group = self.extract_value_group(&record_batch, row_idx)?;
+
+            let value_groups = if let Some(idx) = self.group_key_to_idx.get(&group_key) {
+                self.value_groups.get_mut(*idx).unwrap()
+            } else {
+                self.value_groups.push(Vec::new());
+                self.group_key_to_idx
+                    .insert(group_key, self.value_groups.len() - 1);
+                self.value_groups.last_mut().unwrap()
+            };
+
+            value_groups.push(value_group);
+        }
+
+        Ok(self)
+    }
+
+    fn build(self) -> InfluxqlResult {
+        let ordered_group_keys = {
+            let mut ordered_pairs = self
+                .group_key_to_idx
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>();
+            ordered_pairs.sort_by(|a, b| a.1.cmp(&b.1));
+            ordered_pairs
+                .into_iter()
+                .map(|(key, _)| key)
+                .collect::<Vec<_>>()
+        };
+
+        let series = ordered_group_keys
+            .into_iter()
+            .zip(self.value_groups.into_iter())
+            .map(|(group_key, value_group)| {
+                let name = group_key.measurement;
+                let tags = group_key
+                    .group_by_tag_values
+                    .into_iter()
+                    .enumerate()
+                    .map(|(tagk_idx, tagv)| {
+                        let tagk_col_idx = self.group_by_tag_col_idxs[tagk_idx];
+                        let tagk = self.column_schemas[tagk_col_idx].name.clone();
+
+                        (tagk, tagv)
+                    })
+                    .collect::<Vec<_>>();
+
+                let columns = self
+                    .value_col_idxs
+                    .iter()
+                    .map(|idx| self.column_schemas[*idx].name.clone())
+                    .collect::<Vec<_>>();
+
+                OneSeries {
+                    name,
+                    tags: Some(Tags(tags)),
+                    columns,
+                    values: value_group,
+                }
+            })
+            .collect();
+
+        InfluxqlResult {
+            series,
+            statement_id: self.statement_id,
+        }
+    }
+
+    fn extract_group_key(&self, record_batch: &RecordBatch, row_idx: usize) -> Result<GroupKey> {
+        let mut group_by_tag_values = Vec::with_capacity(self.group_by_tag_col_idxs.len());
+        let measurement = {
+            let measurement = record_batch.column(0).datum(row_idx);
+            if let Datum::String(m) = measurement {
+                m.to_string()
+            } else {
+                return InfluxDbHandlerInternal { msg: "" }.fail();
+            }
+        };
+
+        for col_idx in &self.group_by_tag_col_idxs {
+            let tag = {
+                let tag_datum = record_batch.column(*col_idx).datum(row_idx);
+                match tag_datum {
+                    Datum::Null => "".to_string(),
+                    Datum::String(tag) => tag.to_string(),
+                    _ => return InfluxDbHandlerInternal { msg: "" }.fail(),
+                }
+            };
+            group_by_tag_values.push(tag);
+        }
+
+        Ok(GroupKey {
+            measurement,
+            group_by_tag_values,
+        })
+    }
+
+    fn extract_value_group(
+        &self,
+        record_batch: &RecordBatch,
+        row_idx: usize,
+    ) -> Result<Vec<Datum>> {
+        let mut value_group = Vec::with_capacity(self.value_col_idxs.len());
+        for col_idx in &self.value_col_idxs {
+            let value = record_batch.column(*col_idx).datum(row_idx);
+
+            value_group.push(value);
+        }
+
+        Ok(value_group)
+    }
+}
+
+#[derive(Hash, PartialEq, Eq, Clone)]
+struct GroupKey {
+    measurement: String,
+    group_by_tag_values: Vec<String>,
+}
+
+#[derive(Hash, PartialEq, Eq)]
+struct TagKv {
+    key: String,
+    value: String,
+}
+
+struct Columns {
+    names: Vec<String>,
+    data: Vec<Datum>,
+}
 
 impl<Q: QueryExecutor + 'static> InfluxDb<Q> {
     pub fn new(instance: InstanceRef<Q>, schema_config_provider: SchemaConfigProviderRef) -> Self {
@@ -229,6 +526,10 @@ fn convert_influx_value(field_value: FieldValue) -> Value {
     Value { value: Some(v) }
 }
 
+// fn convert_query_result(output: Output) -> {
+
+// }
+
 // TODO: Request and response type don't match influxdb's API now.
 pub async fn query<Q: QueryExecutor + 'static>(
     ctx: RequestContext,
@@ -255,16 +556,18 @@ pub async fn write<Q: QueryExecutor + 'static>(
 
 #[cfg(test)]
 mod tests {
+    use common_types::tests::build_schema;
+
     use super::*;
 
     #[test]
     fn test_convert_influxdb_write_req() {
         let lines = r#"
-demo,tag1=t1,tag2=t2 field1=90,field2=100 1678675992000
-demo,tag1=t1,tag2=t2 field1=91,field2=101 1678675993000
-demo,tag1=t11,tag2=t22 field1=900,field2=1000 1678675992000
-demo,tag1=t11,tag2=t22 field1=901,field2=1001 1678675993000
-"#
+            demo,tag1=t1,tag2=t2 field1=90,field2=100 1678675992000
+            demo,tag1=t1,tag2=t2 field1=91,field2=101 1678675993000
+            demo,tag1=t11,tag2=t22 field1=900,field2=1000 1678675992000
+            demo,tag1=t11,tag2=t22 field1=901,field2=1001 1678675993000
+            "#
         .to_string();
         let req = WriteRequest {
             lines,
@@ -365,5 +668,22 @@ demo,tag1=t11,tag2=t22 field1=901,field2=1001 1678675993000
                 ]
             }
         );
+    }
+
+    #[test]
+    fn test_print() {
+
+
+        let one_series = OneSeries {
+            name: "test".to_string(),
+            tags: None,
+            columns: vec!["column1".to_string(), "column2".to_string()],
+            values: vec![
+                vec![Datum::Int32(1), Datum::Int32(2)],
+                vec![Datum::Int32(2), Datum::Int32(2)],
+            ],
+        };
+
+        println!("{}", serde_json::to_string(&one_series).unwrap());
     }
 }

--- a/server/src/handlers/query.rs
+++ b/server/src/handlers/query.rs
@@ -113,7 +113,7 @@ pub enum QueryRequest {
     Influxql(Request),
 }
 impl QueryRequest {
-    fn query(&self) -> &str {
+    pub fn query(&self) -> &str {
         match self {
             QueryRequest::Sql(request) => request.query.as_str(),
             QueryRequest::Influxql(request) => request.query.as_str(),

--- a/sql/src/influxql/planner.rs
+++ b/sql/src/influxql/planner.rs
@@ -19,7 +19,7 @@ use crate::{
     provider::{ContextProviderAdapter, MetaProvider},
 };
 
-const CERESDB_MEASUREMENT_COLUMN_NAME: &str = "ceresdb::measurement";
+pub const CERESDB_MEASUREMENT_COLUMN_NAME: &str = "ceresdb::measurement";
 
 pub(crate) struct Planner<'a, P: MetaProvider> {
     context_provider: ContextProviderAdapter<'a, P>,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Now, we return the influxql result using our inner format rather than influxdb format, we should modify it to the latter.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Convert the influxql result to influxdb format.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Get the influxdb compatible result when using influxql to query data. 
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
