### PR TITLE
feat: configurable record batches in flight

### DIFF
--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -476,6 +476,7 @@ impl ScheduleWorker {
             compression: table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
         };
+        let scan_options = self.scan_options.clone();
 
         // Do actual costly compact job in background.
         self.runtime.spawn(async move {
@@ -484,12 +485,12 @@ impl ScheduleWorker {
 
             let res = space_store
                 .compact_table(
-                    runtime,
-                    &table_data,
                     request_id,
+                    &table_data,
                     &compaction_task,
-                    &self.scan_options,
+                    scan_options,
                     &sst_write_options,
+                    runtime,
                 )
                 .await;
 

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -40,7 +40,7 @@ use crate::{
     instance::{
         flush_compaction::TableFlushOptions, write_worker::CompactionNotifier, Instance, SpaceStore,
     },
-    sst::factory::SstWriteOptions,
+    sst::factory::{ScanOptions, SstWriteOptions},
     table::data::TableDataRef,
     TableOptions,
 };
@@ -289,6 +289,7 @@ impl SchedulerImpl {
         runtime: Arc<Runtime>,
         config: SchedulerConfig,
         write_sst_max_buffer_size: usize,
+        scan_options: ScanOptions,
     ) -> Self {
         let (tx, rx) = mpsc::channel(config.schedule_channel_len);
         let running = Arc::new(AtomicBool::new(true));
@@ -303,6 +304,7 @@ impl SchedulerImpl {
             max_ongoing_tasks: config.max_ongoing_tasks,
             max_unflushed_duration: config.max_unflushed_duration.0,
             write_sst_max_buffer_size,
+            scan_options,
             limit: Arc::new(OngoingTaskLimit {
                 ongoing_tasks: AtomicUsize::new(0),
                 request_buf: RwLock::new(RequestQueue::default()),
@@ -371,6 +373,7 @@ struct ScheduleWorker {
     picker_manager: PickerManager,
     max_ongoing_tasks: usize,
     write_sst_max_buffer_size: usize,
+    scan_options: ScanOptions,
     limit: Arc<OngoingTaskLimit>,
     running: Arc<AtomicBool>,
     memory_limit: MemoryLimit,
@@ -485,6 +488,7 @@ impl ScheduleWorker {
                     &table_data,
                     request_id,
                     &compaction_task,
+                    &self.scan_options,
                     &sst_write_options,
                 )
                 .await;

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -730,6 +730,7 @@ impl SpaceStore {
         table_data: &TableData,
         request_id: RequestId,
         task: &CompactionTask,
+        scan_options: &ScanOptions,
         sst_write_options: &SstWriteOptions,
     ) -> Result<()> {
         debug!(
@@ -768,6 +769,7 @@ impl SpaceStore {
                 table_data,
                 request_id,
                 input,
+                scan_options,
                 sst_write_options,
                 &mut edit_meta,
             )
@@ -799,6 +801,7 @@ impl SpaceStore {
         table_data: &TableData,
         request_id: RequestId,
         input: &CompactionInputFiles,
+        scan_options: &ScanOptions,
         sst_write_options: &SstWriteOptions,
         edit_meta: &mut VersionEditMeta,
     ) -> Result<()> {
@@ -838,8 +841,6 @@ impl SpaceStore {
         let schema = table_data.schema();
         let table_options = table_data.table_options();
         let projected_schema = ProjectedSchema::no_projection(schema.clone());
-        // TODO: make the scan_options configurable for compaction.
-        let scan_options = ScanOptions::default();
         let sst_read_options = SstReadOptions {
             reverse: false,
             num_rows_per_row_group: table_options.num_rows_per_row_group,
@@ -847,7 +848,7 @@ impl SpaceStore {
             projected_schema: projected_schema.clone(),
             predicate: Arc::new(Predicate::empty()),
             meta_cache: self.meta_cache.clone(),
-            scan_options,
+            scan_options: scan_options.clone(),
             runtime: runtime.clone(),
         };
         let iter_options = IterOptions {

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -726,12 +726,12 @@ impl Instance {
 impl SpaceStore {
     pub(crate) async fn compact_table(
         &self,
-        runtime: Arc<Runtime>,
-        table_data: &TableData,
         request_id: RequestId,
+        table_data: &TableData,
         task: &CompactionTask,
-        scan_options: &ScanOptions,
+        scan_options: ScanOptions,
         sst_write_options: &SstWriteOptions,
+        runtime: Arc<Runtime>,
     ) -> Result<()> {
         debug!(
             "Begin compact table, table_name:{}, id:{}, task:{:?}",
@@ -765,12 +765,12 @@ impl SpaceStore {
 
         for input in &task.compaction_inputs {
             self.compact_input_files(
-                runtime.clone(),
-                table_data,
                 request_id,
+                table_data,
                 input,
-                scan_options,
+                scan_options.clone(),
                 sst_write_options,
+                runtime.clone(),
                 &mut edit_meta,
             )
             .await?;
@@ -795,14 +795,15 @@ impl SpaceStore {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn compact_input_files(
         &self,
-        runtime: Arc<Runtime>,
-        table_data: &TableData,
         request_id: RequestId,
+        table_data: &TableData,
         input: &CompactionInputFiles,
-        scan_options: &ScanOptions,
+        scan_options: ScanOptions,
         sst_write_options: &SstWriteOptions,
+        runtime: Arc<Runtime>,
         edit_meta: &mut VersionEditMeta,
     ) -> Result<()> {
         debug!(
@@ -848,7 +849,7 @@ impl SpaceStore {
             projected_schema: projected_schema.clone(),
             predicate: Arc::new(Predicate::empty()),
             meta_cache: self.meta_cache.clone(),
-            scan_options: scan_options.clone(),
+            scan_options,
             runtime: runtime.clone(),
         };
         let iter_options = IterOptions {

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -33,10 +33,9 @@ use wal::manager::{WalLocation, WalManagerRef};
 use crate::{
     compaction::scheduler::CompactionSchedulerRef,
     manifest::ManifestRef,
-    row_iter::IterOptions,
     space::{SpaceId, SpaceRef},
     sst::{
-        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef},
+        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, ScanOptions},
         file::FilePurger,
         meta_data::cache::MetaCacheRef,
     },
@@ -173,7 +172,7 @@ pub struct Instance {
     /// Write sst max buffer size
     pub(crate) write_sst_max_buffer_size: usize,
     /// Options for scanning sst
-    pub(crate) iter_options: IterOptions,
+    pub(crate) scan_options: ScanOptions,
     pub(crate) remote_engine: Option<RemoteEngineRef>,
 }
 

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -33,6 +33,7 @@ use wal::manager::{WalLocation, WalManagerRef};
 use crate::{
     compaction::scheduler::CompactionSchedulerRef,
     manifest::ManifestRef,
+    row_iter::IterOptions,
     space::{SpaceId, SpaceRef},
     sst::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, ScanOptions},
@@ -173,6 +174,7 @@ pub struct Instance {
     pub(crate) write_sst_max_buffer_size: usize,
     /// Options for scanning sst
     pub(crate) scan_options: ScanOptions,
+    pub(crate) iter_options: Option<IterOptions>,
     pub(crate) remote_engine: Option<RemoteEngineRef>,
 }
 

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     manifest::{meta_data::TableManifestData, LoadRequest, ManifestRef},
     payload::{ReadPayload, WalDecoder},
+    row_iter::IterOptions,
     space::{Space, SpaceContext, SpaceId, SpaceRef},
     sst::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, ScanOptions},
@@ -78,6 +79,10 @@ impl Instance {
             max_record_batches_in_flight: ctx.config.scan_max_record_batches_in_flight,
         };
 
+        let iter_options = ctx
+            .config
+            .scan_batch_size
+            .map(|batch_size| IterOptions { batch_size });
         let instance = Arc::new(Instance {
             space_store,
             runtimes: ctx.runtimes.clone(),
@@ -93,6 +98,7 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_bytes() as usize,
+            iter_options,
             scan_options,
             remote_engine: remote_engine_ref,
         });

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -35,10 +35,9 @@ use crate::{
     },
     manifest::{meta_data::TableManifestData, LoadRequest, ManifestRef},
     payload::{ReadPayload, WalDecoder},
-    row_iter::IterOptions,
     space::{Space, SpaceContext, SpaceId, SpaceRef},
     sst::{
-        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef},
+        factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, ScanOptions},
         file::FilePurger,
     },
     table::data::{TableData, TableDataRef},
@@ -74,9 +73,9 @@ impl Instance {
 
         let file_purger = FilePurger::start(&bg_runtime, store_picker.default_store().clone());
 
-        let iter_options = IterOptions {
-            batch_size: ctx.config.scan_batch_size,
-            sst_background_read_parallelism: ctx.config.sst_background_read_parallelism,
+        let scan_options = ScanOptions {
+            background_read_parallelism: ctx.config.sst_background_read_parallelism,
+            max_record_batches_in_flight: ctx.config.scan_max_record_batches_in_flight,
         };
 
         let instance = Arc::new(Instance {
@@ -94,7 +93,7 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_bytes() as usize,
-            iter_options,
+            scan_options,
             remote_engine: remote_engine_ref,
         });
 

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -94,8 +94,6 @@ impl Instance {
         );
 
         let table_data = space_table.table_data();
-
-        let iter_options = self.iter_options.clone();
         let table_options = table_data.table_options();
 
         // Collect metrics.
@@ -108,12 +106,12 @@ impl Instance {
 
         if need_merge_sort {
             let merge_iters = self
-                .build_merge_iters(table_data, &request, iter_options, &table_options)
+                .build_merge_iters(table_data, &request, &table_options)
                 .await?;
             self.build_partitioned_streams(&request, merge_iters)
         } else {
             let chain_iters = self
-                .build_chain_iters(table_data, &request, iter_options, &table_options)
+                .build_chain_iters(table_data, &request, &table_options)
                 .await?;
             self.build_partitioned_streams(&request, chain_iters)
         }
@@ -155,27 +153,28 @@ impl Instance {
         &self,
         table_data: &TableData,
         request: &ReadRequest,
-        iter_options: IterOptions,
         table_options: &TableOptions,
     ) -> Result<Vec<DedupIterator<MergeIterator>>> {
         // Current visible sequence
         let sequence = table_data.last_sequence();
         let projected_schema = request.projected_schema.clone();
         let sst_read_options = SstReadOptions {
-            read_batch_row_num: table_options.num_rows_per_row_group,
             reverse: request.order.is_in_desc_order(),
             frequency: ReadFrequency::Frequent,
             projected_schema: projected_schema.clone(),
             predicate: request.predicate.clone(),
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
-            background_read_parallelism: iter_options.sst_background_read_parallelism,
             num_rows_per_row_group: table_options.num_rows_per_row_group,
+            scan_options: self.scan_options.clone(),
         };
 
         let time_range = request.predicate.time_range();
         let version = table_data.current_version();
         let read_views = self.partition_ssts_and_memtables(time_range, version, table_options);
+        let iter_options = IterOptions {
+            batch_size: table_options.num_rows_per_row_group,
+        };
 
         let mut iters = Vec::with_capacity(read_views.len());
         for (idx, read_view) in read_views.into_iter().enumerate() {
@@ -226,7 +225,6 @@ impl Instance {
         &self,
         table_data: &TableData,
         request: &ReadRequest,
-        iter_options: IterOptions,
         table_options: &TableOptions,
     ) -> Result<Vec<ChainIterator>> {
         let projected_schema = request.projected_schema.clone();
@@ -234,7 +232,6 @@ impl Instance {
         assert!(request.order.is_out_of_order());
 
         let sst_read_options = SstReadOptions {
-            read_batch_row_num: table_options.num_rows_per_row_group,
             // no need to read in order so just read in asc order by default.
             reverse: false,
             frequency: ReadFrequency::Frequent,
@@ -242,8 +239,8 @@ impl Instance {
             predicate: request.predicate.clone(),
             meta_cache: self.meta_cache.clone(),
             runtime: self.read_runtime().clone(),
-            background_read_parallelism: iter_options.sst_background_read_parallelism,
             num_rows_per_row_group: table_options.num_rows_per_row_group,
+            scan_options: self.scan_options.clone(),
         };
 
         let time_range = request.predicate.time_range();

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -172,9 +172,7 @@ impl Instance {
         let time_range = request.predicate.time_range();
         let version = table_data.current_version();
         let read_views = self.partition_ssts_and_memtables(time_range, version, table_options);
-        let iter_options = IterOptions {
-            batch_size: table_options.num_rows_per_row_group,
-        };
+        let iter_options = self.make_iter_options(table_options.num_rows_per_row_group);
 
         let mut iters = Vec::with_capacity(read_views.len());
         for (idx, read_view) in read_views.into_iter().enumerate() {
@@ -327,6 +325,12 @@ impl Instance {
         }
 
         read_view_by_time.into_values().collect()
+    }
+
+    fn make_iter_options(&self, num_rows_per_row_group: usize) -> IterOptions {
+        self.iter_options.clone().unwrap_or(IterOptions {
+            batch_size: num_rows_per_row_group,
+        })
     }
 }
 

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -71,8 +71,10 @@ pub struct Config {
     /// End of global write buffer options.
 
     // Iterator scanning options
-    /// Batch size for iterator
+    /// Batch size for iterator.
     pub scan_batch_size: usize,
+    /// Max record batches in flight when scan
+    pub scan_max_record_batches_in_flight: usize,
     /// Sst background reading parallelism
     pub sst_background_read_parallelism: usize,
     /// Max buffer size for writing sst
@@ -108,8 +110,10 @@ impl Default for Config {
             /// Zero means disabling this param, give a positive value to enable
             /// it.
             db_write_buffer_size: 0,
+            #[allow(deprecated)]
             scan_batch_size: 500,
             sst_background_read_parallelism: 8,
+            scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),
             wal: WalStorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -72,7 +72,10 @@ pub struct Config {
 
     // Iterator scanning options
     /// Batch size for iterator.
-    pub scan_batch_size: usize,
+    ///
+    /// The `num_rows_per_row_group` in `table options` will be used if this is
+    /// not set.
+    pub scan_batch_size: Option<usize>,
     /// Max record batches in flight when scan
     pub scan_max_record_batches_in_flight: usize,
     /// Sst background reading parallelism
@@ -110,8 +113,7 @@ impl Default for Config {
             /// Zero means disabling this param, give a positive value to enable
             /// it.
             db_write_buffer_size: 0,
-            #[allow(deprecated)]
-            scan_batch_size: 500,
+            scan_batch_size: None,
             sst_background_read_parallelism: 8,
             scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),

--- a/analytic_engine/src/row_iter/dedup.rs
+++ b/analytic_engine/src/row_iter/dedup.rs
@@ -229,7 +229,8 @@ mod tests {
             ],
         );
 
-        let mut iter = DedupIterator::new(RequestId::next_id(), iter, IterOptions::default());
+        let mut iter =
+            DedupIterator::new(RequestId::next_id(), iter, IterOptions { batch_size: 500 });
         check_iterator(
             &mut iter,
             vec![

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -910,7 +910,7 @@ mod tests {
             schema.to_record_schema_with_key(),
             streams,
             Vec::new(),
-            IterOptions::default(),
+            IterOptions { batch_size: 500 },
             false,
             Metrics::new(1, 1, None),
         );
@@ -963,7 +963,7 @@ mod tests {
             schema.to_record_schema_with_key(),
             streams,
             Vec::new(),
-            IterOptions::default(),
+            IterOptions { batch_size: 500 },
             true,
             Metrics::new(1, 1, None),
         );

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -95,18 +95,31 @@ pub struct SstReadHint {
 }
 
 #[derive(Debug, Clone)]
+pub struct ScanOptions {
+    /// The suggested parallelism while reading sst
+    pub background_read_parallelism: usize,
+    /// The max record batches in flight
+    pub max_record_batches_in_flight: usize,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self {
+            background_read_parallelism: 1,
+            max_record_batches_in_flight: 64,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct SstReadOptions {
-    pub read_batch_row_num: usize,
     pub reverse: bool,
     pub frequency: ReadFrequency,
+    pub num_rows_per_row_group: usize,
     pub projected_schema: ProjectedSchema,
     pub predicate: PredicateRef,
     pub meta_cache: Option<MetaCacheRef>,
-
-    /// The max number of rows in one row group
-    pub num_rows_per_row_group: usize,
-    /// The suggested parallelism while reading sst
-    pub background_read_parallelism: usize,
+    pub scan_options: ScanOptions,
 
     pub runtime: Arc<Runtime>,
 }
@@ -152,7 +165,8 @@ impl Factory for FactoryImpl {
                 let reader = ThreadedReader::new(
                     reader,
                     options.runtime.clone(),
-                    options.background_read_parallelism,
+                    options.scan_options.background_read_parallelism,
+                    options.scan_options.max_record_batches_in_flight,
                 );
                 Ok(Box::new(reader))
             }

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -66,6 +66,7 @@ struct RecordBatchGroupWriter {
     request_id: RequestId,
     hybrid_encoding: bool,
     input: RecordBatchStream,
+    input_exhausted: bool,
     meta_data: MetaData,
     num_rows_per_row_group: usize,
     max_buffer_size: usize,
@@ -110,6 +111,10 @@ impl RecordBatchGroupWriter {
                 continue;
             }
 
+            if self.input_exhausted {
+                break;
+            }
+
             // Previous record batch has been exhausted, and let's fetch next record batch.
             match self.input.next().await {
                 Some(v) => {
@@ -124,7 +129,10 @@ impl RecordBatchGroupWriter {
                     // fill `curr_row_group`.
                     prev_record_batch.replace(v);
                 }
-                None => break,
+                None => {
+                    self.input_exhausted = true;
+                    break;
+                }
             };
         }
 
@@ -271,6 +279,7 @@ impl<'a> SstWriter for ParquetSstWriter<'a> {
             hybrid_encoding: self.hybrid_encoding,
             request_id,
             input,
+            input_exhausted: false,
             num_rows_per_row_group: self.num_rows_per_row_group,
             max_buffer_size: self.max_buffer_size,
             compression: self.compression,
@@ -521,6 +530,7 @@ mod tests {
             request_id: RequestId::next_id(),
             hybrid_encoding: false,
             input: record_batch_stream,
+            input_exhausted: false,
             num_rows_per_row_group,
             compression: Compression::UNCOMPRESSED,
             meta_data: MetaData {

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -333,7 +333,9 @@ mod tests {
     use crate::{
         row_iter::tests::build_record_batch_with_key,
         sst::{
-            factory::{Factory, FactoryImpl, ReadFrequency, SstReadOptions, SstWriteOptions},
+            factory::{
+                Factory, FactoryImpl, ReadFrequency, ScanOptions, SstReadOptions, SstWriteOptions,
+            },
             parquet::AsyncParquetReader,
             reader::{tests::check_stream, SstReader},
         },
@@ -411,17 +413,17 @@ mod tests {
 
             assert_eq!(15, sst_info.row_num);
 
+            let scan_options = ScanOptions::default();
             // read sst back to test
             let sst_read_options = SstReadOptions {
-                read_batch_row_num: 5,
                 reverse: false,
                 frequency: ReadFrequency::Frequent,
+                num_rows_per_row_group: 5,
                 projected_schema,
                 predicate: Arc::new(Predicate::empty()),
                 meta_cache: None,
+                scan_options,
                 runtime: runtime.clone(),
-                num_rows_per_row_group: 5,
-                background_read_parallelism: 1,
             };
 
             let mut reader: Box<dyn SstReader + Send> = {

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -50,7 +50,7 @@ pub struct SstBenchConfig {
 
     /// Max number of projection columns.
     pub max_projections: usize,
-    pub read_batch_row_num: usize,
+    pub num_rows_per_row_group: usize,
     pub predicate: BenchPredicate,
     pub sst_meta_cache_cap: Option<usize>,
     pub sst_data_cache_cap: Option<usize>,
@@ -70,7 +70,7 @@ pub struct MergeSstBenchConfig {
 
     /// Max number of projection columns.
     pub max_projections: usize,
-    pub read_batch_row_num: usize,
+    pub num_rows_per_row_group: usize,
     pub predicate: BenchPredicate,
 }
 

--- a/benchmarks/src/parquet_bench.rs
+++ b/benchmarks/src/parquet_bench.rs
@@ -48,7 +48,7 @@ impl ParquetBench {
             _predicate: config.predicate.into_predicate(),
             runtime: Arc::new(runtime),
             is_async: config.is_async,
-            batch_size: config.read_batch_row_num,
+            batch_size: config.num_rows_per_row_group,
         }
     }
 

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -15,7 +15,7 @@ use analytic_engine::{
     sst::{
         factory::{
             Factory, FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
-            SstReadHint, SstReadOptions, SstWriteOptions,
+            ScanOptions, SstReadHint, SstReadOptions, SstWriteOptions,
         },
         file::FilePurgeQueue,
         manager::FileId,
@@ -78,7 +78,6 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
 pub struct RebuildSstConfig {
     store_path: String,
     input_file_name: String,
-    read_batch_row_num: usize,
     predicate: BenchPredicate,
 
     // Output sst config:
@@ -96,16 +95,19 @@ pub async fn rebuild_sst(config: RebuildSstConfig, runtime: Arc<Runtime>) {
     let sst_meta = util::meta_from_sst(&store, &input_path, &None).await;
 
     let projected_schema = ProjectedSchema::no_projection(sst_meta.schema.clone());
+    let scan_options = ScanOptions {
+        background_read_parallelism: 1,
+        max_record_batches_in_flight: 1024,
+    };
     let sst_read_options = SstReadOptions {
-        read_batch_row_num: config.read_batch_row_num,
         reverse: false,
         frequency: ReadFrequency::Once,
+        num_rows_per_row_group: config.num_rows_per_row_group,
         projected_schema,
         predicate: config.predicate.into_predicate(),
         meta_cache: None,
+        scan_options,
         runtime,
-        background_read_parallelism: 1,
-        num_rows_per_row_group: config.read_batch_row_num,
     };
 
     let record_batch_stream =
@@ -154,7 +156,6 @@ pub struct MergeSstConfig {
     table_id: TableId,
     sst_file_ids: Vec<FileId>,
     dedup: bool,
-    read_batch_row_num: usize,
     predicate: BenchPredicate,
 
     // Output sst config:
@@ -196,8 +197,11 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
     let first_sst_path = sst_util::new_sst_file_path(space_id, table_id, config.sst_file_ids[0]);
     let schema = util::schema_from_sst(&store, &first_sst_path, &None).await;
     let iter_options = IterOptions {
-        batch_size: config.read_batch_row_num,
-        sst_background_read_parallelism: 1,
+        batch_size: config.num_rows_per_row_group,
+    };
+    let scan_options = ScanOptions {
+        background_read_parallelism: 1,
+        max_record_batches_in_flight: 1024,
     };
 
     let request_id = RequestId::next_id();
@@ -205,15 +209,14 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
     let store_picker: ObjectStorePickerRef = Arc::new(store);
     let projected_schema = ProjectedSchema::no_projection(schema.clone());
     let sst_read_options = SstReadOptions {
-        read_batch_row_num: config.read_batch_row_num,
         reverse: false,
         frequency: ReadFrequency::Once,
+        num_rows_per_row_group: config.num_rows_per_row_group,
         projected_schema: projected_schema.clone(),
         predicate: config.predicate.into_predicate(),
         meta_cache: None,
+        scan_options,
         runtime: runtime.clone(),
-        background_read_parallelism: iter_options.sst_background_read_parallelism,
-        num_rows_per_row_group: config.read_batch_row_num,
     };
     let iter = {
         let space_id = config.space_id;
@@ -245,9 +248,9 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
 
     let record_batch_stream = if config.dedup {
         let iter = DedupIterator::new(request_id, iter, iter_options);
-        row_iter::record_batch_with_key_iter_to_stream(iter, &runtime)
+        row_iter::record_batch_with_key_iter_to_stream(iter)
     } else {
-        row_iter::record_batch_with_key_iter_to_stream(iter, &runtime)
+        row_iter::record_batch_with_key_iter_to_stream(iter)
     };
 
     let sst_meta = {

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -6,8 +6,8 @@ use std::{error::Error, sync::Arc};
 
 use analytic_engine::{
     sst::factory::{
-        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, SstReadHint, SstReadOptions,
-        SstWriteOptions,
+        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, ScanOptions, SstReadHint,
+        SstReadOptions, SstWriteOptions,
     },
     table_options::{Compression, StorageFormatHint},
 };
@@ -74,16 +74,16 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     let input_path = Path::from(args.input);
     let sst_meta = sst_util::meta_from_sst(&store, &input_path).await;
     let factory = FactoryImpl;
+    let scan_options = ScanOptions::default();
     let reader_opts = SstReadOptions {
-        read_batch_row_num: 8192,
         reverse: false,
         frequency: ReadFrequency::Once,
+        num_rows_per_row_group: 8192,
         projected_schema: ProjectedSchema::no_projection(sst_meta.schema.clone()),
         predicate: Arc::new(Predicate::empty()),
         meta_cache: None,
+        scan_options,
         runtime,
-        background_read_parallelism: 1,
-        num_rows_per_row_group: 8192,
     };
     let store_picker: ObjectStorePickerRef = Arc::new(store);
     let mut reader = factory


### PR DESCRIPTION
## Which issue does this PR close?

Closes #735

## Rationale for this change
Currently, streaming reading sst has already been supported. However, the max record batches in flight is not configurable, which is hard-coded as 1024. This pr makes it configurable, especially for normal query and compaction reading.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Make `scan_max_record_batches_in_flight` configurable;
- Refactor the implementation for Stream based on a future method;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
A new config options is provided called `scan_max_record_batches_in_flight.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
