### PR TITLE
feat: make influxql query interface compatible with influxdb1.8

### DIFF
--- a/integration_tests/src/database.rs
+++ b/integration_tests/src/database.rs
@@ -245,6 +245,7 @@ impl<T: Backend> CeresDB<T> {
 
 impl<T> CeresDB<T> {
     async fn execute_influxql(query: String, http_client: HttpClient) -> Box<dyn Display> {
+        let query = format!("q={query}");
         let url = format!("http://{}/influxdb/v1/query", http_client.endpoint);
         let resp = http_client
             .client

--- a/server/src/handlers/influxdb.rs
+++ b/server/src/handlers/influxdb.rs
@@ -189,7 +189,6 @@ impl From<&str> for Epoch {
     }
 }
 
-// The query parameters for list_todos.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct Parameters {

--- a/server/src/handlers/query.rs
+++ b/server/src/handlers/query.rs
@@ -23,6 +23,7 @@ use sql::{
     provider::CatalogMetaProvider,
 };
 
+use super::influxdb::InfluxqlRequest;
 use crate::handlers::{
     error::{
         CreatePlan, InterpreterExec, ParseInfluxql, ParseSql, QueryBlock, QueryTimeout, TooMuchStmt,
@@ -110,7 +111,7 @@ impl From<Bytes> for Request {
 pub enum QueryRequest {
     Sql(Request),
     // TODO: influxql include more parameters, we should add it in later.
-    Influxql(Request),
+    Influxql(InfluxqlRequest),
 }
 impl QueryRequest {
     pub fn query(&self) -> &str {

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -260,7 +260,7 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
     /// for query api:
     ///     POST/GET `/influxdb/v1/query`
     ///
-    ///     It is derived from the influxdb 1.x query api described doc of 1.8:
+    /// It's derived from the influxdb 1.x query api described doc of 1.8:
     ///     https://docs.influxdata.com/influxdb/v1.8/tools/api/#query-http-endpoint
     fn influxdb_api(
         &self,

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -283,7 +283,8 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
                     return Err(reject::reject());
                 }
 
-                let request = InfluxqlRequest::try_new(method, body, params).map_err(reject::custom)?;
+                let request =
+                    InfluxqlRequest::try_new(method, body, params).map_err(reject::custom)?;
                 influxdb::query(ctx, db, QueryRequest::Influxql(request)).await
             });
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
See title.
And after doing this, we can connect ceresdb to grafana with inluxdb protocol.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
See title.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Can use the same influxdb1.8 compatible query api to query data from ceresdb.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Test manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
