### PR TITLE
feat: add default schema config

### DIFF
--- a/cluster/src/config.rs
+++ b/cluster/src/config.rs
@@ -5,7 +5,7 @@ use meta_client::meta_impl::MetaClientConfig;
 use serde::{Deserialize, Serialize};
 use table_engine::ANALYTIC_ENGINE_TYPE;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 // TODO: move this to table_engine crates
 pub struct SchemaConfig {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -111,6 +111,8 @@ pub struct ServerConfig {
     /// used in gRPC
     pub auto_create_table: bool,
 
+    pub default_schema_config: SchemaConfig,
+
     // Config of route
     pub route_cache: router::RouteCacheConfig,
 }
@@ -118,7 +120,7 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
-            bind_addr: String::from("0.0.0.0"),
+            bind_addr: String::from("127.0.0.1"),
             http_port: 5440,
             mysql_port: 3307,
             grpc_port: 8831,
@@ -128,6 +130,7 @@ impl Default for ServerConfig {
             resp_compress_min_length: ReadableSize::mb(4),
             forward: forward::Config::default(),
             auto_create_table: true,
+            default_schema_config: Default::default(),
             route_cache: router::RouteCacheConfig::default(),
         }
     }

--- a/server/src/schema_config_provider/config_based.rs
+++ b/server/src/schema_config_provider/config_based.rs
@@ -14,16 +14,24 @@ pub type SchemaConfigs = HashMap<String, SchemaConfig>;
 #[derive(Debug)]
 pub struct ConfigBasedProvider {
     schema_configs: SchemaConfigs,
+    default: SchemaConfig,
 }
 
 impl ConfigBasedProvider {
-    pub fn new(schema_configs: SchemaConfigs) -> Self {
-        Self { schema_configs }
+    pub fn new(schema_configs: SchemaConfigs, default: SchemaConfig) -> Self {
+        Self {
+            schema_configs,
+            default,
+        }
     }
 }
 
 impl SchemaConfigProvider for ConfigBasedProvider {
     fn schema_config(&self, schema_name: &str) -> Result<Option<&SchemaConfig>> {
-        Ok(self.schema_configs.get(schema_name))
+        Ok(Some(
+            self.schema_configs
+                .get(schema_name)
+                .unwrap_or(&self.default),
+        ))
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -311,7 +311,10 @@ async fn build_without_meta<Q: Executor + 'static, T: WalsOpener>(
         cluster_view,
         static_route_config.rules.clone(),
     ));
-    let schema_config_provider = Arc::new(ConfigBasedProvider::new(schema_configs));
+    let schema_config_provider = Arc::new(ConfigBasedProvider::new(
+        schema_configs,
+        config.server.default_schema_config.clone(),
+    ));
 
     builder
         .table_engine(engine_proxy)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
Simplify schema config setting. If we don't provide a define one, we need to set schema config one by one, something like

```
[[cluster_deployment.topology.schema_shards]]
schema = 'public_0'
default_timestamp_column_name = 'time'
[[cluster_deployment.topology.schema_shards.shard_views]]
shard_id = 0
[cluster_deployment.topology.schema_shards.shard_views.endpoint]
addr = '127.0.0.1'
port = 8831
[[cluster_deployment.topology.schema_shards.shard_views]]
shard_id = 1
[cluster_deployment.topology.schema_shards.shard_views.endpoint]
addr = '127.0.0.1'
port = 8831
```

This is very inconvient.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Add default schema config in server

```toml
[server.default_schema_config]
default_timestamp_column_name = "time"
```
- Update bind_addr to 127.0.0.1, which is more safe than before.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

Manully
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

