### PR TITLE
feat: impl getTableInfo in remoteEngine service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "common_types",
  "common_util",
  "datafusion",
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "1.0.1"
-source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd#9209de4ec683b7639e6aa3198704c5656dea91dd"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b#1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1328,7 +1328,7 @@ name = "cluster"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "common_types",
  "common_util",
  "log",
@@ -1379,7 +1379,7 @@ dependencies = [
  "arrow_ext",
  "byteorder",
  "bytes_ext",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "chrono",
  "datafusion",
  "murmur3",
@@ -1397,7 +1397,7 @@ version = "1.0.0"
 dependencies = [
  "arrow 32.0.0",
  "backtrace",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "chrono",
  "common_types",
  "crossbeam-utils 0.8.11",
@@ -3490,7 +3490,7 @@ name = "meta_client"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "common_types",
  "common_util",
  "futures 0.3.25",
@@ -3979,7 +3979,7 @@ version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "chrono",
  "clru",
  "common_util",
@@ -5154,7 +5154,7 @@ version = "1.0.0"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "clru",
  "common_types",
  "common_util",
@@ -5255,7 +5255,7 @@ name = "router"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "cluster",
  "common_types",
  "common_util",
@@ -5594,7 +5594,7 @@ dependencies = [
  "async-trait",
  "bytes 1.4.0",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "cluster",
  "common_types",
  "common_util",
@@ -5931,7 +5931,7 @@ dependencies = [
  "arrow 32.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "cluster",
  "common_types",
  "common_util",
@@ -6160,7 +6160,7 @@ dependencies = [
  "arrow 32.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "common_types",
  "common_util",
  "futures 0.3.25",
@@ -6179,7 +6179,7 @@ dependencies = [
  "arrow 32.0.0",
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "common_types",
  "common_util",
  "datafusion",
@@ -7024,7 +7024,7 @@ name = "wal"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
  "chrono",
  "common_types",
  "common_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.0",
  "bytes 1.4.0",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "common_types",
  "common_util",
  "datafusion",
@@ -1124,7 +1124,7 @@ checksum = "6a2c1699cb154e97cfccd3d6a0679f561c6214a33d86b3eacb78685c7479d022"
 dependencies = [
  "arrow 23.0.0",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dashmap 5.4.0",
  "futures 0.3.25",
  "paste 1.0.8",
@@ -1155,6 +1155,18 @@ name = "ceresdbproto"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c656dfafeb22c315ec8ec842fa78e5e887c9411053e41ade06efb0f91c0589a"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic",
+ "tonic-build",
+ "walkdir",
+]
+
+[[package]]
+name = "ceresdbproto"
+version = "1.0.1"
+source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd#9209de4ec683b7639e6aa3198704c5656dea91dd"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1316,7 +1328,7 @@ name = "cluster"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "common_types",
  "common_util",
  "log",
@@ -1367,7 +1379,7 @@ dependencies = [
  "arrow_ext",
  "byteorder",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "chrono",
  "datafusion",
  "murmur3",
@@ -1385,7 +1397,7 @@ version = "1.0.0"
 dependencies = [
  "arrow 32.0.0",
  "backtrace",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "chrono",
  "common_types",
  "crossbeam-utils 0.8.11",
@@ -3478,7 +3490,7 @@ name = "meta_client"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "common_types",
  "common_util",
  "futures 0.3.25",
@@ -3967,7 +3979,7 @@ version = "1.0.0"
 dependencies = [
  "async-trait",
  "bytes 1.4.0",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "chrono",
  "clru",
  "common_util",
@@ -5142,7 +5154,7 @@ version = "1.0.0"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "clru",
  "common_types",
  "common_util",
@@ -5243,7 +5255,7 @@ name = "router"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "cluster",
  "common_types",
  "common_util",
@@ -5582,7 +5594,7 @@ dependencies = [
  "async-trait",
  "bytes 1.4.0",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "cluster",
  "common_types",
  "common_util",
@@ -5919,7 +5931,7 @@ dependencies = [
  "arrow 32.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "cluster",
  "common_types",
  "common_util",
@@ -6148,7 +6160,7 @@ dependencies = [
  "arrow 32.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "common_types",
  "common_util",
  "futures 0.3.25",
@@ -6167,7 +6179,7 @@ dependencies = [
  "arrow 32.0.0",
  "arrow_ext",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "common_types",
  "common_util",
  "datafusion",
@@ -7012,7 +7024,7 @@ name = "wal"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.1 (git+https://github.com/chunshao90/ceresdbproto.git?rev=9209de4ec683b7639e6aa3198704c5656dea91dd)",
  "chrono",
  "common_types",
  "common_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ bytes = "1.1.0"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = "1.0.1"
+#ceresdbproto = "1.0.1"
 chrono = "0.4"
 clap = "3.0"
 clru = "0.6.1"
@@ -149,6 +149,10 @@ sort = "0.8.5"
 table_engine = { workspace = true }
 toml = { workspace = true }
 tracing_util = { workspace = true }
+
+[workspace.dependencies.ceresdbproto]
+git = "https://github.com/chunshao90/ceresdbproto.git"
+rev = "9209de4ec683b7639e6aa3198704c5656dea91dd"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ bytes = "1.1.0"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-#ceresdbproto = "1.0.1"
 chrono = "0.4"
 clap = "3.0"
 clru = "0.6.1"
@@ -151,8 +150,8 @@ toml = { workspace = true }
 tracing_util = { workspace = true }
 
 [workspace.dependencies.ceresdbproto]
-git = "https://github.com/chunshao90/ceresdbproto.git"
-rev = "9209de4ec683b7639e6aa3198704c5656dea91dd"
+git = "https://github.com/CeresDB/ceresdbproto.git"
+rev = "1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Schema of table
 
@@ -987,6 +987,12 @@ impl From<&Schema> for schema_pb::TableSchema {
             columns,
             primary_key_ids,
         }
+    }
+}
+
+impl From<Schema> for schema_pb::TableSchema {
+    fn from(value: Schema) -> Self {
+        (&value).into()
     }
 }
 

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -990,12 +990,6 @@ impl From<&Schema> for schema_pb::TableSchema {
     }
 }
 
-impl From<Schema> for schema_pb::TableSchema {
-    fn from(value: Schema) -> Self {
-        (&value).into()
-    }
-}
-
 /// Schema builder
 #[must_use]
 pub struct Builder {

--- a/server/src/grpc/metrics.rs
+++ b/server/src/grpc/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 // Grpc server metrics
 
@@ -24,6 +24,7 @@ make_auto_flush_static_metric! {
     pub label_enum RemoteEngineTypeKind {
         stream_read,
         write,
+        get_table_info,
     }
 
     pub struct RemoteEngineGrpcHandlerDurationHistogramVec: LocalHistogram {

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 // Remote engine rpc service implementation.
 
@@ -6,11 +6,12 @@ use std::{sync::Arc, time::Instant};
 
 use arrow_ext::ipc::{self, CompressOptions, CompressOutput, CompressionMethod};
 use async_trait::async_trait;
-use catalog::manager::ManagerRef;
+use catalog::{manager::ManagerRef, schema::SchemaRef};
 use ceresdbproto::{
     remote_engine::{
         read_response::Output::Arrow, remote_engine_service_server::RemoteEngineService,
-        ReadRequest, ReadResponse, WriteRequest, WriteResponse,
+        GetTableInfoRequest, GetTableInfoResponse, ReadRequest, ReadResponse, WriteRequest,
+        WriteResponse,
     },
     storage::{arrow_payload, ArrowPayload},
 };
@@ -31,9 +32,7 @@ use tonic::{Request, Response, Status};
 use crate::{
     grpc::{
         metrics::REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC,
-        remote_engine_service::error::{
-            build_ok_header, ErrNoCause, ErrWithCause, Result, StatusCode,
-        },
+        remote_engine_service::error::{ErrNoCause, ErrWithCause, Result, StatusCode},
     },
     instance::InstanceRef,
 };
@@ -123,6 +122,39 @@ impl<Q: QueryExecutor + 'static> RemoteEngineServiceImpl<Q> {
         Ok(Response::new(resp))
     }
 
+    async fn get_table_info_internal(
+        &self,
+        request: Request<GetTableInfoRequest>,
+    ) -> std::result::Result<Response<GetTableInfoResponse>, Status> {
+        let begin_instant = Instant::now();
+        let ctx = self.handler_ctx();
+        let handle = self.runtimes.meta_runtime.spawn(async move {
+            let request = request.into_inner();
+            handle_get_table_info(ctx, request).await
+        });
+
+        let res = handle.await.box_err().context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: "fail to join task",
+        });
+
+        let mut resp = GetTableInfoResponse::default();
+        match res {
+            Ok(Ok(v)) => {
+                resp.header = Some(error::build_ok_header());
+                resp.table_info = v.table_info;
+            }
+            Ok(Err(e)) | Err(e) => {
+                resp.header = Some(error::build_err_header(e));
+            }
+        };
+
+        REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC
+            .get_table_info
+            .observe(begin_instant.saturating_elapsed().as_secs_f64());
+        Ok(Response::new(resp))
+    }
+
     fn handler_ctx(&self) -> HandlerContext {
         HandlerContext {
             catalog_manager: self.instance.catalog_manager.clone(),
@@ -170,7 +202,7 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
                                 };
 
                                 ReadResponse {
-                                    header: Some(build_ok_header()),
+                                    header: Some(error::build_ok_header()),
                                     output: Some(Arrow(ArrowPayload {
                                         record_batches: vec![payload],
                                         compression: compression as i32,
@@ -208,6 +240,13 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
         request: Request<WriteRequest>,
     ) -> std::result::Result<Response<WriteResponse>, Status> {
         self.write_internal(request).await
+    }
+
+    async fn get_table_info(
+        &self,
+        request: Request<GetTableInfoRequest>,
+    ) -> std::result::Result<Response<GetTableInfoResponse>, Status> {
+        self.get_table_info_internal(request).await
     }
 }
 
@@ -258,10 +297,68 @@ async fn handle_write(ctx: HandlerContext, request: WriteRequest) -> Result<Writ
     })
 }
 
+async fn handle_get_table_info(
+    ctx: HandlerContext,
+    request: GetTableInfoRequest,
+) -> Result<GetTableInfoResponse> {
+    let write_request: table_engine::remote::model::GetTableInfoRequest =
+        request.try_into().box_err().context(ErrWithCause {
+            code: StatusCode::BadRequest,
+            msg: "fail to convert get table info request",
+        })?;
+
+    let schema = find_schema_by_identifier(&ctx, &write_request.table)?;
+    let table = schema
+        .table_by_name(&write_request.table.table)
+        .box_err()
+        .context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: format!("fail to get table, table:{}", write_request.table.table),
+        })?
+        .context(ErrNoCause {
+            code: StatusCode::NotFound,
+            msg: format!("table is not found, table:{}", write_request.table.table),
+        })?;
+
+    Ok(GetTableInfoResponse {
+        header: None,
+        table_info: Some(ceresdbproto::remote_engine::TableInfo {
+            catalog_name: write_request.table.catalog,
+            schema_name: schema.name().to_string(),
+            schema_id: schema.id().as_u32(),
+            table_name: table.name().to_string(),
+            table_id: table.id().as_u64(),
+            table_schema: Some(table.schema().into()),
+            engine: table.engine_type().to_string(),
+            options: table.options(),
+            partition_info: table.partition_info().map(Into::into),
+        }),
+    })
+}
+
 fn find_table_by_identifier(
     ctx: &HandlerContext,
     table_identifier: &TableIdentifier,
 ) -> Result<TableRef> {
+    let schema = find_schema_by_identifier(ctx, table_identifier)?;
+
+    schema
+        .table_by_name(&table_identifier.table)
+        .box_err()
+        .context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: format!("fail to get table, table:{}", table_identifier.table),
+        })?
+        .context(ErrNoCause {
+            code: StatusCode::NotFound,
+            msg: format!("table is not found, table:{}", table_identifier.table),
+        })
+}
+
+fn find_schema_by_identifier(
+    ctx: &HandlerContext,
+    table_identifier: &TableIdentifier,
+) -> Result<SchemaRef> {
     let catalog = ctx
         .catalog_manager
         .catalog_by_name(&table_identifier.catalog)
@@ -274,7 +371,7 @@ fn find_table_by_identifier(
             code: StatusCode::NotFound,
             msg: format!("catalog is not found, catalog:{}", table_identifier.catalog),
         })?;
-    let schema = catalog
+    catalog
         .schema_by_name(&table_identifier.schema)
         .box_err()
         .context(ErrWithCause {
@@ -290,17 +387,5 @@ fn find_table_by_identifier(
                 "schema of table is not found, schema:{}",
                 table_identifier.schema
             ),
-        })?;
-
-    schema
-        .table_by_name(&table_identifier.table)
-        .box_err()
-        .context(ErrWithCause {
-            code: StatusCode::Internal,
-            msg: format!("fail to get table, table:{}", table_identifier.table),
-        })?
-        .context(ErrNoCause {
-            code: StatusCode::NotFound,
-            msg: format!("table is not found, table:{}", table_identifier.table),
         })
 }

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Model for remote table engine
 
@@ -226,6 +226,30 @@ impl TryFrom<WriteRequest> for ceresdbproto::remote_engine::WriteRequest {
             table: Some(table_pb),
             row_group: Some(row_group_pb),
         })
+    }
+}
+
+pub struct GetTableInfoRequest {
+    pub table: TableIdentifier,
+}
+
+impl TryFrom<ceresdbproto::remote_engine::GetTableInfoRequest> for GetTableInfoRequest {
+    type Error = Error;
+
+    fn try_from(
+        value: ceresdbproto::remote_engine::GetTableInfoRequest,
+    ) -> std::result::Result<Self, Self::Error> {
+        let table = value.table.context(EmptyTableIdentifier)?.into();
+        Ok(Self { table })
+    }
+}
+
+impl TryFrom<GetTableInfoRequest> for ceresdbproto::remote_engine::GetTableInfoRequest {
+    type Error = Error;
+
+    fn try_from(value: GetTableInfoRequest) -> std::result::Result<Self, Self::Error> {
+        let table = value.table.into();
+        Ok(Self { table: Some(table) })
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
The schema of partition table will be obtained from the first sub-table, so a remote engine is needed to implement the table information access interface.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Impl getTableInfo in remoteEngine service.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Testing will be conducted with the partition table, and it will be used internally by the engine without affecting external users for the time being.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
