### PR TITLE
fix: avoid send empty record batch to client

### DIFF
--- a/common_types/src/record_batch.rs
+++ b/common_types/src/record_batch.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Record batch
 
@@ -234,23 +234,33 @@ impl RecordBatch {
         &self.schema
     }
 
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.num_rows() == 0
+    }
+
     // REQUIRE: index is valid
+    #[inline]
     pub fn column(&self, index: usize) -> &ColumnBlock {
         &self.data.column_blocks[index]
     }
 
+    #[inline]
     pub fn num_columns(&self) -> usize {
         self.schema.num_columns()
     }
 
+    #[inline]
     pub fn num_rows(&self) -> usize {
         self.data.num_rows()
     }
 
+    #[inline]
     pub fn as_arrow_record_batch(&self) -> &ArrowRecordBatch {
         &self.data.arrow_record_batch
     }
 
+    #[inline]
     pub fn into_arrow_record_batch(self) -> ArrowRecordBatch {
         self.data.arrow_record_batch
     }

--- a/components/arrow_ext/src/ipc.rs
+++ b/components/arrow_ext/src/ipc.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Utilities for `RecordBatch` serialization using Arrow IPC
 
@@ -109,6 +109,7 @@ impl RecordBatchesEncoder {
         let stream_writer = if let Some(v) = &mut self.stream_writer {
             v
         } else {
+            // TODO: pre-allocate the buffer.
             let buffer: Vec<u8> = Vec::new();
             let stream_writer =
                 StreamWriter::try_new(buffer, &batch.schema()).context(ArrowError)?;

--- a/server/src/proxy/grpc/sql_query.rs
+++ b/server/src/proxy/grpc/sql_query.rs
@@ -453,6 +453,10 @@ impl QueryResponseWriter {
     }
 
     pub fn write(&mut self, batch: &RecordBatch) -> Result<()> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+
         self.encoder
             .write(batch.as_arrow_record_batch())
             .box_err()


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, empty record batch will be generated by the datafusion, and will be sent to the client too. Avoid the empty record batch because it is a waste for both server and client.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Avoid encoding the empty record batch into the `SqlQueryResponse`;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
1. The client won't receive any empty record batch;
2. The schema information won't be sent to the client if the whole query response is empty;

As for the second cheanges, all the sdks has been tested for the compatibility.

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
