### PR TITLE
refactor: make tsbs more configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,5 @@ ensure-disk-quota:
 	# ensure the target directory not to exceed 40GB
 	python3 ./scripts/clean-large-folder.py ./target 42949672960
 
-tsbs: build-slim
+tsbs: build
 	cd $(DIR); sh scripts/run-tsbs.sh

--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,5 @@ ensure-disk-quota:
 	# ensure the target directory not to exceed 40GB
 	python3 ./scripts/clean-large-folder.py ./target 42949672960
 
-tsbs:
+tsbs: build-slim
 	cd $(DIR); sh scripts/run-tsbs.sh

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,6 @@ miri:
 ensure-disk-quota:
 	# ensure the target directory not to exceed 40GB
 	python3 ./scripts/clean-large-folder.py ./target 42949672960
+
+tsbs:
+	cd $(DIR); sh scripts/run-tsbs.sh

--- a/scripts/run-tsbs.sh
+++ b/scripts/run-tsbs.sh
@@ -94,7 +94,7 @@ fi
 cat ${BULK_DATA_DIR}/ceresdb-single-groupby-5-8-1-queries.gz | gunzip | ./tsbs_run_queries_ceresdb --ceresdb-addr=${CERESDB_ADDR} | tee ${LOG_DIR}/5-8-1.log
 
 # Clean the result file
-rm -rf ${RESULT_FILE}
+rm ${RESULT_FILE}
 
 # Output write & query result
 echo '# Write' >> ${RESULT_FILE}

--- a/scripts/run-tsbs.sh
+++ b/scripts/run-tsbs.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
 
+# This bash supports these settings by enviroment variables:
+# - RESULT_FILE
+# - DATA_FILE
+# - LOG_DIR
+# - CERESDB_CONFIG_FILE
+# - CERESDB_ADDR
+
 export CURR_DIR=$(pwd)
-# used to create issue in https://github.com/CeresDB/tsbs/labels
-export RESULT_FILE=${CURR_DIR}/tsbs/result.md
-export CONFIG_FILE=${CONFIG_FILE:-docs/minimal.toml}
-export LOG_DIR=${CURR_DIR}/logs
-# where generated data stored
+export DEFAULT_RESULT_FILE=${CURR_DIR}/tsbs/result.md
+export RESULT_FILE=${RESULT_FILE:-${DEFAULT_RESULT_FILE}}
+export CERESDB_CONFIG_FILE=${CERESDB_CONFIG_FILE:-docs/minimal.toml}
+export LOG_DIR=${LOG_DIR:-${CURR_DIR}/logs}
+export CERESDB_ADDR=${CERESDB_ADDR:-127.0.0.1:8831}
+export CERESDB_PID_FILE=${CURR_DIR}/ceresdb-server.pid
+# Where generated data stored
 export DATA_FILE=${DATA_FILE:-data.out}
-# how many values in host tag
+# How many values in host tag
 export HOST_NUM=${HOST_NUM:-10000}
+
+# Used for `generate_queries.sh` start.
 export TS_START="2022-09-05T00:00:00Z"
 export TS_END="2022-09-05T12:00:01Z"
 export EXE_FILE_NAME=${CURR_DIR}/tsbs/tsbs_generate_queries
@@ -22,18 +33,32 @@ single-groupby-1-8-1 \
 single-groupby-5-1-1 \
 single-groupby-5-1-12 \
 single-groupby-5-8-1"
+# Used for `generate_queries.sh` end.
 
 set -x
+
+kill_ceresdb_server() {
+  if [ -f ${CERESDB_PID_FILE} ]; then
+    pid=$(cat ${CERESDB_PID_FILE})
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid"
+    fi
+  fi
+}
+
 trap cleanup EXIT
 cleanup() {
   ls -lha ${LOG_DIR}
   ls -lha ${CURR_DIR}/tsbs
   ls -lha ${BULK_DATA_DIR}
+
+  kill_ceresdb_server
 }
 
 mkdir -p ${LOG_DIR}
 
-nohup ./target/release/ceresdb-server -c ${CONFIG_FILE} > ${LOG_DIR}/server.log &
+kill_ceresdb_server
+nohup ./target/release/ceresdb-server -c ${CERESDB_CONFIG_FILE} > ${LOG_DIR}/server.log & echo $! > ${CERESDB_PID_FILE}
 
 git clone -b feat-ceresdb --depth 1 --single-branch https://github.com/CeresDB/tsbs.git
 
@@ -43,22 +68,33 @@ go build ./cmd/tsbs_load_ceresdb
 go build ./cmd/tsbs_generate_queries
 go build ./cmd/tsbs_run_queries_ceresdb
 
-# generate benchmark data
-./tsbs_generate_data --use-case="cpu-only" --seed=123 --initial-scale=${HOST_NUM} --scale=${HOST_NUM} \
-                     --timestamp-start="${TS_START}" \
-                     --timestamp-end="${TS_END}" \
-                     --log-interval="60s" --format="${FORMATS}" > ${DATA_FILE}
+if [ ! -f ${DATA_FILE} ]; then
+  # Generate benchmark data if it does not exist.
+  ./tsbs_generate_data \
+    --use-case="cpu-only" \
+    --seed=123 \
+    --initial-scale=${HOST_NUM} \
+    --scale=${HOST_NUM} \
+    --timestamp-start="${TS_START}" \
+    --timestamp-end="${TS_END}" \
+    --log-interval="60s" \
+    --format="${FORMATS}" > ${DATA_FILE}
+fi
 
 
-# write data to ceresdb
-./tsbs_load_ceresdb --file ${DATA_FILE} | tee ${LOG_DIR}/write.log
+# Write data to ceresdb
+./tsbs_load_ceresdb --ceresdb-addr=${CERESDB_ADDR} --file ${DATA_FILE} | tee ${LOG_DIR}/write.log
+    
 
-# generate queries
+# Generate queries for query
 ./scripts/generate_queries.sh
 
-# run queries against ceresdb
-# Note: only run 5-8-1 now
-cat ${BULK_DATA_DIR}/ceresdb-single-groupby-5-8-1-queries.gz | gunzip | ./tsbs_run_queries_ceresdb | tee ${LOG_DIR}/5-8-1.log
+# Run queries against ceresdb
+# TODO: support more kinds of queries besides 5-8-1.
+cat ${BULK_DATA_DIR}/ceresdb-single-groupby-5-8-1-queries.gz | gunzip | ./tsbs_run_queries_ceresdb --ceresdb-addr=${CERESDB_ADDR} | tee ${LOG_DIR}/5-8-1.log
+
+# Clean the result file
+rm -rf ${RESULT_FILE}
 
 # Output write & query result
 echo '# Write' >> ${RESULT_FILE}


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 In order to prepare for nightly running tsbs on a server, the run-tsbs script should more configurable.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Expose more config, including log directory, ceresdb grpc addr and so on;
- Record the ceresdb pid and kill it after finished;

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
It has been used on the https://github.com/ShiKaiWi/ceresdb-benchmark
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
