### PR TITLE
fix: avoid break when drop wal table failed

### DIFF
--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1441,7 +1441,13 @@ fn purge_buckets<T: TableKv>(
     for bucket in &buckets {
         // Delete all tables of this bucket.
         for table_name in &bucket.wal_shard_names {
-            table_kv.drop_table(table_name).map_err(Box::new)?;
+            let drop_result = table_kv.drop_table(table_name);
+            if drop_result.is_err() {
+                error!(
+                    "Purge buckets drop table failed, table:{table_name}, err:{:?}",
+                    drop_result.err()
+                );
+            }
         }
 
         // All tables of this bucket have been dropped, we can remove the bucket record

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1441,13 +1441,11 @@ fn purge_buckets<T: TableKv>(
     for bucket in &buckets {
         // Delete all tables of this bucket.
         for table_name in &bucket.wal_shard_names {
-            let drop_result = table_kv.drop_table(table_name);
-            if drop_result.is_err() {
+            let _ = table_kv.drop_table(table_name).map_err(|e| {
                 error!(
-                    "Purge buckets drop table failed, table:{table_name}, err:{:?}",
-                    drop_result.err()
+                    "Purge buckets drop table failed, table:{table_name}, err:{e}",
                 );
-            }
+            });
         }
 
         // All tables of this bucket have been dropped, we can remove the bucket record

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1442,9 +1442,7 @@ fn purge_buckets<T: TableKv>(
         // Delete all tables of this bucket.
         for table_name in &bucket.wal_shard_names {
             let _ = table_kv.drop_table(table_name).map_err(|e| {
-                error!(
-                    "Purge buckets drop table failed, table:{table_name}, err:{e}",
-                );
+                error!("Purge buckets drop table failed, table:{table_name}, err:{e}");
             });
         }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
It occurs error when dropping expired wal table. 
```
2023-04-04 12:08:40.363 ERRO [components/table_kv/src/obkv.rs:439] Failed to drop table, table_name:wal_wal_20230317000000_000003, err:Table not dropped, table:wal_wal_20230317000000_000003.
Backtrace:
0 <snafu::backtrace_shim::Backtrace as snafu::GenerateBacktrace>::generate::hfa679d2c718d0b38
  /root/.cargo/registry/src/github.com-1ecc6299db9ec823/snafu-0.6.10/src/backtrace_shim.rs:15
  table_kv::obkv::TableNotDropped<__T0>::build::hf3dea826ebd60599
  /xunming/ceresdb/components/table_kv/src/obkv.rs:23
  table_kv::obkv::TableNotDropped<__T0>::fail::hfb145a30c5888703
  /xunming/ceresdb/components/table_kv/src/obkv.rs:23
  table_kv::obkv::ObkvImpl::try_drop_kv_table::h7edb8769b0ed116c
  /xunming/ceresdb/components/table_kv/src/obkv.rs:374
  <table_kv::obkv::ObkvImpl as table_kv::TableKv>::drop_table::h3b83a7345d116784
  /xunming/ceresdb/components/table_kv/src/obkv.rs:438
1 wal::table_kv_impl::namespace::purge_buckets::hb4395adb5b50e83e
  /xunming/ceresdb/wal/src/table_kv_impl/namespace.rs:1444
2 wal::table_kv_impl::namespace::NamespaceInner<T>::load_buckets::{{closure}}::h4922baf7634505ad
  /xunming/ceresdb/wal/src/table_kv_impl/namespace.rs:354
  <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll::h270e8b114cddbb1b
  /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/blocking/task.rs:42
  tokio::runtime::task::core::Core<T,S>::poll::{{closure}}::hea44e76037d909f7
  /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/core.rs:223
  tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut::h24af6522353d4a69
  /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/loom/std/unsafe_cell.rs:14
  tokio::runtime::task::core::Core<T,S>::poll::h378d8040acaefa93
  /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/core.rs:212
  tokio::runtime::task::harness::poll_future::{{closure}}::h92d37d5647cfe3a6
  /root/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:476
  <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h3dc7a85ad1d5e8ec
  /rustc/11d96b59307b1702fffe871bfc2d0145d070881e/library/core/src/panic/unwind_safe.rs:271
  std::panicking::try::do_call::hd1d739daf4f7b5fa
  /rustc/11d96b59307b1702fffe871bfc2d0145d070881e/library/std/src/panicking.rs:483
  std::panicking::try::hd06767296cb7e461
  /rustc/11d96b59307b1702fffe871bfc2d0145d070881e/library/std/src/panicking.rs:447
  std::panic::catch_unwind::h51d62c40d2d54cda
  /rustc/11d96b59307b1702fffe871bfc2d0145d070881e/library/std/src/panic.rs:140
```

## What changes are included in this PR?

Print error log when dropping expired wal table failed, and continue to drop other tables.

## Are there any user-facing changes?

None

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
