### PR TITLE
feat: expose rocksdb background jobs option

### DIFF
--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -30,7 +30,7 @@ use storage_options::StorageOptions;
 use table_kv::config::ObkvConfig;
 use wal::{
     message_queue_impl::config::Config as MessageQueueWalConfig,
-    table_kv_impl::model::NamespaceConfig,
+    rocks_impl::config::Config as RocksDBWalConfig, table_kv_impl::model::NamespaceConfig,
 };
 
 pub use crate::{compaction::scheduler::SchedulerConfig, table_options::TableOptions};
@@ -254,18 +254,17 @@ pub struct KafkaWalConfig {
 pub struct RocksDBConfig {
     /// Data directory used by RocksDB.
     pub data_dir: String,
-    pub sst_max_background_jobs: i32,
-    pub manifest_max_background_jobs: i32,
+
+    pub data_namespace: RocksDBWalConfig,
+    pub meta_namespace: RocksDBWalConfig,
 }
 
 impl Default for RocksDBConfig {
     fn default() -> Self {
         Self {
             data_dir: "/tmp/ceresdb".to_string(),
-            // Same with rocksdb
-            // https://github.com/facebook/rocksdb/blob/v6.4.6/include/rocksdb/options.h#L537
-            sst_max_background_jobs: 2,
-            manifest_max_background_jobs: 2,
+            data_namespace: Default::default(),
+            meta_namespace: Default::default(),
         }
     }
 }

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -254,12 +254,18 @@ pub struct KafkaWalConfig {
 pub struct RocksDBConfig {
     /// Data directory used by RocksDB.
     pub data_dir: String,
+    pub sst_max_background_jobs: i32,
+    pub manifest_max_background_jobs: i32,
 }
 
 impl Default for RocksDBConfig {
     fn default() -> Self {
         Self {
             data_dir: "/tmp/ceresdb".to_string(),
+            // Same with rocksdb
+            // https://github.com/facebook/rocksdb/blob/v6.4.6/include/rocksdb/options.h#L537
+            sst_max_background_jobs: 2,
+            manifest_max_background_jobs: 2,
         }
     }
 }

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -789,10 +789,9 @@ mod tests {
         }
 
         async fn open_manifest(&self) -> ManifestImpl {
-            let manifest_wal =
-                WalBuilder::with_default_rocksdb_config(self.dir.clone(), self.runtime.clone())
-                    .build()
-                    .unwrap();
+            let manifest_wal = WalBuilder::new(self.dir.clone(), self.runtime.clone())
+                .build()
+                .unwrap();
 
             let object_store = LocalFileSystem::new_with_prefix(&self.dir).unwrap();
             ManifestImpl::open(

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -182,13 +182,13 @@ impl WalsOpener for RocksDBWalsOpener {
         let data_path = Path::new(&rocksdb_wal_config.data_dir);
         let wal_path = data_path.join(WAL_DIR_NAME);
         let data_wal = RocksWalBuilder::new(wal_path, write_runtime.clone())
-            .max_background_jobs(rocksdb_wal_config.sst_max_background_jobs)
+            .max_background_jobs(rocksdb_wal_config.data_namespace.max_background_jobs)
             .build()
             .context(OpenWal)?;
 
         let manifest_path = data_path.join(MANIFEST_DIR_NAME);
         let manifest_wal = RocksWalBuilder::new(manifest_path, write_runtime)
-            .max_background_jobs(rocksdb_wal_config.manifest_max_background_jobs)
+            .max_background_jobs(rocksdb_wal_config.meta_namespace.max_background_jobs)
             .build()
             .context(OpenManifestWal)?;
         let opened_wals = OpenedWals {

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -181,16 +181,16 @@ impl WalsOpener for RocksDBWalsOpener {
         let write_runtime = engine_runtimes.write_runtime.clone();
         let data_path = Path::new(&rocksdb_wal_config.data_dir);
         let wal_path = data_path.join(WAL_DIR_NAME);
-        let data_wal =
-            RocksWalBuilder::with_default_rocksdb_config(wal_path, write_runtime.clone())
-                .build()
-                .context(OpenWal)?;
+        let data_wal = RocksWalBuilder::new(wal_path, write_runtime.clone())
+            .max_background_jobs(rocksdb_wal_config.sst_max_background_jobs)
+            .build()
+            .context(OpenWal)?;
 
         let manifest_path = data_path.join(MANIFEST_DIR_NAME);
-        let manifest_wal =
-            RocksWalBuilder::with_default_rocksdb_config(manifest_path, write_runtime)
-                .build()
-                .context(OpenManifestWal)?;
+        let manifest_wal = RocksWalBuilder::new(manifest_path, write_runtime)
+            .max_background_jobs(rocksdb_wal_config.manifest_max_background_jobs)
+            .build()
+            .context(OpenManifestWal)?;
         let opened_wals = OpenedWals {
             data_wal: Arc::new(data_wal),
             manifest_wal: Arc::new(manifest_wal),

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -183,12 +183,14 @@ impl WalsOpener for RocksDBWalsOpener {
         let wal_path = data_path.join(WAL_DIR_NAME);
         let data_wal = RocksWalBuilder::new(wal_path, write_runtime.clone())
             .max_background_jobs(rocksdb_wal_config.data_namespace.max_background_jobs)
+            .enable_statistics(rocksdb_wal_config.data_namespace.enable_statistics)
             .build()
             .context(OpenWal)?;
 
         let manifest_path = data_path.join(MANIFEST_DIR_NAME);
         let manifest_wal = RocksWalBuilder::new(manifest_path, write_runtime)
             .max_background_jobs(rocksdb_wal_config.meta_namespace.max_background_jobs)
+            .enable_statistics(rocksdb_wal_config.meta_namespace.enable_statistics)
             .build()
             .context(OpenManifestWal)?;
         let opened_wals = OpenedWals {

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -435,6 +435,7 @@ impl Builder {
             },
             wal: WalStorageConfig::RocksDB(Box::new(RocksDBConfig {
                 data_dir: dir.path().to_str().unwrap().to_string(),
+                ..Default::default()
             })),
             ..Default::default()
         };
@@ -495,6 +496,7 @@ impl Default for RocksDBEngineBuildContext {
 
             wal: WalStorageConfig::RocksDB(Box::new(RocksDBConfig {
                 data_dir: dir.path().to_str().unwrap().to_string(),
+                ..Default::default()
             })),
             ..Default::default()
         };
@@ -522,6 +524,7 @@ impl Clone for RocksDBEngineBuildContext {
         config.storage = storage;
         config.wal = WalStorageConfig::RocksDB(Box::new(RocksDBConfig {
             data_dir: dir.path().to_str().unwrap().to_string(),
+            ..Default::default()
         }));
 
         Self { config }

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -431,13 +431,11 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
                     &opened_wals
                         .data_wal
                         .get_statistics()
-                        .clone()
                         .unwrap_or_else(|| "Unknown".to_string()),
                     "Manifest wal stats:",
                     &opened_wals
                         .manifest_wal
                         .get_statistics()
-                        .clone()
                         .unwrap_or_else(|| "Unknown".to_string()),
                 ]
                 .join("\n")

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -340,6 +340,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             .schema_config_provider(provider.clone())
             .config_content(config_content)
             .router(router.clone())
+            .opened_wals(opened_wals.clone())
             .build()
             .context(HttpService {
                 msg: "build failed",

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -314,6 +314,11 @@ pub trait WalManager: Send + Sync + fmt::Debug + 'static {
 
     /// Scan all logs from a `Region`.
     async fn scan(&self, ctx: &ScanContext, req: &ScanRequest) -> Result<BatchLogIteratorAdapter>;
+
+    /// Get statistics
+    fn get_statistics(&self) -> Option<String> {
+        None
+    }
 }
 
 #[derive(Debug)]

--- a/wal/src/rocks_impl/config.rs
+++ b/wal/src/rocks_impl/config.rs
@@ -1,0 +1,23 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! RocksDB Config
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub max_background_jobs: i32,
+    pub enable_statistics: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            // Same with rocksdb
+            // https://github.com/facebook/rocksdb/blob/v6.4.6/include/rocksdb/options.h#L537
+            max_background_jobs: 2,
+            enable_statistics: false,
+        }
+    }
+}

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -522,36 +522,34 @@ impl RocksImpl {
 /// Builder for `RocksImpl`.
 pub struct Builder {
     wal_path: String,
-    rocksdb_config: DBOptions,
     runtime: Arc<Runtime>,
+    max_background_jobs: Option<i32>,
 }
 
 impl Builder {
-    pub fn with_default_rocksdb_config(
-        wal_path: impl Into<PathBuf>,
-        runtime: Arc<Runtime>,
-    ) -> Self {
-        let mut rocksdb_config = DBOptions::default();
-        // TODO(yingwen): Move to another function?
-        rocksdb_config.create_if_missing(true);
-        Self::new(wal_path, runtime, rocksdb_config)
-    }
-
-    pub fn new(
-        wal_path: impl Into<PathBuf>,
-        runtime: Arc<Runtime>,
-        rocksdb_config: DBOptions,
-    ) -> Self {
+    pub fn new(wal_path: impl Into<PathBuf>, runtime: Arc<Runtime>) -> Self {
         let wal_path: PathBuf = wal_path.into();
         Self {
             wal_path: wal_path.to_str().unwrap().to_owned(),
-            rocksdb_config,
             runtime,
+            max_background_jobs: None,
         }
     }
 
+    pub fn max_background_jobs(mut self, n: i32) -> Self {
+        self.max_background_jobs = Some(n);
+        self
+    }
+
     pub fn build(self) -> Result<RocksImpl> {
-        let db = DB::open(self.rocksdb_config, &self.wal_path)
+        let mut rocksdb_config = DBOptions::default();
+        rocksdb_config.create_if_missing(true);
+
+        if let Some(n) = self.max_background_jobs {
+            rocksdb_config.set_max_background_jobs(n);
+        }
+
+        let db = DB::open(rocksdb_config, &self.wal_path)
             .map_err(|e| e.into())
             .context(Open {
                 wal_path: self.wal_path.clone(),

--- a/wal/src/rocks_impl/mod.rs
+++ b/wal/src/rocks_impl/mod.rs
@@ -2,4 +2,5 @@
 
 //! WalManager implementation based on RocksDB
 
+pub mod config;
 pub mod manager;

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -53,8 +53,7 @@ impl WalBuilder for RocksWalBuilder {
     type Wal = RocksImpl;
 
     async fn build(&self, data_path: &Path, runtime: Arc<Runtime>) -> Arc<Self::Wal> {
-        let wal_builder =
-            rocks_impl::manager::Builder::with_default_rocksdb_config(data_path, runtime);
+        let wal_builder = rocks_impl::manager::Builder::new(data_path, runtime);
 
         Arc::new(
             wal_builder


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
Max background jobs is hard-code, expose an option to configure this.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Add new options for background jobs.
- Add new http endpoint for debugging `GET /debug/stats`, this require following config:
```
[analytic.wal.data_namespace]
enable_statistics = true
max_background_jobs = 8
```

<img width="766" alt="image" src="https://user-images.githubusercontent.com/3848910/230563943-7f2ec465-a72a-4a9c-b2f7-bab25acf1bf3.png">

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

