### PR TITLE
feat: serialize table operations by lock rather than queue

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Compaction.
 
@@ -11,7 +11,6 @@ use tokio::sync::oneshot;
 
 use crate::{
     compaction::picker::{CommonCompactionPicker, CompactionPickerRef},
-    instance::write_worker::CompactionNotifier,
     sst::file::{FileHandle, Level},
     table::data::TableDataRef,
     table_options::COMPACTION_STRATEGY,
@@ -429,18 +428,13 @@ impl Drop for WaiterNotifier {
 /// Request to compact single table.
 pub struct TableCompactionRequest {
     pub table_data: TableDataRef,
-    pub compaction_notifier: Option<CompactionNotifier>,
     pub waiter: Option<oneshot::Sender<WaitResult<()>>>,
 }
 
 impl TableCompactionRequest {
-    pub fn no_waiter(
-        table_data: TableDataRef,
-        compaction_notifier: Option<CompactionNotifier>,
-    ) -> Self {
+    pub fn no_waiter(table_data: TableDataRef) -> Self {
         TableCompactionRequest {
             table_data,
-            compaction_notifier,
             waiter: None,
         }
     }

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -645,8 +645,8 @@ impl ScheduleWorker {
             if last_flush_time + self.max_unflushed_duration.as_millis_u64()
                 > common_util::time::current_time_millis()
             {
-                let mut serializer = table_data.serializer.lock().await;
-                let flush_scheduler = serializer.flush_scheduler();
+                let mut serial_exec = table_data.serial_exec.lock().await;
+                let flush_scheduler = serial_exec.flush_scheduler();
                 // Instance flush the table asynchronously.
                 if let Err(e) = flusher
                     .schedule_flush(flush_scheduler, table_data, TableFlushOptions::default())

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -38,7 +38,8 @@ use crate::{
         PickerManager, TableCompactionRequest, WaitError, WaiterNotifier,
     },
     instance::{
-        flush_compaction::TableFlushOptions, write_worker::CompactionNotifier, Instance, SpaceStore,
+        flush_compaction::{Flusher, TableFlushOptions},
+        SpaceStore,
     },
     sst::factory::{ScanOptions, SstWriteOptions},
     table::data::TableDataRef,
@@ -458,7 +459,6 @@ impl ScheduleWorker {
         &self,
         table_data: TableDataRef,
         compaction_task: CompactionTask,
-        compaction_notifier: Option<CompactionNotifier>,
         waiter_notifier: WaiterNotifier,
         token: MemoryUsageToken,
     ) {
@@ -518,27 +518,18 @@ impl ScheduleWorker {
             // Notify the background compact table result.
             match res {
                 Ok(()) => {
-                    if let Some(notifier) = compaction_notifier.clone() {
-                        notifier.notify_ok();
-                    }
                     waiter_notifier.notify_wait_result(Ok(()));
 
                     if keep_scheduling_compaction {
                         schedule_table_compaction(
                             sender,
-                            TableCompactionRequest::no_waiter(
-                                table_data.clone(),
-                                compaction_notifier.clone(),
-                            ),
+                            TableCompactionRequest::no_waiter(table_data.clone()),
                         )
                         .await;
                     }
                 }
                 Err(e) => {
                     let e = Arc::new(e);
-                    if let Some(notifier) = compaction_notifier {
-                        notifier.notify_err(e.clone());
-                    }
 
                     let wait_err = WaitError::Compaction { source: e };
                     waiter_notifier.notify_wait_result(Err(wait_err));
@@ -612,16 +603,9 @@ impl ScheduleWorker {
             }
         };
 
-        let compaction_notifier = compact_req.compaction_notifier;
         let waiter_notifier = WaiterNotifier::new(compact_req.waiter);
 
-        self.do_table_compaction_task(
-            table_data,
-            compaction_task,
-            compaction_notifier,
-            waiter_notifier,
-            token,
-        );
+        self.do_table_compaction_task(table_data, compaction_task, waiter_notifier, token);
     }
 
     async fn schedule(&mut self) {
@@ -642,25 +626,31 @@ impl ScheduleWorker {
 
             // This will spawn a background job to purge ssts and avoid schedule thread
             // blocked.
-            self.handle_table_compaction_request(TableCompactionRequest::no_waiter(
-                table_data, None,
-            ))
-            .await;
+            self.handle_table_compaction_request(TableCompactionRequest::no_waiter(table_data))
+                .await;
         }
     }
 
     async fn flush_tables(&self) {
         let mut tables_buf = Vec::new();
         self.space_store.list_all_tables(&mut tables_buf);
+        let flusher = Flusher {
+            space_store: self.space_store.clone(),
+            runtime: self.runtime.clone(),
+            write_sst_max_buffer_size: self.write_sst_max_buffer_size,
+        };
 
         for table_data in &tables_buf {
             let last_flush_time = table_data.last_flush_time();
             if last_flush_time + self.max_unflushed_duration.as_millis_u64()
                 > common_util::time::current_time_millis()
             {
+                let mut serializer = table_data.serializer.lock().await;
+                let flush_scheduler = serializer.flush_scheduler();
                 // Instance flush the table asynchronously.
-                if let Err(e) =
-                    Instance::flush_table(table_data.clone(), TableFlushOptions::default()).await
+                if let Err(e) = flusher
+                    .schedule_flush(flush_scheduler, table_data, TableFlushOptions::default())
+                    .await
                 {
                     error!("Failed to flush table, err:{}", e);
                 }

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -1,14 +1,13 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Alter [Schema] and [TableOptions] logic of instance.
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use common_util::error::BoxError;
 use log::info;
 use snafu::{ensure, ResultExt};
 use table_engine::table::AlterSchemaRequest;
-use tokio::sync::oneshot;
 use wal::{kv_encoder::LogBatchEncoder, manager::WriteContext};
 
 use crate::{
@@ -16,66 +15,50 @@ use crate::{
         self,
         engine::{
             AlterDroppedTable, EncodePayloads, FlushTable, InvalidOptions, InvalidPreVersion,
-            InvalidSchemaVersion, OperateByWriteWorker, Result, WriteManifest, WriteWal,
+            InvalidSchemaVersion, Result, WriteManifest, WriteWal,
         },
         flush_compaction::TableFlushOptions,
-        write_worker,
-        write_worker::{AlterOptionsCommand, AlterSchemaCommand, WorkerLocal},
-        Instance,
+        serializer::TableOpSerializer,
+        InstanceRef,
     },
     manifest::meta_update::{AlterOptionsMeta, AlterSchemaMeta, MetaUpdate, MetaUpdateRequest},
     payload::WritePayload,
-    space::SpaceAndTable,
     table::data::TableDataRef,
     table_options,
 };
 
-impl Instance {
+pub struct Alterer<'a> {
+    table_data: TableDataRef,
+    serializer: &'a mut TableOpSerializer,
+
+    instance: InstanceRef,
+}
+
+impl<'a> Alterer<'a> {
+    pub async fn make(
+        table_data: TableDataRef,
+        serializer: &'a mut TableOpSerializer,
+        instance: InstanceRef,
+    ) -> Alterer<'a> {
+        assert_eq!(table_data.id, serializer.table_id());
+        Self {
+            table_data,
+            serializer,
+            instance,
+        }
+    }
+}
+
+impl<'a> Alterer<'a> {
     // Alter schema need to be handled by write worker.
-    pub async fn alter_schema_of_table(
-        &self,
-        space_table: &SpaceAndTable,
-        request: AlterSchemaRequest,
-    ) -> Result<()> {
+    pub async fn alter_schema_of_table(&mut self, request: AlterSchemaRequest) -> Result<()> {
         info!(
-            "Instance alter schema, space_table:{:?}, request:{:?}",
-            space_table, request
+            "Instance alter schema, table:{:?}, request:{:?}",
+            self.table_data.name, request
         );
 
-        // Create a oneshot channel to send/receive alter schema result.
-        let (tx, rx) = oneshot::channel();
-        let cmd = AlterSchemaCommand {
-            // space_table: space_table.clone(),
-            table_data: space_table.table_data().clone(),
-            request,
-            tx,
-        };
-
-        // Send alter schema request to write worker, actual works done in
-        // Self::process_alter_schema_command()
-        write_worker::process_command_in_write_worker(
-            cmd.into_command(),
-            space_table.table_data(),
-            rx,
-        )
-        .await
-        .context(OperateByWriteWorker {
-            space_id: space_table.space().id,
-            table: &space_table.table_data().name,
-            table_id: space_table.table_data().id,
-        })
-    }
-
-    /// Do the actual alter schema job, must called by write worker in write
-    /// thread sequentially.
-    pub(crate) async fn process_alter_schema_command(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
-        table_data: &TableDataRef,
-        request: AlterSchemaRequest,
-    ) -> Result<()> {
         // Validate alter schema request.
-        self.validate_before_alter(table_data, &request)?;
+        self.validate_before_alter(&request)?;
 
         // Now we can persist and update the schema, since this function is called by
         // write worker, so there is no other concurrent writer altering the
@@ -83,22 +66,22 @@ impl Instance {
 
         // First trigger a flush before alter schema, to ensure ensure all wal entries
         // with old schema are flushed
-        let opts = TableFlushOptions {
-            block_on_write_thread: true,
-            ..Default::default()
-        };
-        self.flush_table_in_worker(worker_local, table_data, opts)
+        let opts = TableFlushOptions::default();
+        let flush_scheduler = self.serializer.flush_scheduler();
+        let flusher = self.instance.make_flusher();
+        flusher
+            .do_flush(flush_scheduler, &self.table_data, opts)
             .await
             .context(FlushTable {
-                space_id: table_data.space_id,
-                table: &table_data.name,
-                table_id: table_data.id,
+                space_id: self.table_data.space_id,
+                table: &self.table_data.name,
+                table_id: self.table_data.id,
             })?;
 
         // Build alter op
         let manifest_update = AlterSchemaMeta {
-            space_id: table_data.space_id,
-            table_id: table_data.id,
+            space_id: self.table_data.space_id,
+            table_id: self.table_data.id,
             schema: request.schema.clone(),
             pre_schema_version: request.pre_schema_version,
         };
@@ -108,26 +91,27 @@ impl Instance {
         let payload = WritePayload::AlterSchema(&alter_schema_pb);
 
         // Encode payloads
-        let table_location = table_data.table_location();
+        let table_location = self.table_data.table_location();
         let wal_location =
             instance::create_wal_location(table_location.id, table_location.shard_info);
         let log_batch_encoder = LogBatchEncoder::create(wal_location);
         let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
-            table: &table_data.name,
+            table: &self.table_data.name,
             wal_location,
         })?;
 
         // Write log batch
         let write_ctx = WriteContext::default();
-        self.space_store
+        self.instance
+            .space_store
             .wal_manager
             .write(&write_ctx, &log_batch)
             .await
             .box_err()
             .context(WriteWal {
-                space_id: table_data.space_id,
-                table: &table_data.name,
-                table_id: table_data.id,
+                space_id: self.table_data.space_id,
+                table: &self.table_data.name,
+                table_id: self.table_data.id,
             })?;
 
         info!(
@@ -139,45 +123,42 @@ impl Instance {
         let update_req = {
             let meta_update = MetaUpdate::AlterSchema(manifest_update);
             MetaUpdateRequest {
-                shard_info: table_data.shard_info,
+                shard_info: self.table_data.shard_info,
                 meta_update,
             }
         };
-        self.space_store
+        self.instance
+            .space_store
             .manifest
             .store_update(update_req)
             .await
             .context(WriteManifest {
-                space_id: table_data.space_id,
-                table: &table_data.name,
-                table_id: table_data.id,
+                space_id: self.table_data.space_id,
+                table: &self.table_data.name,
+                table_id: self.table_data.id,
             })?;
 
         // Update schema in memory.
-        table_data.set_schema(request.schema);
+        self.table_data.set_schema(request.schema);
 
         Ok(())
     }
 
     // Most validation should be done by catalog module, so we don't do too much
     // duplicate check here, especially the schema compatibility.
-    fn validate_before_alter(
-        &self,
-        table_data: &TableDataRef,
-        request: &AlterSchemaRequest,
-    ) -> Result<()> {
+    fn validate_before_alter(&self, request: &AlterSchemaRequest) -> Result<()> {
         ensure!(
-            !table_data.is_dropped(),
+            !self.table_data.is_dropped(),
             AlterDroppedTable {
-                table: &table_data.name,
+                table: &self.table_data.name,
             }
         );
 
-        let current_version = table_data.schema_version();
+        let current_version = self.table_data.schema_version();
         ensure!(
             current_version < request.schema.version(),
             InvalidSchemaVersion {
-                table: &table_data.name,
+                table: &self.table_data.name,
                 current_version,
                 given_version: request.schema.version(),
             }
@@ -186,7 +167,7 @@ impl Instance {
         ensure!(
             current_version == request.pre_schema_version,
             InvalidPreVersion {
-                table: &table_data.name,
+                table: &self.table_data.name,
                 current_version,
                 pre_version: request.pre_schema_version,
             }
@@ -197,73 +178,41 @@ impl Instance {
 
     pub async fn alter_options_of_table(
         &self,
-        space_table: &SpaceAndTable,
         // todo: encapsulate this into a struct like other functions.
         options: HashMap<String, String>,
     ) -> Result<()> {
         info!(
-            "Instance alter options of table, space_table:{:?}, options:{:?}",
-            space_table, options
+            "Instance alter options of table, table:{:?}, options:{:?}",
+            self.table_data.name, options
         );
 
-        // Create a oneshot channel to send/receive alter options result.
-        let (tx, rx) = oneshot::channel();
-        let cmd = AlterOptionsCommand {
-            table_data: space_table.table_data().clone(),
-            options,
-            tx,
-        };
-
-        // Send alter options request to write worker, actual works done in
-        // Self::process_alter_options_command()
-        write_worker::process_command_in_write_worker(
-            cmd.into_command(),
-            space_table.table_data(),
-            rx,
-        )
-        .await
-        .context(OperateByWriteWorker {
-            space_id: space_table.space().id,
-            table: &space_table.table_data().name,
-            table_id: space_table.table_data().id,
-        })
-    }
-
-    /// Do the actual alter options job, must called by write worker in write
-    /// thread sequentially.
-    pub(crate) async fn process_alter_options_command(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
-        table_data: &TableDataRef,
-        options: HashMap<String, String>,
-    ) -> Result<()> {
         ensure!(
-            !table_data.is_dropped(),
+            !self.table_data.is_dropped(),
             AlterDroppedTable {
-                table: &table_data.name,
+                table: &self.table_data.name,
             }
         );
 
         // AlterOptions doesn't need a flush.
 
         // Generate options after alter op
-        let current_table_options = table_data.table_options();
+        let current_table_options = self.table_data.table_options();
         info!(
             "Instance alter options, space_id:{}, tables:{:?}, old_table_opts:{:?}, options:{:?}",
-            table_data.space_id, table_data.name, current_table_options, options
+            self.table_data.space_id, self.table_data.name, current_table_options, options
         );
         let mut table_opts =
             table_options::merge_table_options_for_alter(&options, &current_table_options)
                 .box_err()
                 .context(InvalidOptions {
-                    space_id: table_data.space_id,
-                    table: &table_data.name,
-                    table_id: table_data.id,
+                    space_id: self.table_data.space_id,
+                    table: &self.table_data.name,
+                    table_id: self.table_data.id,
                 })?;
         table_opts.sanitize();
         let manifest_update = AlterOptionsMeta {
-            space_id: table_data.space_id,
-            table_id: table_data.id,
+            space_id: self.table_data.space_id,
+            table_id: self.table_data.id,
             options: table_opts.clone(),
         };
 
@@ -276,48 +225,51 @@ impl Instance {
         let payload = WritePayload::AlterOption(&alter_options_pb);
 
         // Encode payload
-        let table_location = table_data.table_location();
+        let table_location = self.table_data.table_location();
         let wal_location =
             instance::create_wal_location(table_location.id, table_location.shard_info);
         let log_batch_encoder = LogBatchEncoder::create(wal_location);
         let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
-            table: &table_data.name,
+            table: &self.table_data.name,
             wal_location,
         })?;
 
         // Write log batch
         let write_ctx = WriteContext::default();
-        self.space_store
+        self.instance
+            .space_store
             .wal_manager
             .write(&write_ctx, &log_batch)
             .await
             .box_err()
             .context(WriteWal {
-                space_id: table_data.space_id,
-                table: &table_data.name,
-                table_id: table_data.id,
+                space_id: self.table_data.space_id,
+                table: &self.table_data.name,
+                table_id: self.table_data.id,
             })?;
 
         // Write to Manifest
         let update_req = {
             let meta_update = MetaUpdate::AlterOptions(manifest_update);
             MetaUpdateRequest {
-                shard_info: table_data.shard_info,
+                shard_info: self.table_data.shard_info,
                 meta_update,
             }
         };
-        self.space_store
+        self.instance
+            .space_store
             .manifest
             .store_update(update_req)
             .await
             .context(WriteManifest {
-                space_id: table_data.space_id,
-                table: &table_data.name,
-                table_id: table_data.id,
+                space_id: self.table_data.space_id,
+                table: &self.table_data.name,
+                table_id: self.table_data.id,
             })?;
 
         // Update memory status
-        table_data.set_table_options(worker_local, table_opts);
+        self.table_data.set_table_options(table_opts);
+
         Ok(())
     }
 }

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -35,7 +35,7 @@ pub struct Alterer<'a> {
 }
 
 impl<'a> Alterer<'a> {
-    pub async fn make(
+    pub async fn new(
         table_data: TableDataRef,
         serializer: &'a mut TableOpSerializer,
         instance: InstanceRef,

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -1,55 +1,33 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Close table logic of instance
-
-use std::sync::Arc;
 
 use log::{info, warn};
 use snafu::ResultExt;
 use table_engine::engine::CloseTableRequest;
-use tokio::sync::oneshot;
 
 use crate::{
     instance::{
-        engine::{DoManifestSnapshot, FlushTable, OperateByWriteWorker, Result},
-        flush_compaction::TableFlushOptions,
-        write_worker::{self, CloseTableCommand, WorkerLocal},
-        Instance,
+        engine::{DoManifestSnapshot, FlushTable, Result},
+        flush_compaction::{Flusher, TableFlushOptions},
     },
-    manifest::SnapshotRequest,
+    manifest::{ManifestRef, SnapshotRequest},
     space::SpaceRef,
 };
 
-impl Instance {
+pub(crate) struct Closer {
+    pub space: SpaceRef,
+    pub manifest: ManifestRef,
+
+    pub flusher: Flusher,
+}
+
+impl Closer {
     /// Close table need to be handled by write worker.
-    pub async fn do_close_table(&self, space: SpaceRef, request: CloseTableRequest) -> Result<()> {
-        info!("Instance close table, request:{:?}", request);
+    pub async fn close(&self, request: CloseTableRequest) -> Result<()> {
+        info!("Try to close table, request:{:?}", request);
 
-        let table_data = match space.find_table_by_id(request.table_id) {
-            Some(v) => v,
-            None => return Ok(()),
-        };
-
-        let (tx, rx) = oneshot::channel::<Result<()>>();
-        let cmd = CloseTableCommand { space, request, tx };
-        write_worker::process_command_in_write_worker(cmd.into_command(), &table_data, rx)
-            .await
-            .context(OperateByWriteWorker {
-                space_id: table_data.space_id,
-                table: &table_data.name,
-                table_id: table_data.id,
-            })
-    }
-
-    /// Do the actual close table job, must be called by write worker in write
-    /// thread sequentially.
-    pub(crate) async fn process_close_table_command(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
-        space: SpaceRef,
-        request: CloseTableRequest,
-    ) -> Result<()> {
-        let table_data = match space.find_table_by_id(request.table_id) {
+        let table_data = match self.space.find_table_by_id(request.table_id) {
             Some(v) => v,
             None => {
                 warn!("try to close a closed table, request:{:?}", request);
@@ -58,42 +36,40 @@ impl Instance {
         };
 
         // Flush table.
-        let opts = TableFlushOptions {
-            block_on_write_thread: true,
-            // The table will be dropped, no need to trigger a compaction.
-            compact_after_flush: false,
-            ..Default::default()
-        };
-        self.flush_table_in_worker(worker_local, &table_data, opts)
+        let opts = TableFlushOptions::default();
+        let mut serializer = table_data.serializer.lock().await;
+        let flush_scheduler = serializer.flush_scheduler();
+
+        self.flusher
+            .do_flush(flush_scheduler, &table_data, opts)
             .await
             .context(FlushTable {
-                space_id: space.id,
+                space_id: self.space.id,
                 table: &table_data.name,
                 table_id: table_data.id,
             })?;
 
         // Force manifest to do snapshot.
         let snapshot_request = SnapshotRequest {
-            space_id: space.id,
+            space_id: self.space.id,
             table_id: table_data.id,
             shard_id: table_data.shard_info.shard_id,
         };
-        self.space_store
-            .manifest
+        self.manifest
             .do_snapshot(snapshot_request)
             .await
             .context(DoManifestSnapshot {
-                space_id: space.id,
+                space_id: self.space.id,
                 table: &table_data.name,
             })?;
 
         // Table has been closed so remove it from the space.
-        let removed_table = space.remove_table(&request.table_name);
+        let removed_table = self.space.remove_table(&request.table_name);
         assert!(removed_table.is_some());
 
         info!(
             "table:{}-{} has been removed from the space_id:{}",
-            table_data.name, table_data.id, space.id
+            table_data.name, table_data.id, self.space.id
         );
         Ok(())
     }

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -37,8 +37,8 @@ impl Closer {
 
         // Flush table.
         let opts = TableFlushOptions::default();
-        let mut serializer = table_data.serializer.lock().await;
-        let flush_scheduler = serializer.flush_scheduler();
+        let mut serial_exec = table_data.serial_exec.lock().await;
+        let flush_scheduler = serial_exec.flush_scheduler();
 
         self.flusher
             .do_flush(flush_scheduler, &table_data, opts)

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -36,7 +36,7 @@ impl Dropper {
             }
         };
 
-        let mut serializer = table_data.serializer.lock().await;
+        let mut serial_exec = table_data.serial_exec.lock().await;
 
         if table_data.is_dropped() {
             warn!(
@@ -50,7 +50,7 @@ impl Dropper {
         //  is marked for deletable. However, the overhead of the flushing can
         //  be avoided.
         let opts = TableFlushOptions::default();
-        let flush_scheduler = serializer.flush_scheduler();
+        let flush_scheduler = serial_exec.flush_scheduler();
         self.flusher
             .do_flush(flush_scheduler, &table_data, opts)
             .await

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -2,7 +2,7 @@
 
 // Flush and compaction logic of instance
 
-use std::{cmp, collections::Bound, sync::Arc};
+use std::{cmp, collections::Bound, fmt, sync::Arc};
 
 use common_types::{
     projected_schema::ProjectedSchema,
@@ -16,7 +16,7 @@ use common_util::{
     config::ReadableDuration,
     define_result,
     error::{BoxError, GenericError},
-    runtime::Runtime,
+    runtime::{Runtime, RuntimeRef},
     time,
 };
 use futures::{
@@ -32,13 +32,10 @@ use wal::manager::WalLocation;
 
 use crate::{
     compaction::{
-        CompactionInputFiles, CompactionTask, ExpiredFiles, TableCompactionRequest, WaitError,
+        scheduler::CompactionSchedulerRef, CompactionInputFiles, CompactionTask, ExpiredFiles,
+        TableCompactionRequest,
     },
-    instance::{
-        self,
-        write_worker::{self, CompactTableCommand, FlushTableCommand, WorkerLocal},
-        Instance, SpaceStore,
-    },
+    instance::{self, serializer::TableFlushScheduler, SpaceStore, SpaceStoreRef},
     manifest::meta_update::{AlterOptionsMeta, MetaUpdate, MetaUpdateRequest, VersionEditMeta},
     memtable::{ColumnarIterPtr, MemTableRef, ScanContext, ScanRequest},
     row_iter::{
@@ -47,7 +44,6 @@ use crate::{
         merge::{MergeBuilder, MergeConfig},
         IterOptions,
     },
-    space::SpaceAndTable,
     sst::{
         factory::{self, ReadFrequency, ScanOptions, SstReadOptions, SstWriteOptions},
         file::FileMeta,
@@ -97,20 +93,12 @@ pub enum Error {
     #[snafu(display("Failed to write sst, file_path:{}, source:{}", path, source))]
     WriteSst { path: String, source: GenericError },
 
-    #[snafu(display("Background flush failed, cannot schedule flush task, err:{}", source))]
-    BackgroundFlushFailed {
-        source: crate::instance::write_worker::Error,
-    },
-
-    #[snafu(display("Failed to send flush command, err:{}", source))]
-    SendFlushCmd {
-        source: crate::instance::write_worker::Error,
-    },
-
-    #[snafu(display("Failed to send compact command, err:{}", source))]
-    SendCompactCmd {
-        source: crate::instance::write_worker::Error,
-    },
+    #[snafu(display(
+        "Background flush failed, cannot write more data, err:{}.\nBacktrace:\n{}",
+        msg,
+        backtrace
+    ))]
+    BackgroundFlushFailed { msg: String, backtrace: Backtrace },
 
     #[snafu(display("Failed to build merge iterator, table:{}, err:{}", table, source))]
     BuildMergeIterator {
@@ -139,37 +127,29 @@ pub enum Error {
 
     #[snafu(display("Other failure, msg:{}.\nBacktrace:\n{:?}", msg, backtrace))]
     Other { msg: String, backtrace: Backtrace },
-
-    #[snafu(display("Unknown flush policy.\nBacktrace:\n{:?}", backtrace))]
-    UnknownPolicy { backtrace: Backtrace },
 }
 
 define_result!(Error);
 
 /// Options to flush single table.
-#[derive(Debug)]
+#[derive(Default)]
 pub struct TableFlushOptions {
     /// Flush result sender.
     ///
     /// Default is None.
     pub res_sender: Option<oneshot::Sender<TableResult<()>>>,
-    /// Schedule a compaction request after flush.
+    /// Schedule a compaction request after flush if it is not [None].
     ///
-    /// Default is true.
-    pub compact_after_flush: bool,
-    /// Whether to block on write thread.
-    ///
-    /// Default is false.
-    pub block_on_write_thread: bool,
+    /// If it is [None], no compaction will be scheduled.
+    pub compact_after_flush: Option<CompactionSchedulerRef>,
 }
 
-impl Default for TableFlushOptions {
-    fn default() -> Self {
-        Self {
-            res_sender: None,
-            compact_after_flush: true,
-            block_on_write_thread: false,
-        }
+impl fmt::Debug for TableFlushOptions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TableFlushOptions")
+            .field("res_sender", &self.res_sender.is_some())
+            .field("compact_after_flush", &self.compact_after_flush.is_some())
+            .finish()
     }
 }
 
@@ -181,94 +161,66 @@ pub struct TableFlushRequest {
     pub max_sequence: SequenceNumber,
 }
 
-impl Instance {
-    /// Flush this table.
-    pub async fn flush_table(
-        table_data: TableDataRef,
-        flush_opts: TableFlushOptions,
-    ) -> Result<()> {
-        info!(
-            "Instance flush table, table_data:{:?}, flush_opts:{:?}",
-            table_data, flush_opts
-        );
+pub struct Flusher {
+    pub space_store: SpaceStoreRef,
 
-        // Create a oneshot channel to send/receive flush result.
-        let (tx, rx) = oneshot::channel();
-        let cmd = FlushTableCommand {
-            table_data: table_data.clone(),
-            flush_opts,
-            tx,
-        };
+    pub runtime: RuntimeRef,
+    pub write_sst_max_buffer_size: usize,
+}
 
-        // Actual work is done in flush_table_in_worker().
-        write_worker::process_command_in_write_worker(cmd.into_command(), &table_data, rx)
-            .await
-            .context(SendFlushCmd)
-    }
+struct FlushTask {
+    space_store: SpaceStoreRef,
+    table_data: TableDataRef,
+    max_sequence: SequenceNumber,
 
-    /// Compact the table manually.
-    pub async fn manual_compact_table(&self, space_table: &SpaceAndTable) -> Result<()> {
-        info!("Instance compact table, space_table:{:?}", space_table);
+    runtime: RuntimeRef,
+    write_sst_max_buffer_size: usize,
+}
 
-        // Create a oneshot channel to send/receive result from write worker.
-        let (tx, rx) = oneshot::channel();
-        let (compact_tx, compact_rx) = oneshot::channel();
-        // Create a oneshot channel to send/receive compaction result.
-        let cmd = CompactTableCommand {
-            table_data: space_table.table_data().clone(),
-            waiter: Some(compact_tx),
-            tx,
-        };
-
-        // The write worker will call schedule_table_compaction().
-        write_worker::process_command_in_write_worker(
-            cmd.into_command(),
-            space_table.table_data(),
-            rx,
-        )
-        .await
-        .context(SendCompactCmd)?;
-
-        // Now wait for compaction done, if the sender has been dropped, we convert it
-        // into Error::Canceled.
-        compact_rx
-            .await
-            .unwrap_or(Err(WaitError::Canceled))
-            .context(ManualCompactFailed)
-    }
-
-    /// Flush given table in write worker thread.
-    pub(crate) async fn flush_table_in_worker(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
+impl Flusher {
+    /// Schedule a flush request.
+    pub async fn schedule_flush(
+        &self,
+        flush_scheduler: &mut TableFlushScheduler,
         table_data: &TableDataRef,
         opts: TableFlushOptions,
     ) -> Result<()> {
-        let flush_req = self.preprocess_flush(worker_local, table_data).await?;
+        info!(
+            "Instance flush table, table_data:{:?}, flush_opts:{:?}",
+            table_data, opts
+        );
 
-        self.schedule_table_flush(worker_local, flush_req, opts)
+        let flush_req = self.preprocess_flush(table_data).await?;
+
+        self.schedule_table_flush(flush_scheduler, flush_req, opts, false)
             .await
     }
 
-    async fn preprocess_flush(
+    /// Do flush and wait for it to finish.
+    pub async fn do_flush(
         &self,
-        worker_local: &mut WorkerLocal,
+        flush_scheduler: &mut TableFlushScheduler,
         table_data: &TableDataRef,
-    ) -> Result<TableFlushRequest> {
-        worker_local
-            .ensure_permission(
-                &table_data.name,
-                table_data.id.as_u64() as usize,
-                self.write_group_worker_num,
-            )
-            .context(BackgroundFlushFailed)?;
+        opts: TableFlushOptions,
+    ) -> Result<()> {
+        info!(
+            "Instance flush table, table_data:{:?}, flush_opts:{:?}",
+            table_data, opts
+        );
 
+        let flush_req = self.preprocess_flush(table_data).await?;
+
+        self.schedule_table_flush(flush_scheduler, flush_req, opts, true)
+            .await
+    }
+
+    async fn preprocess_flush(&self, table_data: &TableDataRef) -> Result<TableFlushRequest> {
         let current_version = table_data.current_version();
         let last_sequence = table_data.last_sequence();
         // Switch (freeze) all mutable memtables. And update segment duration if
         // suggestion is returned.
         if let Some(suggest_segment_duration) =
-            current_version.switch_memtables_or_suggest_duration(worker_local)
+            current_version.switch_memtables_or_suggest_duration()
         {
             info!(
                 "Update segment duration, table:{}, table_id:{}, segment_duration:{:?}",
@@ -279,8 +231,6 @@ impl Instance {
             let mut new_table_opts = (*table_data.table_options()).clone();
             new_table_opts.segment_duration = Some(ReadableDuration(suggest_segment_duration));
 
-            // Now persist the new options, the `worker_local` ensure there is no race
-            // condition.
             let update_req = {
                 let meta_update = MetaUpdate::AlterOptions(AlterOptionsMeta {
                     space_id: table_data.space_id,
@@ -298,11 +248,11 @@ impl Instance {
                 .await
                 .context(StoreVersionEdit)?;
 
-            table_data.set_table_options(worker_local, new_table_opts);
+            table_data.set_table_options(new_table_opts);
 
             // Now the segment duration is applied, we can stop sampling and freeze the
             // sampling memtable.
-            current_version.freeze_sampling(worker_local);
+            current_version.freeze_sampling();
         }
 
         info!("Try to trigger memtable flush of table, table:{}, table_id:{}, max_memtable_id:{}, last_sequence:{}",
@@ -317,67 +267,69 @@ impl Instance {
 
     /// Schedule table flush request to background workers
     async fn schedule_table_flush(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
+        &self,
+        flush_scheduler: &mut TableFlushScheduler,
         flush_req: TableFlushRequest,
         opts: TableFlushOptions,
+        block_on: bool,
     ) -> Result<()> {
-        // TODO(yingwen): Store pending flush reqs and retry flush on recoverable error,
-        // or try to recover from background error
         let table_data = flush_req.table_data.clone();
         let table = table_data.name.clone();
 
-        let instance = self.clone();
-        let flush_job = async move { instance.flush_memtables(&flush_req).await };
+        let flush_task = FlushTask {
+            table_data: table_data.clone(),
+            max_sequence: flush_req.max_sequence,
+            space_store: self.space_store.clone(),
+            runtime: self.runtime.clone(),
+            write_sst_max_buffer_size: self.write_sst_max_buffer_size,
+        };
+        let flush_job = async move { flush_task.run().await };
 
-        let compact_req = TableCompactionRequest::no_waiter(
-            table_data.clone(),
-            Some(worker_local.compaction_notifier()),
-        );
-        let instance = self.clone();
-
-        if opts.compact_after_flush {
+        // TODO: The immediate compaction after flush is not a good idea because it may
+        // block on the write procedure.
+        if let Some(compaction_scheduler) = opts.compact_after_flush {
             // Schedule compaction if flush completed successfully.
+            let compact_req = TableCompactionRequest::no_waiter(table_data.clone());
             let on_flush_success = async move {
                 // Here we don't care whether it is scheduled successfully or not.
-                instance.schedule_table_compaction(compact_req).await;
+                compaction_scheduler
+                    .schedule_table_compaction(compact_req)
+                    .await;
             };
 
-            worker_local
+            flush_scheduler
                 .flush_sequentially(
                     table,
                     &table_data.metrics,
                     flush_job,
                     on_flush_success,
-                    opts.block_on_write_thread,
+                    block_on,
+                    &self.runtime,
                     opts.res_sender,
                 )
                 .await
-                .context(BackgroundFlushFailed)
         } else {
-            worker_local
+            flush_scheduler
                 .flush_sequentially(
                     table,
                     &table_data.metrics,
                     flush_job,
                     async {},
-                    opts.block_on_write_thread,
+                    block_on,
+                    &self.runtime,
                     opts.res_sender,
                 )
                 .await
-                .context(BackgroundFlushFailed)
         }
     }
+}
 
-    /// Each table can only have one running flush job.
-    async fn flush_memtables(&self, flush_req: &TableFlushRequest) -> Result<()> {
-        let TableFlushRequest {
-            table_data,
-            max_sequence,
-        } = flush_req;
-
-        let current_version = table_data.current_version();
-        let mems_to_flush = current_version.pick_memtables_to_flush(*max_sequence);
+impl FlushTask {
+    /// Each table can only have one running flush task at the same time, which
+    /// should be ensured by the caller.
+    async fn run(&self) -> Result<()> {
+        let current_version = self.table_data.current_version();
+        let mems_to_flush = current_version.pick_memtables_to_flush(self.max_sequence);
 
         if mems_to_flush.is_empty() {
             return Ok(());
@@ -386,20 +338,20 @@ impl Instance {
         let request_id = RequestId::next_id();
         info!(
             "Instance try to flush memtables, table:{}, table_id:{}, request_id:{}, mems_to_flush:{:?}",
-            table_data.name, table_data.id, request_id, mems_to_flush
+            self.table_data.name, self.table_data.id, request_id, mems_to_flush
         );
 
         // Start flush duration timer.
-        let local_metrics = table_data.metrics.local_flush_metrics();
+        let local_metrics = self.table_data.metrics.local_flush_metrics();
         let _timer = local_metrics.start_flush_timer();
-        self.dump_memtables(table_data, request_id, &mems_to_flush)
-            .await?;
+        self.dump_memtables(request_id, &mems_to_flush).await?;
 
-        table_data.set_last_flush_time(time::current_time_millis());
+        self.table_data
+            .set_last_flush_time(time::current_time_millis());
 
         info!(
             "Instance flush memtables done, table:{}, table_id:{}, request_id:{}",
-            table_data.name, table_data.id, request_id
+            self.table_data.name, self.table_data.id, request_id
         );
 
         Ok(())
@@ -413,11 +365,10 @@ impl Instance {
     /// number in dumped memtables will be sent to the [WalManager].
     async fn dump_memtables(
         &self,
-        table_data: &TableData,
         request_id: RequestId,
         mems_to_flush: &FlushableMemTables,
     ) -> Result<()> {
-        let local_metrics = table_data.metrics.local_flush_metrics();
+        let local_metrics = self.table_data.metrics.local_flush_metrics();
         let mut files_to_level0 = Vec::with_capacity(mems_to_flush.memtables.len());
         let mut flushed_sequence = 0;
         let mut sst_num = 0;
@@ -425,7 +376,7 @@ impl Instance {
         // process sampling memtable and frozen memtable
         if let Some(sampling_mem) = &mems_to_flush.sampling_mem {
             if let Some(seq) = self
-                .dump_sampling_memtable(table_data, request_id, sampling_mem, &mut files_to_level0)
+                .dump_sampling_memtable(request_id, sampling_mem, &mut files_to_level0)
                 .await?
             {
                 flushed_sequence = seq;
@@ -436,9 +387,7 @@ impl Instance {
             }
         }
         for mem in &mems_to_flush.memtables {
-            let file = self
-                .dump_normal_memtable(table_data, request_id, mem)
-                .await?;
+            let file = self.dump_normal_memtable(request_id, mem).await?;
             if let Some(file) = file {
                 let sst_size = file.size;
                 files_to_level0.push(AddFile { level: 0, file });
@@ -457,8 +406,8 @@ impl Instance {
 
         info!(
             "Instance flush memtables to output, table:{}, table_id:{}, request_id:{}, mems_to_flush:{:?}, files_to_level0:{:?}, flushed_sequence:{}",
-            table_data.name,
-            table_data.id,
+            self.table_data.name,
+            self.table_data.id,
             request_id,
             mems_to_flush,
             files_to_level0,
@@ -468,15 +417,15 @@ impl Instance {
         // Persist the flush result to manifest.
         let update_req = {
             let edit_meta = VersionEditMeta {
-                space_id: table_data.space_id,
-                table_id: table_data.id,
+                space_id: self.table_data.space_id,
+                table_id: self.table_data.id,
                 flushed_sequence,
                 files_to_add: files_to_level0.clone(),
                 files_to_delete: vec![],
             };
             let meta_update = MetaUpdate::VersionEdit(edit_meta);
             MetaUpdateRequest {
-                shard_info: table_data.shard_info,
+                shard_info: self.table_data.shard_info,
                 meta_update,
             }
         };
@@ -494,10 +443,10 @@ impl Instance {
             files_to_add: files_to_level0,
             files_to_delete: vec![],
         };
-        table_data.current_version().apply_edit(edit);
+        self.table_data.current_version().apply_edit(edit);
 
         // Mark sequence <= flushed_sequence to be deleted.
-        let table_location = table_data.table_location();
+        let table_location = self.table_data.table_location();
         let wal_location =
             instance::create_wal_location(table_location.id, table_location.shard_info);
         self.space_store
@@ -518,7 +467,6 @@ impl Instance {
     /// Returns flushed sequence.
     async fn dump_sampling_memtable(
         &self,
-        table_data: &TableData,
         request_id: RequestId,
         sampling_mem: &SamplingMemTable,
         files_to_level0: &mut Vec<AddFile>,
@@ -535,24 +483,24 @@ impl Instance {
         let time_ranges = sampling_mem.sampler.ranges();
 
         info!("Flush sampling memtable, table_id:{:?}, table_name:{:?}, request_id:{}, sampling memtable time_ranges:{:?}",
-            table_data.id,table_data.name, request_id, time_ranges);
+            self.table_data.id, self.table_data.name, request_id, time_ranges);
 
         let mut batch_record_senders = Vec::with_capacity(time_ranges.len());
         let mut sst_handlers = Vec::with_capacity(time_ranges.len());
         let mut file_ids = Vec::with_capacity(time_ranges.len());
 
         let sst_write_options = SstWriteOptions {
-            storage_format_hint: table_data.table_options().storage_format_hint,
-            num_rows_per_row_group: table_data.table_options().num_rows_per_row_group,
-            compression: table_data.table_options().compression,
+            storage_format_hint: self.table_data.table_options().storage_format_hint,
+            num_rows_per_row_group: self.table_data.table_options().num_rows_per_row_group,
+            compression: self.table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
         };
 
         for time_range in &time_ranges {
             let (batch_record_sender, batch_record_receiver) =
                 channel::<Result<RecordBatchWithKey>>(DEFAULT_CHANNEL_SIZE);
-            let file_id = table_data.alloc_file_id();
-            let sst_file_path = table_data.set_sst_file_path(file_id);
+            let file_id = self.table_data.alloc_file_id();
+            let sst_file_path = self.table_data.set_sst_file_path(file_id);
 
             // TODO: `min_key` & `max_key` should be figured out when writing sst.
             let sst_meta = MetaData {
@@ -560,15 +508,15 @@ impl Instance {
                 max_key: max_key.clone(),
                 time_range: *time_range,
                 max_sequence,
-                schema: table_data.schema(),
+                schema: self.table_data.schema(),
             };
 
             let store = self.space_store.clone();
-            let storage_format_hint = table_data.table_options().storage_format_hint;
+            let storage_format_hint = self.table_data.table_options().storage_format_hint;
             let sst_write_options = sst_write_options.clone();
 
             // spawn build sst
-            let handler = self.runtimes.write_runtime.spawn(async move {
+            let handler = self.runtime.spawn(async move {
                 let mut writer = store
                     .sst_factory
                     .create_writer(&sst_write_options, &sst_file_path, store.store_picker())
@@ -600,9 +548,9 @@ impl Instance {
             file_ids.push(file_id);
         }
 
-        let iter = build_mem_table_iter(sampling_mem.mem.clone(), table_data)?;
+        let iter = build_mem_table_iter(sampling_mem.mem.clone(), &self.table_data)?;
 
-        let timestamp_idx = table_data.schema().timestamp_index();
+        let timestamp_idx = self.table_data.schema().timestamp_index();
 
         for data in iter {
             for (idx, record_batch) in split_record_batch_with_time_ranges(
@@ -645,7 +593,6 @@ impl Instance {
     /// Flush rows in normal (non-sampling) memtable to at most one sst file.
     async fn dump_normal_memtable(
         &self,
-        table_data: &TableData,
         request_id: RequestId,
         memtable_state: &MemTableState,
     ) -> Result<Option<FileMeta>> {
@@ -663,18 +610,18 @@ impl Instance {
             max_key,
             time_range: memtable_state.time_range,
             max_sequence,
-            schema: table_data.schema(),
+            schema: self.table_data.schema(),
         };
 
         // Alloc file id for next sst file
-        let file_id = table_data.alloc_file_id();
-        let sst_file_path = table_data.set_sst_file_path(file_id);
+        let file_id = self.table_data.alloc_file_id();
+        let sst_file_path = self.table_data.set_sst_file_path(file_id);
 
-        let storage_format_hint = table_data.table_options().storage_format_hint;
+        let storage_format_hint = self.table_data.table_options().storage_format_hint;
         let sst_write_options = SstWriteOptions {
             storage_format_hint,
-            num_rows_per_row_group: table_data.table_options().num_rows_per_row_group,
-            compression: table_data.table_options().compression,
+            num_rows_per_row_group: self.table_data.table_options().num_rows_per_row_group,
+            compression: self.table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
         };
         let mut writer = self
@@ -690,7 +637,7 @@ impl Instance {
                 storage_format_hint,
             })?;
 
-        let iter = build_mem_table_iter(memtable_state.mem.clone(), table_data)?;
+        let iter = build_mem_table_iter(memtable_state.mem.clone(), &self.table_data)?;
 
         let record_batch_stream: RecordBatchStream =
             Box::new(stream::iter(iter).map_err(|e| Box::new(e) as _));
@@ -713,14 +660,6 @@ impl Instance {
             max_seq: memtable_state.last_sequence(),
             storage_format: sst_info.storage_format,
         }))
-    }
-
-    /// Schedule table compaction request to background workers and return
-    /// immediately.
-    pub async fn schedule_table_compaction(&self, compact_req: TableCompactionRequest) -> bool {
-        self.compaction_scheduler
-            .schedule_table_compaction(compact_req)
-            .await
     }
 }
 
@@ -1047,7 +986,10 @@ fn split_record_batch_with_time_ranges(
     Ok(ret)
 }
 
-fn build_mem_table_iter(memtable: MemTableRef, table_data: &TableData) -> Result<ColumnarIterPtr> {
+fn build_mem_table_iter(
+    memtable: MemTableRef,
+    table_data: &TableDataRef,
+) -> Result<ColumnarIterPtr> {
     let scan_ctx = ScanContext::default();
     let scan_req = ScanRequest {
         start_user_key: Bound::Unbounded,

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -35,7 +35,7 @@ use crate::{
         scheduler::CompactionSchedulerRef, CompactionInputFiles, CompactionTask, ExpiredFiles,
         TableCompactionRequest,
     },
-    instance::{self, serializer::TableFlushScheduler, SpaceStore, SpaceStoreRef},
+    instance::{self, serial_executor::TableFlushScheduler, SpaceStore, SpaceStoreRef},
     manifest::meta_update::{AlterOptionsMeta, MetaUpdate, MetaUpdateRequest, VersionEditMeta},
     memtable::{ColumnarIterPtr, MemTableRef, ScanContext, ScanRequest},
     row_iter::{

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -14,7 +14,7 @@ pub mod flush_compaction;
 pub(crate) mod mem_collector;
 pub mod open;
 mod read;
-pub(crate) mod serializer;
+pub(crate) mod serial_executor;
 pub(crate) mod write;
 
 use std::{
@@ -221,8 +221,8 @@ impl Instance {
         };
 
         let flusher = self.make_flusher();
-        let mut serializer = table_data.serializer.lock().await;
-        let flush_scheduler = serializer.flush_scheduler();
+        let mut serial_exec = table_data.serial_exec.lock().await;
+        let flush_scheduler = serial_exec.flush_scheduler();
         flusher
             .schedule_flush(flush_scheduler, table_data, flush_opts)
             .await

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -374,7 +374,7 @@ impl Instance {
 
                     let index_in_writer =
                         IndexInWriterSchema::for_same_schema(row_group.schema().num_columns());
-                    let memtable_writer = MemTableWriter::make(table_data.clone(), serializer);
+                    let memtable_writer = MemTableWriter::new(table_data.clone(), serializer);
                     memtable_writer
                         .write(sequence, &row_group.into(), index_in_writer)
                         .context(ApplyMemTable {

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -55,7 +55,8 @@ impl Default for TableFlushScheduler {
     }
 }
 
-/// All operations on tables must hold the mutable reference of this serializer.
+/// All operations on tables must hold the mutable reference of this
+/// [TableOpSerialExecutor].
 ///
 /// To ensure the consistency of a table's data, these rules are required:
 /// - The write procedure (write wal + write memtable) should be serialized as a
@@ -64,12 +65,12 @@ impl Default for TableFlushScheduler {
 /// - Any operation that may change the data of a table should be serialized,
 ///   including altering table schema, dropping table, etc;
 /// - The flush procedure of a table should be serialized;
-pub struct TableOpSerializer {
+pub struct TableOpSerialExecutor {
     table_id: TableId,
     flush_scheduler: TableFlushScheduler,
 }
 
-impl TableOpSerializer {
+impl TableOpSerialExecutor {
     pub fn new(table_id: TableId) -> Self {
         Self {
             table_id,
@@ -83,7 +84,7 @@ impl TableOpSerializer {
     }
 }
 
-impl TableOpSerializer {
+impl TableOpSerialExecutor {
     pub fn flush_scheduler(&mut self) -> &mut TableFlushScheduler {
         &mut self.flush_scheduler
     }

--- a/analytic_engine/src/instance/serializer.rs
+++ b/analytic_engine/src/instance/serializer.rs
@@ -1,0 +1,175 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::{
+    sync::{Arc, Condvar, Mutex},
+    time::Instant,
+};
+
+use common_util::{runtime::Runtime, time::InstantExt};
+use futures::Future;
+use log::error;
+use table_engine::table::{Error as TableError, Result as TableResult, TableId};
+use tokio::sync::oneshot;
+
+use crate::{
+    instance::flush_compaction::{self, BackgroundFlushFailed},
+    table::metrics::Metrics,
+};
+
+#[derive(Default)]
+enum FlushState {
+    #[default]
+    Ok,
+    Flushing,
+    Failed {
+        err_msg: String,
+    },
+}
+
+type ScheduleLock = Arc<(Mutex<FlushState>, Condvar)>;
+
+#[derive(Default)]
+pub struct TableFlushScheduler {
+    schedule_lock: ScheduleLock,
+}
+
+/// To ensure the consistency of a table's data, these rules are required:
+/// - The write procedure (write wal + write memtable) should be serialized as a
+///   whole, that is to say, it is not allowed to write wal and memtable
+///   concurrently or interleave the two sub-procedures;
+/// - Any operation that may change the data of a table should be serialized,
+///   including altering table schema, dropping table, etc;
+/// - The flush procedure of a table should be serialized;
+pub struct TableOpSerializer {
+    table_id: TableId,
+    flush_scheduler: TableFlushScheduler,
+}
+
+impl TableOpSerializer {
+    pub fn new(table_id: TableId) -> Self {
+        Self {
+            table_id,
+            flush_scheduler: TableFlushScheduler::default(),
+        }
+    }
+
+    #[inline]
+    pub fn table_id(&self) -> TableId {
+        self.table_id
+    }
+}
+
+impl TableOpSerializer {
+    pub fn flush_scheduler(&mut self) -> &mut TableFlushScheduler {
+        &mut self.flush_scheduler
+    }
+}
+
+impl TableFlushScheduler {
+    /// Control the flush procedure and ensure multiple flush procedures to be
+    /// sequential.
+    ///
+    /// REQUIRE: should only be called by the write thread.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn flush_sequentially<F, T>(
+        &mut self,
+        table: String,
+        metrics: &Metrics,
+        flush_job: F,
+        on_flush_success: T,
+        block_on_write_thread: bool,
+        runtime: &Runtime,
+        res_sender: Option<oneshot::Sender<TableResult<()>>>,
+    ) -> flush_compaction::Result<()>
+    where
+        F: Future<Output = flush_compaction::Result<()>> + Send + 'static,
+        T: Future<Output = ()> + Send + 'static,
+    {
+        // If flush operation is running, then we need to wait for it to complete first.
+        // Actually, the loop waiting ensures the multiple flush procedures to be
+        // sequential, that is to say, at most one flush is being executed at
+        // the same time.
+        {
+            let mut stall_begin: Option<Instant> = None;
+            let mut flush_state = self.schedule_lock.0.lock().unwrap();
+            loop {
+                match &*flush_state {
+                    FlushState::Ok => {
+                        break;
+                    }
+                    FlushState::Flushing => (),
+                    FlushState::Failed { err_msg } => {
+                        return BackgroundFlushFailed { msg: err_msg }.fail();
+                    }
+                }
+
+                if stall_begin.is_none() {
+                    stall_begin = Some(Instant::now());
+                }
+                flush_state = self.schedule_lock.1.wait(flush_state).unwrap();
+            }
+            if let Some(stall_begin) = stall_begin {
+                metrics.on_write_stall(stall_begin.saturating_elapsed());
+            }
+
+            // TODO(yingwen): Store pending flush requests and retry flush on recoverable
+            // error,  or try to recover from background error.
+
+            // Mark the worker is flushing.
+            *flush_state = FlushState::Flushing;
+        }
+
+        let schedule_lock = self.schedule_lock.clone();
+        let task = async move {
+            let flush_res = flush_job.await;
+            on_flush_finished(schedule_lock, &flush_res);
+
+            match flush_res {
+                Ok(()) => {
+                    on_flush_success.await;
+                    send_flush_result(res_sender, Ok(()));
+                }
+                Err(e) => {
+                    let e = Arc::new(e);
+                    send_flush_result(
+                        res_sender,
+                        Err(TableError::Flush {
+                            source: Box::new(e),
+                            table,
+                        }),
+                    );
+                }
+            }
+        };
+
+        if block_on_write_thread {
+            task.await;
+        } else {
+            runtime.spawn(task);
+        }
+
+        Ok(())
+    }
+}
+
+fn on_flush_finished(schedule_lock: ScheduleLock, res: &flush_compaction::Result<()>) {
+    let mut flush_state = schedule_lock.0.lock().unwrap();
+    match res {
+        Ok(()) => {
+            *flush_state = FlushState::Ok;
+        }
+        Err(e) => {
+            let err_msg = e.to_string();
+            *flush_state = FlushState::Failed { err_msg };
+        }
+    }
+    schedule_lock.1.notify_all();
+}
+
+fn send_flush_result(res_sender: Option<oneshot::Sender<TableResult<()>>>, res: TableResult<()>) {
+    if let Some(tx) = res_sender {
+        if let Err(send_res) = tx.send(res) {
+            error!("Fail to send flush result, send_res:{:?}", send_res);
+        }
+    }
+}

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -246,7 +246,7 @@ pub struct Writer<'a> {
 }
 
 impl<'a> Writer<'a> {
-    pub fn make(
+    pub fn new(
         instance: InstanceRef,
         space_table: SpaceAndTable,
         serializer: &'a mut TableOpSerializer,
@@ -268,7 +268,7 @@ pub(crate) struct MemTableWriter<'a> {
 }
 
 impl<'a> MemTableWriter<'a> {
-    pub fn make(table_data: TableDataRef, serializer: &'a mut TableOpSerializer) -> Self {
+    pub fn new(table_data: TableDataRef, serializer: &'a mut TableOpSerializer) -> Self {
         Self {
             table_data,
             _serializer: serializer,
@@ -425,7 +425,7 @@ impl<'a> Writer<'a> {
         encoded_rows: Vec<ByteVec>,
     ) -> Result<()> {
         let sequence = self.write_to_wal(encoded_rows).await?;
-        let memtable_writer = MemTableWriter::make(table_data.clone(), self.serializer);
+        let memtable_writer = MemTableWriter::new(table_data.clone(), self.serializer);
 
         memtable_writer
             .write(sequence, &row_group, index_in_writer)

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -2,8 +2,6 @@
 
 //! Write logic of instance
 
-use std::sync::Arc;
-
 use ceresdbproto::{schema as schema_pb, table_requests};
 use common_types::{
     bytes::ByteVec,
@@ -15,7 +13,6 @@ use log::{debug, error, info, trace, warn};
 use smallvec::SmallVec;
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use table_engine::table::WriteRequest;
-use tokio::sync::oneshot;
 use wal::{
     kv_encoder::LogBatchEncoder,
     manager::{SequenceNumber, WalLocation, WriteContext},
@@ -23,19 +20,11 @@ use wal::{
 
 use crate::{
     instance,
-    instance::{
-        flush_compaction::TableFlushOptions,
-        write_worker,
-        write_worker::{BackgroundStatus, WorkerLocal, WriteTableCommand},
-        Instance,
-    },
+    instance::{flush_compaction::TableFlushOptions, serializer::TableOpSerializer, InstanceRef},
     memtable::{key::KeySequence, PutContext},
     payload::WritePayload,
     space::{SpaceAndTable, SpaceRef},
-    table::{
-        data::{TableData, TableDataRef},
-        version::MemTableForWrite,
-    },
+    table::{data::TableDataRef, version::MemTableForWrite},
 };
 
 #[derive(Debug, Snafu)]
@@ -85,8 +74,6 @@ pub enum Error {
         table: String,
         source: crate::table::data::Error,
     },
-    #[snafu(display("Failed to write table, source:{}", source,))]
-    Write { source: write_worker::Error },
 
     #[snafu(display("Failed to flush table, table:{}, err:{}", table, source))]
     FlushTable {
@@ -251,56 +238,132 @@ impl WriteRowGroupSplitter {
     }
 }
 
-impl Instance {
-    /// Write data to the table under give space.
-    pub async fn write_to_table(
-        &self,
-        space_table: &SpaceAndTable,
-        request: WriteRequest,
-    ) -> Result<usize> {
-        // Collect metrics.
-        space_table.table_data().metrics.on_write_request_begin();
+pub struct Writer<'a> {
+    instance: InstanceRef,
+    space: SpaceRef,
+    table_data: TableDataRef,
+    serializer: &'a mut TableOpSerializer,
+}
 
-        self.validate_before_write(space_table, &request)?;
+impl<'a> Writer<'a> {
+    pub fn make(
+        instance: InstanceRef,
+        space_table: SpaceAndTable,
+        serializer: &'a mut TableOpSerializer,
+    ) -> Writer<'a> {
+        assert_eq!(space_table.table_data().id, serializer.table_id());
 
-        // Create a oneshot channel to send/receive write result.
-        let (tx, rx) = oneshot::channel();
-        let cmd = WriteTableCommand {
+        Self {
+            instance,
             space: space_table.space().clone(),
             table_data: space_table.table_data().clone(),
-            request,
-            tx,
-        };
+            serializer,
+        }
+    }
+}
 
-        // Send write request to write worker, actual works done in
-        // Self::process_write_table_command().
-        write_worker::process_command_in_write_worker(
-            cmd.into_command(),
-            space_table.table_data(),
-            rx,
-        )
-        .await
-        .context(Write)
+pub(crate) struct MemTableWriter<'a> {
+    table_data: TableDataRef,
+    _serializer: &'a mut TableOpSerializer,
+}
+
+impl<'a> MemTableWriter<'a> {
+    pub fn make(table_data: TableDataRef, serializer: &'a mut TableOpSerializer) -> Self {
+        Self {
+            table_data,
+            _serializer: serializer,
+        }
     }
 
+    // TODO(yingwen): How to trigger flush if we found memtables are full during
+    // inserting memtable? RocksDB checks memtable size in MemTableInserter
+    /// Write data into memtable.
+    ///
+    /// The data in `encoded_rows` will be moved to memtable.
+    ///
+    /// The len of `row_group` and `encoded_rows` must be equal.
+    pub fn write(
+        &self,
+        sequence: SequenceNumber,
+        row_group: &RowGroupSlicer,
+        index_in_writer: IndexInWriterSchema,
+    ) -> Result<()> {
+        let _timer = self.table_data.metrics.start_table_write_memtable_timer();
+        if row_group.is_empty() {
+            return Ok(());
+        }
+
+        let schema = row_group.schema();
+        // Store all memtables we wrote and update their last sequence later.
+        let mut wrote_memtables: SmallVec<[_; 4]> = SmallVec::new();
+        let mut last_mutable_mem: Option<MemTableForWrite> = None;
+
+        let mut ctx = PutContext::new(index_in_writer);
+        for (row_idx, row) in row_group.iter().enumerate() {
+            // TODO(yingwen): Add RowWithSchema and take RowWithSchema as input, then remove
+            // this unwrap()
+            let timestamp = row.timestamp(schema).unwrap();
+            // skip expired row
+            if self.table_data.is_expired(timestamp) {
+                trace!("Skip expired row when write to memtable, row:{:?}", row);
+                continue;
+            }
+            if last_mutable_mem.is_none()
+                || !last_mutable_mem
+                    .as_ref()
+                    .unwrap()
+                    .accept_timestamp(timestamp)
+            {
+                // The time range is not processed by current memtable, find next one.
+                let mutable_mem = self
+                    .table_data
+                    .find_or_create_mutable(timestamp, schema)
+                    .context(FindMutableMemTable {
+                        table: &self.table_data.name,
+                    })?;
+                wrote_memtables.push(mutable_mem.clone());
+                last_mutable_mem = Some(mutable_mem);
+            }
+
+            // We have check the row num is less than `MAX_ROWS_TO_WRITE`, it is safe to
+            // cast it to u32 here
+            let key_seq = KeySequence::new(sequence, row_idx as u32);
+            // TODO(yingwen): Batch sample timestamp in sampling phase.
+            last_mutable_mem
+                .as_ref()
+                .unwrap()
+                .put(&mut ctx, key_seq, row, schema, timestamp)
+                .context(WriteMemTable {
+                    table: &self.table_data.name,
+                })?;
+        }
+
+        // Update last sequence of memtable.
+        for mem_wrote in wrote_memtables {
+            mem_wrote
+                .set_last_sequence(sequence)
+                .context(UpdateMemTableSequence)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Writer<'a> {
     /// Do the actual write, must called by write worker in write thread
     /// sequentially.
-    pub(crate) async fn process_write_table_command(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
-        space: &SpaceRef,
-        table_data: &TableDataRef,
-        request: WriteRequest,
-    ) -> Result<usize> {
-        let _timer = table_data.metrics.start_table_write_timer();
+    pub(crate) async fn write(&mut self, request: WriteRequest) -> Result<usize> {
+        let _timer = self.table_data.metrics.start_table_write_timer();
+        self.table_data.metrics.on_write_request_begin();
+
+        self.validate_before_write(&request)?;
         let mut encode_ctx = EncodeContext::new(request.row_group);
 
-        self.preprocess_write(worker_local, space, table_data, &mut encode_ctx)
-            .await?;
+        self.preprocess_write(&mut encode_ctx).await?;
 
         {
-            let _timer = table_data.metrics.start_table_write_encode_timer();
-            let schema = table_data.schema();
+            let _timer = self.table_data.metrics.start_table_write_encode_timer();
+            let schema = self.table_data.schema();
             encode_ctx.encode_rows(&schema)?;
         }
 
@@ -310,19 +373,15 @@ impl Instance {
             encoded_rows,
         } = encode_ctx;
 
-        match self.maybe_split_write_request(encoded_rows, &row_group) {
+        let table_data = self.table_data.clone();
+        let split_res = self.maybe_split_write_request(encoded_rows, &row_group);
+        match split_res {
             SplitResult::Integrate {
                 encoded_rows,
                 row_group,
             } => {
-                self.write_table_row_group(
-                    worker_local,
-                    table_data,
-                    row_group,
-                    index_in_writer,
-                    encoded_rows,
-                )
-                .await?;
+                self.write_table_row_group(&table_data, row_group, index_in_writer, encoded_rows)
+                    .await?;
             }
             SplitResult::Splitted {
                 encoded_batches,
@@ -331,8 +390,7 @@ impl Instance {
                 for (encoded_rows, row_group) in encoded_batches.into_iter().zip(row_group_batches)
                 {
                     self.write_table_row_group(
-                        worker_local,
-                        table_data,
+                        &table_data,
                         row_group,
                         index_in_writer.clone(),
                         encoded_rows,
@@ -345,48 +403,41 @@ impl Instance {
         Ok(row_group.num_rows())
     }
 
-    fn maybe_split_write_request(
-        self: &Arc<Self>,
+    fn maybe_split_write_request<'b>(
+        &'a self,
         encoded_rows: Vec<ByteVec>,
-        row_group: &RowGroup,
-    ) -> SplitResult {
-        if self.max_bytes_per_write_batch.is_none() {
+        row_group: &'b RowGroup,
+    ) -> SplitResult<'b> {
+        if self.instance.max_bytes_per_write_batch.is_none() {
             return SplitResult::Integrate {
                 encoded_rows,
                 row_group: RowGroupSlicer::from(row_group),
             };
         }
 
-        let splitter = WriteRowGroupSplitter::new(self.max_bytes_per_write_batch.unwrap());
+        let splitter = WriteRowGroupSplitter::new(self.instance.max_bytes_per_write_batch.unwrap());
         splitter.split(encoded_rows, row_group)
     }
 
     async fn write_table_row_group(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
+        &mut self,
         table_data: &TableDataRef,
         row_group: RowGroupSlicer<'_>,
         index_in_writer: IndexInWriterSchema,
         encoded_rows: Vec<ByteVec>,
     ) -> Result<()> {
-        let sequence = self
-            .write_to_wal(worker_local, table_data, encoded_rows)
-            .await?;
+        let sequence = self.write_to_wal(encoded_rows).await?;
+        let memtable_writer = MemTableWriter::make(table_data.clone(), self.serializer);
 
-        Self::write_to_memtable(
-            worker_local,
-            table_data,
-            sequence,
-            &row_group,
-            index_in_writer,
-        )
-        .map_err(|e| {
-            error!(
-                "Failed to write to memtable, table:{}, table_id:{}, err:{}",
-                table_data.name, table_data.id, e
-            );
-            e
-        })?;
+        memtable_writer
+            .write(sequence, &row_group, index_in_writer)
+            .map_err(|e| {
+                error!(
+                    "Failed to write to memtable, table:{}, table_id:{}, err:{}",
+                    table_data.name, table_data.id, e
+                );
+                e
+            })?;
 
         // Failure of writing memtable may cause inconsecutive sequence.
         if table_data.last_sequence() + 1 != sequence {
@@ -415,15 +466,11 @@ impl Instance {
 
     /// Return Ok if the request is valid, this is done before entering the
     /// write thread.
-    fn validate_before_write(
-        &self,
-        space_table: &SpaceAndTable,
-        request: &WriteRequest,
-    ) -> Result<()> {
+    fn validate_before_write(&self, request: &WriteRequest) -> Result<()> {
         ensure!(
             request.row_group.num_rows() < MAX_ROWS_TO_WRITE,
             TooManyRows {
-                table: &space_table.table_data().name,
+                table: &self.table_data.name,
                 rows: request.row_group.num_rows(),
             }
         );
@@ -436,33 +483,17 @@ impl Instance {
     ///  - memtable capacity and maybe trigger flush
     ///
     /// Fills [common_types::schema::IndexInWriterSchema] in [EncodeContext]
-    async fn preprocess_write(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
-        // space_table: &SpaceAndTable,
-        space: &SpaceRef,
-        table_data: &TableDataRef,
-        encode_ctx: &mut EncodeContext,
-    ) -> Result<()> {
-        let _total_timer = table_data.metrics.start_table_write_preprocess_timer();
+    async fn preprocess_write(&mut self, encode_ctx: &mut EncodeContext) -> Result<()> {
+        let _total_timer = self.table_data.metrics.start_table_write_preprocess_timer();
         ensure!(
-            !table_data.is_dropped(),
+            !self.table_data.is_dropped(),
             WriteDroppedTable {
-                table: &table_data.name,
+                table: &self.table_data.name,
             }
         );
 
-        let worker_id = worker_local.worker_id();
-        worker_local
-            .ensure_permission(
-                &table_data.name,
-                table_data.id.as_u64() as usize,
-                self.write_group_worker_num,
-            )
-            .context(Write)?;
-
         // Checks schema compatibility.
-        table_data
+        self.table_data
             .schema()
             .compatible_for_write(
                 encode_ctx.row_group.schema(),
@@ -470,202 +501,131 @@ impl Instance {
             )
             .context(IncompatSchema)?;
 
-        // TODO(yingwen): Allow write and retry flush.
-        // Check background status, if background error occurred, not allow to write
-        // again.
-        match &*worker_local.background_status() {
-            // Compaction error is ignored now.
-            BackgroundStatus::Ok | BackgroundStatus::CompactionFailed(_) => (),
-            BackgroundStatus::FlushFailed(e) => {
-                return BackgroundFlushFailed { msg: e.to_string() }.fail();
-            }
-        }
-
-        if self.should_flush_instance() {
-            if let Some(space) = self.space_store.find_maximum_memory_usage_space() {
-                if let Some(table) = space.find_maximum_memory_usage_table(worker_id) {
+        if self.instance.should_flush_instance() {
+            if let Some(space) = self.instance.space_store.find_maximum_memory_usage_space() {
+                if let Some(table) = space.find_maximum_memory_usage_table() {
                     info!("Trying to flush table {} bytes {} in space {} because engine total memtable memory usage exceeds db_write_buffer_size {}.",
                           table.name,
                           table.memtable_memory_usage(),
                           space.id,
-                          self.db_write_buffer_size,
+                          self.instance.db_write_buffer_size,
                     );
-
-                    let _timer = table_data
+                    let _timer = self
+                        .table_data
                         .metrics
                         .start_table_write_instance_flush_wait_timer();
-                    self.handle_memtable_flush(worker_local, &table).await?;
+                    self.handle_memtable_flush(&table).await?;
                 }
             }
         }
 
-        if space.should_flush_space() {
-            if let Some(table) = space.find_maximum_memory_usage_table(worker_id) {
+        if self.space.should_flush_space() {
+            if let Some(table) = self.space.find_maximum_memory_usage_table() {
                 info!("Trying to flush table {} bytes {} in space {} because space total memtable memory usage exceeds space_write_buffer_size {}.",
                       table.name,
                       table.memtable_memory_usage() ,
-                      space.id,
-                      space.write_buffer_size,
+                      self.space.id,
+                      self.space.write_buffer_size,
                 );
-
-                let _timer = table_data
+                let _timer = self
+                    .table_data
                     .metrics
                     .start_table_write_space_flush_wait_timer();
-                self.handle_memtable_flush(worker_local, &table).await?;
+                self.handle_memtable_flush(&table).await?;
             }
         }
 
-        if table_data.should_flush_table(worker_local) {
+        if self.table_data.should_flush_table() {
+            let table_data = self.table_data.clone();
             let _timer = table_data.metrics.start_table_write_flush_wait_timer();
-            self.handle_memtable_flush(worker_local, table_data).await?;
+            self.handle_memtable_flush(&table_data).await?;
         }
 
         Ok(())
     }
 
     /// Write log_batch into wal, return the sequence number of log_batch.
-    async fn write_to_wal(
-        &self,
-        worker_local: &WorkerLocal,
-        table_data: &TableData,
-        encoded_rows: Vec<ByteVec>,
-    ) -> Result<SequenceNumber> {
-        let _timer = table_data.metrics.start_table_write_wal_timer();
-
-        worker_local
-            .ensure_permission(
-                &table_data.name,
-                table_data.id.as_u64() as usize,
-                self.write_group_worker_num,
-            )
-            .context(Write)?;
-
+    async fn write_to_wal(&self, encoded_rows: Vec<ByteVec>) -> Result<SequenceNumber> {
+        let _timer = self.table_data.metrics.start_table_write_wal_timer();
         // Convert into pb
         let write_req_pb = table_requests::WriteRequest {
             // FIXME: Shall we avoid the magic number here?
             version: 0,
             // Use the table schema instead of the schema in request to avoid schema
             // mismatch during replaying
-            schema: Some(schema_pb::TableSchema::from(&table_data.schema())),
+            schema: Some(schema_pb::TableSchema::from(&self.table_data.schema())),
             rows: encoded_rows,
         };
 
         // Encode payload
         let payload = WritePayload::Write(&write_req_pb);
-        let table_location = table_data.table_location();
+        let table_location = self.table_data.table_location();
         let wal_location =
             instance::create_wal_location(table_location.id, table_location.shard_info);
         let log_batch_encoder = LogBatchEncoder::create(wal_location);
         let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
-            table: &table_data.name,
+            table: &self.table_data.name,
             wal_location,
         })?;
 
         // Write to wal manager
         let write_ctx = WriteContext::default();
         let sequence = self
+            .instance
             .space_store
             .wal_manager
             .write(&write_ctx, &log_batch)
             .await
             .context(WriteLogBatch {
-                table: &table_data.name,
+                table: &self.table_data.name,
             })?;
 
         Ok(sequence)
     }
 
-    // TODO(yingwen): How to trigger flush if we found memtables are full during
-    // inserting memtable? RocksDB checks memtable size in MemTableInserter
-    /// Write data into memtable.
-    ///
-    /// The data in `encoded_rows` will be moved to memtable.
-    ///
-    /// The len of `row_group` and `encoded_rows` must be equal.
-    pub(crate) fn write_to_memtable(
-        worker_local: &WorkerLocal,
-        table_data: &TableDataRef,
-        sequence: SequenceNumber,
-        row_group: &RowGroupSlicer,
-        index_in_writer: IndexInWriterSchema,
-    ) -> Result<()> {
-        let _timer = table_data.metrics.start_table_write_memtable_timer();
-
-        if row_group.is_empty() {
-            return Ok(());
-        }
-
-        let schema = row_group.schema();
-        // Store all memtables we wrote and update their last sequence later.
-        let mut wrote_memtables: SmallVec<[_; 4]> = SmallVec::new();
-        let mut last_mutable_mem: Option<MemTableForWrite> = None;
-
-        let mut ctx = PutContext::new(index_in_writer);
-        for (row_idx, row) in row_group.iter().enumerate() {
-            // TODO(yingwen): Add RowWithSchema and take RowWithSchema as input, then remove
-            // this unwrap()
-            let timestamp = row.timestamp(schema).unwrap();
-            // skip expired row
-            if table_data.is_expired(timestamp) {
-                trace!("Skip expired row when write to memtable, row:{:?}", row);
-                continue;
-            }
-            if last_mutable_mem.is_none()
-                || !last_mutable_mem
-                    .as_ref()
-                    .unwrap()
-                    .accept_timestamp(timestamp)
-            {
-                // The time range is not processed by current memtable, find next one.
-                let mutable_mem = table_data
-                    .find_or_create_mutable(worker_local, timestamp, schema)
-                    .context(FindMutableMemTable {
-                        table: &table_data.name,
-                    })?;
-                wrote_memtables.push(mutable_mem.clone());
-                last_mutable_mem = Some(mutable_mem);
-            }
-
-            // We have check the row num is less than `MAX_ROWS_TO_WRITE`, it is safe to
-            // cast it to u32 here
-            let key_seq = KeySequence::new(sequence, row_idx as u32);
-            // TODO(yingwen): Batch sample timestamp in sampling phase.
-            last_mutable_mem
-                .as_ref()
-                .unwrap()
-                .put(&mut ctx, key_seq, row, schema, timestamp)
-                .context(WriteMemTable {
-                    table: &table_data.name,
-                })?;
-        }
-
-        // Update last sequence of memtable.
-        for mem_wrote in wrote_memtables {
-            mem_wrote
-                .set_last_sequence(sequence)
-                .context(UpdateMemTableSequence)?;
-        }
-
-        Ok(())
-    }
-
     /// Flush memtables of table in background.
     ///
-    /// Only flush mutable memtables, assuming all immutable memtables are
-    /// flushing.
-    async fn handle_memtable_flush(
-        self: &Arc<Self>,
-        worker_local: &mut WorkerLocal,
-        table_data: &TableDataRef,
-    ) -> Result<()> {
+    /// Note the table to flush may not the same as `self.table_data`. And if we
+    /// try to flush other table in this table's writer, the lock should be
+    /// acquired in advance. And in order to avoid deadlock, we should not wait
+    /// for the lock.
+    async fn handle_memtable_flush(&mut self, table_data: &TableDataRef) -> Result<()> {
         let opts = TableFlushOptions::default();
+        let flusher = self.instance.make_flusher();
+        if table_data.id == self.table_data.id {
+            let flush_scheduler = self.serializer.flush_scheduler();
+            // Set `block_on_write_thread` to false and let flush do in background.
+            return flusher
+                .schedule_flush(flush_scheduler, table_data, opts)
+                .await
+                .context(FlushTable {
+                    table: &table_data.name,
+                });
+        }
 
-        // Set `block_on_write_thread` to false and let flush do in background.
-        self.flush_table_in_worker(worker_local, table_data, opts)
-            .await
-            .context(FlushTable {
-                table: &table_data.name,
-            })
+        debug!(
+            "Try to trigger flush of other table:{} from the write procedure of table:{}",
+            table_data.name, self.table_data.name
+        );
+        match table_data.serializer.try_lock() {
+            Ok(mut serializer) => {
+                let flush_scheduler = serializer.flush_scheduler();
+                // Set `block_on_write_thread` to false and let flush do in background.
+                flusher
+                    .schedule_flush(flush_scheduler, table_data, opts)
+                    .await
+                    .context(FlushTable {
+                        table: &table_data.name,
+                    })
+            }
+            Err(_) => {
+                warn!(
+                    "Failed to acquire write lock for flush table:{}",
+                    table_data.name,
+                );
+                Ok(())
+            }
+        }
     }
 }
 

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -350,8 +350,6 @@ impl<'a> MemTableWriter<'a> {
 }
 
 impl<'a> Writer<'a> {
-    /// Do the actual write, must called by write worker in write thread
-    /// sequentially.
     pub(crate) async fn write(&mut self, request: WriteRequest) -> Result<usize> {
         let _timer = self.table_data.metrics.start_table_write_timer();
         self.table_data.metrics.on_write_request_begin();

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Analytic table engine implementations
 
@@ -46,10 +46,7 @@ pub struct Config {
     pub replay_batch_size: usize,
     /// Batch size to replay tables
     pub max_replay_tables_per_batch: usize,
-    // Write group options:
-    pub write_group_worker_num: usize,
-    pub write_group_command_channel_cap: usize,
-    // End of write group options.
+
     /// Default options for table
     pub table_opts: TableOptions,
 
@@ -104,8 +101,6 @@ impl Default for Config {
             storage: Default::default(),
             replay_batch_size: 500,
             max_replay_tables_per_batch: 64,
-            write_group_worker_num: 8,
-            write_group_command_channel_cap: 128,
             table_opts: TableOptions::default(),
             compaction_config: SchedulerConfig::default(),
             sst_meta_cache_cap: Some(1000),

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -35,7 +35,6 @@ use wal::{
     },
 };
 
-use super::SnapshotRequest;
 use crate::{
     manifest::{
         meta_data::{TableManifestData, TableManifestDataBuilder},
@@ -43,7 +42,7 @@ use crate::{
             AddTableMeta, MetaUpdate, MetaUpdateDecoder, MetaUpdatePayload, MetaUpdateRequest,
             VersionEditMeta,
         },
-        LoadRequest, Manifest,
+        LoadRequest, Manifest, SnapshotRequest,
     },
     space::SpaceId,
     table::version::TableVersionMeta,

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -30,7 +30,7 @@ use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::{engine::CreateTableRequest, table::TableId};
 
 use crate::{
-    instance::serializer::TableOpSerializer,
+    instance::serial_executor::TableOpSerialExecutor,
     manifest::meta_update::AddTableMeta,
     memtable::{
         factory::{FactoryRef as MemTableFactoryRef, Options as MemTableOptions},
@@ -146,8 +146,8 @@ pub struct TableData {
     /// Shard info of the table
     pub shard_info: TableShardInfo,
 
-    /// The table operation serializer
-    pub serializer: tokio::sync::Mutex<TableOpSerializer>,
+    /// The table operation serial_exec
+    pub serial_exec: tokio::sync::Mutex<TableOpSerialExecutor>,
 }
 
 impl fmt::Debug for TableData {
@@ -215,7 +215,7 @@ impl TableData {
             dropped: AtomicBool::new(false),
             metrics,
             shard_info: TableShardInfo::new(request.shard_id),
-            serializer: tokio::sync::Mutex::new(TableOpSerializer::new(request.table_id)),
+            serial_exec: tokio::sync::Mutex::new(TableOpSerialExecutor::new(request.table_id)),
         })
     }
 
@@ -250,7 +250,7 @@ impl TableData {
             dropped: AtomicBool::new(false),
             metrics,
             shard_info: TableShardInfo::new(shard_id),
-            serializer: tokio::sync::Mutex::new(TableOpSerializer::new(add_meta.table_id)),
+            serial_exec: tokio::sync::Mutex::new(TableOpSerialExecutor::new(add_meta.table_id)),
         })
     }
 

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -112,11 +112,11 @@ impl Table for TableImpl {
     }
 
     async fn write(&self, request: WriteRequest) -> Result<usize> {
-        let mut serializer = self.table_data.serializer.lock().await;
+        let mut serial_exec = self.table_data.serial_exec.lock().await;
         let mut writer = Writer::new(
             self.instance.clone(),
             self.space_table.clone(),
-            &mut serializer,
+            &mut serial_exec,
         );
 
         let num_rows = writer
@@ -231,10 +231,10 @@ impl Table for TableImpl {
     }
 
     async fn alter_schema(&self, request: AlterSchemaRequest) -> Result<usize> {
-        let mut serializer = self.table_data.serializer.lock().await;
+        let mut serial_exec = self.table_data.serial_exec.lock().await;
         let mut alterer = Alterer::new(
             self.table_data.clone(),
-            &mut serializer,
+            &mut serial_exec,
             self.instance.clone(),
         )
         .await;
@@ -248,10 +248,10 @@ impl Table for TableImpl {
     }
 
     async fn alter_options(&self, options: HashMap<String, String>) -> Result<usize> {
-        let mut serializer = self.table_data.serializer.lock().await;
+        let mut serial_exec = self.table_data.serial_exec.lock().await;
         let alterer = Alterer::new(
             self.table_data.clone(),
-            &mut serializer,
+            &mut serial_exec,
             self.instance.clone(),
         )
         .await;

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -113,7 +113,7 @@ impl Table for TableImpl {
 
     async fn write(&self, request: WriteRequest) -> Result<usize> {
         let mut serializer = self.table_data.serializer.lock().await;
-        let mut writer = Writer::make(
+        let mut writer = Writer::new(
             self.instance.clone(),
             self.space_table.clone(),
             &mut serializer,
@@ -232,7 +232,7 @@ impl Table for TableImpl {
 
     async fn alter_schema(&self, request: AlterSchemaRequest) -> Result<usize> {
         let mut serializer = self.table_data.serializer.lock().await;
-        let mut alterer = Alterer::make(
+        let mut alterer = Alterer::new(
             self.table_data.clone(),
             &mut serializer,
             self.instance.clone(),
@@ -249,7 +249,7 @@ impl Table for TableImpl {
 
     async fn alter_options(&self, options: HashMap<String, String>) -> Result<usize> {
         let mut serializer = self.table_data.serializer.lock().await;
-        let alterer = Alterer::make(
+        let alterer = Alterer::new(
             self.table_data.clone(),
             &mut serializer,
             self.instance.clone(),

--- a/common_util/src/runtime/mod.rs
+++ b/common_util/src/runtime/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! A multi-threaded runtime that supports running Futures
 use std::{
@@ -43,6 +43,8 @@ pub enum Error {
 }
 
 define_result!(Error);
+
+pub type RuntimeRef = Arc<Runtime>;
 
 /// A runtime to run future tasks
 #[derive(Debug)]

--- a/components/skiplist/src/list.rs
+++ b/components/skiplist/src/list.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use std::{
     alloc::Layout,
@@ -15,7 +15,7 @@ use std::{
 use arena::{Arena, BasicStats};
 use rand::Rng;
 
-use super::{slice::ArenaSlice, KeyComparator, MAX_HEIGHT};
+use crate::{slice::ArenaSlice, KeyComparator, MAX_HEIGHT};
 
 const HEIGHT_INCREASE: u32 = u32::MAX / 3;
 

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -260,7 +260,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             let builder = meta_event_service::Builder {
                 cluster: v,
                 instance: instance.clone(),
-                runtime: runtimes.meta_runtime.clone(),
+                runtime: runtimes.default_runtime.clone(),
                 opened_wals,
             };
             MetaEventServiceServer::new(builder.build())

--- a/server/src/handlers/query.rs
+++ b/server/src/handlers/query.rs
@@ -22,11 +22,11 @@ use sql::{
     provider::CatalogMetaProvider,
 };
 
-use super::influxdb::InfluxqlRequest;
 use crate::handlers::{
     error::{
         CreatePlan, InterpreterExec, ParseInfluxql, ParseSql, QueryBlock, QueryTimeout, TooMuchStmt,
     },
+    influxdb::InfluxqlRequest,
     prelude::*,
 };
 

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -447,13 +447,13 @@ impl SysCatalogTable {
             table_info
         );
 
-        let table_writer = TableWriter {
+        let serializer = TableWriter {
             catalog_table: self.table.clone(),
             table_to_write: table_info,
             typ,
         };
 
-        table_writer.write().await?;
+        serializer.write().await?;
 
         Ok(())
     }

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -10,7 +10,7 @@ use common_types::{
     schema::Schema,
     table::{ShardId, DEFAULT_SHARD_ID},
 };
-use common_util::{error::GenericError, runtime::Runtime};
+use common_util::{error::GenericError, runtime::RuntimeRef};
 use snafu::{ensure, Backtrace, Snafu};
 
 use crate::{
@@ -304,15 +304,15 @@ pub type TableEngineRef = Arc<dyn TableEngine>;
 #[derive(Clone, Debug)]
 pub struct EngineRuntimes {
     /// Runtime for reading data
-    pub read_runtime: Arc<Runtime>,
+    pub read_runtime: RuntimeRef,
     /// Runtime for writing data
-    pub write_runtime: Arc<Runtime>,
+    pub write_runtime: RuntimeRef,
     /// Runtime for compacting data
-    pub compact_runtime: Arc<Runtime>,
+    pub compact_runtime: RuntimeRef,
     /// Runtime for ceresmeta communication
-    pub meta_runtime: Arc<Runtime>,
+    pub meta_runtime: RuntimeRef,
     /// Runtime for some other tasks which are not so important
-    pub default_runtime: Arc<Runtime>,
+    pub default_runtime: RuntimeRef,
     /// Runtime for io task
-    pub io_runtime: Arc<Runtime>,
+    pub io_runtime: RuntimeRef,
 }


### PR DESCRIPTION
## Which issue does this PR close?

Prepare for #800 

## Rationale for this change
Currently, the operations on tables are serialized by the worker queue, which has a serious disadvantage -- no work steal, which may leading to hungry of some tables' operations because of one big table.

This PR will replace the worker queue with a simple lock for every table.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Replace the worker queue with lock for every table;

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
Remove the configs for the write workers.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
