### PR TITLE
feat: install dev dependencies in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,29 @@ miri:
 ensure-disk-quota:
 	# ensure the target directory not to exceed 40GB
 	python3 ./scripts/clean-large-folder.py ./target 42949672960
+
+# install dev dependencies
+ifeq ($(shell uname), Darwin)
+dev-setup:
+	echo "Detecting macOS system..."
+	brew --version >/dev/null 2>&1 || { echo "Error: Homebrew is not installed. Exiting..."; exit 1; }
+	echo "Installing dependencies using Homebrew..."
+	brew install git curl openssl protobuf cmake
+else ifeq ($(shell uname), Linux)
+dev-setup:
+	echo "Detecting Linux system..."
+	os_id=$(shell awk -F= '/^ID=/{print $$2}' /etc/os-release) && \
+	if [ "$$os_id" = "ubuntu" ]; then \
+		echo "Detected Ubuntu system..."; \
+		echo "Installing dependencies using apt-get..."; \
+		sudo apt-get update; \
+		sudo apt install git curl gcc g++ libssl-dev pkg-config protobuf-compiler cmake; \
+	else \
+		echo "Error: Unsupported Linux distribution. Exiting..."; \
+		exit 1; \
+	fi
+else
+dev-setup:
+	echo "Error: Unsupported OS. Exiting..."
+	exit 1
+endif


### PR DESCRIPTION
## Which issue does this PR close?

Closes #529 

## Rationale for this change
 
see #529 

## What changes are included in this PR?

Add a new target `make dev-setup` in make file to install dev dependencies.

## Are there any user-facing changes?

User can execute command `make dev-setup` to install dev dependencies.

## How does this change test

<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
