### PR TITLE
feat: upgrade rust-rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,7 +3631,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 [[package]]
 name = "librocksdb_sys"
 version = "0.1.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7e4d1901cbe3f2782c5c63cb7af628bac"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=a9fbe325939c166ffc5f80e63066f5d8594a1fff#a9fbe325939c166ffc5f80e63066f5d8594a1fff"
 dependencies = [
  "bindgen 0.57.0",
  "bzip2-sys",
@@ -3659,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "libtitan_sys"
 version = "0.0.1"
-source = "git+https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7e4d1901cbe3f2782c5c63cb7af628bac"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=a9fbe325939c166ffc5f80e63066f5d8594a1fff#a9fbe325939c166ffc5f80e63066f5d8594a1fff"
 dependencies = [
  "bzip2-sys",
  "cc",
@@ -5937,7 +5937,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.3.0"
-source = "git+https://github.com/tikv/rust-rocksdb.git?rev=084102f7e4d1901cbe3f2782c5c63cb7af628bac#084102f7e4d1901cbe3f2782c5c63cb7af628bac"
+source = "git+https://github.com/tikv/rust-rocksdb.git?rev=a9fbe325939c166ffc5f80e63066f5d8594a1fff#a9fbe325939c166ffc5f80e63066f5d8594a1fff"
 dependencies = [
  "libc",
  "librocksdb_sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,6 @@ dependencies = [
  "serde",
  "server",
  "signal-hook",
- "sort",
  "table_engine",
  "toml 0.7.3",
  "tracing_util",
@@ -1455,7 +1454,6 @@ dependencies = [
  "common_util",
  "log",
  "meta_client",
- "rust-fsm",
  "serde",
  "serde_json",
  "snafu 0.6.10",
@@ -1580,12 +1578,6 @@ name = "constant_time_eq"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation-sys"
@@ -2211,19 +2203,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -3740,7 +3719,6 @@ dependencies = [
  "slog-async",
  "slog-global",
  "slog-term",
- "slog_derive",
 ]
 
 [[package]]
@@ -4433,7 +4411,6 @@ dependencies = [
  "log",
  "lru",
  "object_store 0.5.6",
- "oss-rust-sdk",
  "prometheus 0.12.0",
  "prometheus-static-metric",
  "prost",
@@ -4555,25 +4532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
-name = "oss-rust-sdk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d9aab6ebed77bd0998c728fbef20d6afc63db38c8fe85e0923b624c1b6bfab"
-dependencies = [
- "async-trait",
- "base64 0.13.1",
- "bytes 1.4.0",
- "chrono",
- "derive_more",
- "hmac",
- "httpdate",
- "log",
- "quick-xml 0.27.1",
- "reqwest",
- "sha1 0.10.5",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4667,15 +4625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parquet-format"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0c06cdcd5460967c485f9c40a821746f5955ad81990533c7fae95dbd9bc0b5"
-dependencies = [
- "thrift 0.13.0",
-]
-
-[[package]]
 name = "parquet-format-async-temp"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,9 +4660,7 @@ dependencies = [
  "datafusion",
  "datafusion-expr",
  "log",
- "lru",
  "parquet",
- "parquet-format",
  "thrift 0.13.0",
  "tokio",
 ]
@@ -5156,7 +5103,6 @@ dependencies = [
  "jemalloc-sys",
  "jemallocator",
  "log",
- "tempfile",
 ]
 
 [[package]]
@@ -5462,15 +5408,6 @@ name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc053f057dd768a56f62cd7e434c42c831d296968997e9ac1f76ea7c2d14c41"
 dependencies = [
  "memchr",
 ]
@@ -5822,7 +5759,6 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
- "clru",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -5994,25 +5930,6 @@ dependencies = [
  "rand 0.3.23",
  "rustc-serialize",
  "time 0.1.43",
-]
-
-[[package]]
-name = "rust-fsm"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021d7de715253e45ad24a2fbb0725a0f7f271fd8d3163b130bd65ce2816a860d"
-dependencies = [
- "rust-fsm-dsl",
-]
-
-[[package]]
-name = "rust-fsm-dsl"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a66b1273014079e4cf2b04aad1f3a2849e26e9a106f0411be2b1c15c23a791a"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6365,7 +6282,6 @@ dependencies = [
  "snafu 0.6.10",
  "spin 0.9.8",
  "sql",
- "system_catalog",
  "table_engine",
  "tokio",
  "tokio-stream",
@@ -6574,17 +6490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slog_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6659,12 +6564,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "sort"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b736394cbcbad245669dc12a0caff9b2570e9ad81ce9906f5d7831551cb0c5"
 
 [[package]]
 name = "spin"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6282,6 +6282,7 @@ dependencies = [
  "snafu 0.6.10",
  "spin 0.9.8",
  "sql",
+ "system_catalog",
  "table_engine",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ router = { workspace = true }
 serde = { workspace = true }
 server = { workspace = true }
 signal-hook = "0.3"
-sort = "0.8.5"
 table_engine = { workspace = true }
 toml = { workspace = true }
 tracing_util = { workspace = true }

--- a/cluster/Cargo.toml
+++ b/cluster/Cargo.toml
@@ -17,7 +17,6 @@ common_types = { workspace = true }
 common_util = { workspace = true }
 log = { workspace = true }
 meta_client = { workspace = true }
-rust-fsm = "0.6.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/components/logger/Cargo.toml
+++ b/components/logger/Cargo.toml
@@ -22,4 +22,3 @@ serde = { workspace = true }
 slog = { workspace = true }
 slog-async = "2.6"
 slog-term = "2.8"
-slog_derive = "0.2"

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -22,7 +22,6 @@ futures = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
-oss-rust-sdk = { version = "0.8", default-features = false, features = [ "rustls-tls" ] }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 prost = { workspace = true }

--- a/components/parquet_ext/Cargo.toml
+++ b/components/parquet_ext/Cargo.toml
@@ -19,8 +19,6 @@ common_util = { workspace = true }
 datafusion = { workspace = true }
 datafusion-expr = { workspace = true }
 log = { workspace = true }
-lru = { workspace = true }
 parquet = { workspace = true }
-parquet-format = "4.0.0"
 thrift = "0.13"
 tokio = { workspace = true }

--- a/components/profile/Cargo.toml
+++ b/components/profile/Cargo.toml
@@ -18,4 +18,3 @@ features = ["stats", "profiling", "unprefixed_malloc_on_supported_platforms"]
 jemalloc-ctl = "0.3.2"
 jemallocator = "0.3.2"
 log = { workspace = true }
-tempfile = { workspace = true }

--- a/remote_engine_client/Cargo.toml
+++ b/remote_engine_client/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 arrow_ext = { workspace = true }
 async-trait = { workspace = true }
 ceresdbproto = { workspace = true }
-clru = { workspace = true }
 common_types = { workspace = true }
 common_util = { workspace = true }
 futures = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,6 +47,7 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 spin = { workspace = true }
 sql = { workspace = true }
+system_catalog = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,7 +47,6 @@ serde_json = { workspace = true }
 snafu = { workspace = true }
 spin = { workspace = true }
 sql = { workspace = true }
-system_catalog = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/wal/Cargo.toml
+++ b/wal/Cargo.toml
@@ -14,7 +14,7 @@ test = ["tempfile", "futures", "uuid"]
 
 [dependencies.rocksdb]
 git = "https://github.com/tikv/rust-rocksdb.git"
-rev = "084102f7e4d1901cbe3f2782c5c63cb7af628bac" # at branch tikv-6.1
+rev = "a9fbe325939c166ffc5f80e63066f5d8594a1fff"
 features = ["portable"]
 
 [dependencies]

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -559,7 +559,9 @@ impl Builder {
         }
 
         let stats = if self.enable_statistics.unwrap_or_default() {
-            Some(Statistics::new())
+            let stats = Statistics::new();
+            rocksdb_config.set_statistics(&stats);
+            Some(stats)
         } else {
             None
         };

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! WalManager implementation based on RocksDB
 
@@ -19,7 +19,7 @@ use common_types::{
 };
 use common_util::{error::BoxError, runtime::Runtime};
 use log::{debug, info, warn};
-use rocksdb::{DBIterator, DBOptions, ReadOptions, SeekKey, Writable, WriteBatch, DB};
+use rocksdb::{DBIterator, DBOptions, ReadOptions, SeekKey, Statistics, Writable, WriteBatch, DB};
 use snafu::ResultExt;
 use tokio::sync::Mutex;
 
@@ -235,6 +235,8 @@ pub struct RocksImpl {
     max_seq_meta_encoding: MaxSeqMetaEncoding,
     /// Table units
     table_units: RwLock<HashMap<TableId, Arc<TableUnit>>>,
+    /// Stats of underlying rocksdb
+    stats: Option<Statistics>,
 }
 
 impl Drop for RocksImpl {
@@ -555,9 +557,12 @@ impl Builder {
         if let Some(v) = self.max_background_jobs {
             rocksdb_config.set_max_background_jobs(v);
         }
-        if let Some(v) = self.enable_statistics {
-            rocksdb_config.enable_statistics(v);
-        }
+
+        let stats = if self.enable_statistics.unwrap_or_default() {
+            Some(Statistics::new())
+        } else {
+            None
+        };
 
         let db = DB::open(rocksdb_config, &self.wal_path)
             .map_err(|e| e.into())
@@ -571,6 +576,7 @@ impl Builder {
             log_encoding: CommonLogEncoding::newest(),
             max_seq_meta_encoding: MaxSeqMetaEncoding::newest(),
             table_units: RwLock::new(HashMap::new()),
+            stats,
         };
         rocks_impl.build_table_units()?;
 
@@ -802,7 +808,11 @@ impl WalManager for RocksImpl {
     }
 
     fn get_statistics(&self) -> Option<String> {
-        self.db.get_statistics()
+        if let Some(stats) = &self.stats {
+            stats.to_string()
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

Closes #818

## Rationale for this change
 After upgrade cmake to 2.26, it can't build because of the failure of compiling rocksdb.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Upgrade the rust-rocksdb to keep the latest with the version used by tikv.
- Remove unused dependancies.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
