### PR TITLE
feat: avoid blocking the write procedure because of compaction schedule

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 // Flush and compaction logic of instance
 
@@ -339,6 +339,7 @@ impl Instance {
         if opts.compact_after_flush {
             // Schedule compaction if flush completed successfully.
             let on_flush_success = async move {
+                // Here we don't care whether it is scheduled successfully or not.
                 instance.schedule_table_compaction(compact_req).await;
             };
 
@@ -716,10 +717,10 @@ impl Instance {
 
     /// Schedule table compaction request to background workers and return
     /// immediately.
-    pub async fn schedule_table_compaction(&self, compact_req: TableCompactionRequest) {
+    pub async fn schedule_table_compaction(&self, compact_req: TableCompactionRequest) -> bool {
         self.compaction_scheduler
             .schedule_table_compaction(compact_req)
-            .await;
+            .await
     }
 }
 

--- a/analytic_engine/src/instance/write_worker.rs
+++ b/analytic_engine/src/instance/write_worker.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Write workers
 
@@ -956,7 +956,14 @@ impl WriteWorker {
             waiter,
         };
 
-        self.instance.schedule_table_compaction(request).await;
+        let succeed = self.instance.schedule_table_compaction(request).await;
+        if !succeed {
+            error!(
+                "Failed to schedule compaction, table:{}",
+                request.table_data.name
+            );
+        }
+
         if let Err(_res) = tx.send(Ok(())) {
             error!("handle compact table failed to send result");
         }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Currently, compaction will be scheduled after every flush, and the compaction schedule will block if the schedule channel is full, leading to the flushing is blocked and write stall.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Make compaction schedule won't block, and it will fail fast if the schedule channel is full.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
