### PR TITLE
feat: influxql support fill syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "ahash 0.8.3",
  "arrow 36.0.0",
@@ -1976,7 +1976,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "croaring",
  "influxdb-line-protocol 1.0.0 (git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb)",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -2425,7 +2425,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "futures 0.3.28",
  "libc",
@@ -2799,7 +2799,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "base64 0.21.0",
  "bytes 1.4.0",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "bytes 1.4.0",
  "log",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3341,7 +3341,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "arrow 36.0.0",
  "arrow_util",
@@ -3373,7 +3373,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "arrow 36.0.0",
  "chrono",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "chrono",
  "parking_lot 0.12.1",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -4730,7 +4730,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "arrow 36.0.0",
  "base64 0.21.0",
@@ -5032,7 +5032,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "arrow 36.0.0",
  "chrono",
@@ -5449,6 +5449,7 @@ dependencies = [
  "datafusion-expr",
  "df_operator",
  "futures 0.3.28",
+ "iox_query",
  "log",
  "serde",
  "snafu 0.6.10",
@@ -5460,7 +5461,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "arrow 36.0.0",
  "chrono",
@@ -6208,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "arrow 36.0.0",
  "hashbrown 0.13.2",
@@ -7625,7 +7626,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -7834,8 +7835,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.3.23",
  "static_assertions 1.1.0",
 ]
 
@@ -8435,7 +8436,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#43134dd3331471ab8d4605db5eb6a388b8278099"
+source = "git+https://github.com/jiacai2050/influxdb_iox?branch=ceresdb#04da8923e6617a1fe8b78ce050522ea41217fbde"
 dependencies = [
  "ahash 0.8.3",
  "arrow 36.0.0",

--- a/integration_tests/cases/env/local/influxql/basic.result
+++ b/integration_tests/cases/env/local/influxql/basic.result
@@ -50,6 +50,20 @@ group by location;
 
 {"results":[{"statement_id":0,"series":[{"name":"h2o_feet","columns":["time","location","count"],"values":[[0,"coyote_creek",3],[0,"santa_monica",3]]}]}]}
 
+-- SQLNESS ARG protocol=influxql
+SELECT count(water_level) FROM "h2o_feet"
+where time < 1439828400000ms
+group by location, time(5m);
+
+{"results":[{"statement_id":0,"series":[{"name":"h2o_feet","columns":["time","location","count"],"values":[[1439827200000,"coyote_creek",1],[1439827500000,"coyote_creek",2],[1439827800000,"coyote_creek",null],[1439828100000,"coyote_creek",null],[1439827200000,"santa_monica",1],[1439827500000,"santa_monica",2],[1439827800000,"santa_monica",null],[1439828100000,"santa_monica",null]]}]}]}
+
+-- SQLNESS ARG protocol=influxql
+SELECT count(water_level) FROM "h2o_feet"
+where time < 1439828400000ms
+group by location, time(5m) fill(666);
+
+{"results":[{"statement_id":0,"series":[{"name":"h2o_feet","columns":["time","location","count"],"values":[[1439827200000,"coyote_creek",1],[1439827500000,"coyote_creek",2],[1439827800000,"coyote_creek",666],[1439828100000,"coyote_creek",666],[1439827200000,"santa_monica",1],[1439827500000,"santa_monica",2],[1439827800000,"santa_monica",666],[1439828100000,"santa_monica",666]]}]}]}
+
 DROP TABLE IF EXISTS `h2o_feet`;
 
 affected_rows: 0

--- a/integration_tests/cases/env/local/influxql/basic.sql
+++ b/integration_tests/cases/env/local/influxql/basic.sql
@@ -42,8 +42,14 @@ show measurements;
 SELECT count(water_level) FROM "h2o_feet"
 group by location;
 
--- COMMENT SQLNESS ARG protocol=influxql
--- SELECT count(water_level) FROM "h2o_feet"
--- group by time(5m), location;
+-- SQLNESS ARG protocol=influxql
+SELECT count(water_level) FROM "h2o_feet"
+where time < 1439828400000ms
+group by location, time(5m);
+
+-- SQLNESS ARG protocol=influxql
+SELECT count(water_level) FROM "h2o_feet"
+where time < 1439828400000ms
+group by location, time(5m) fill(666);
 
 DROP TABLE IF EXISTS `h2o_feet`;

--- a/query_engine/Cargo.toml
+++ b/query_engine/Cargo.toml
@@ -21,10 +21,10 @@ datafusion = { workspace = true }
 datafusion-expr = { workspace = true }
 df_operator = { workspace = true }
 futures = { workspace = true }
+iox_query = { git = "https://github.com/jiacai2050/influxdb_iox", branch = "ceresdb" }
 log = { workspace = true }
 serde = { workspace = true }
 snafu = { workspace = true }
 sql = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }
-iox_query = { git = "https://github.com/jiacai2050/influxdb_iox", branch = "ceresdb" }

--- a/query_engine/Cargo.toml
+++ b/query_engine/Cargo.toml
@@ -27,3 +27,4 @@ snafu = { workspace = true }
 sql = { workspace = true }
 table_engine = { workspace = true }
 tokio = { workspace = true }
+iox_query = { git = "https://github.com/jiacai2050/influxdb_iox", branch = "ceresdb" }

--- a/query_engine/src/context.rs
+++ b/query_engine/src/context.rs
@@ -65,6 +65,7 @@ impl Context {
         let state = default_session_builder(df_session_config)
             .with_query_planner(Arc::new(QueryPlannerAdapter))
             .with_optimizer_rules(logical_optimize_rules);
+        let state = iox_query::logical_optimizer::register_iox_logical_optimizers(state);
         let physical_optimizer =
             Self::apply_adapters_for_physical_optimize_rules(state.physical_optimizers());
         SessionContext::with_state(state.with_physical_optimizer_rules(physical_optimizer))

--- a/query_engine/src/df_planner_extension/mod.rs
+++ b/query_engine/src/df_planner_extension/mod.rs
@@ -30,6 +30,7 @@ impl QueryPlanner for QueryPlannerAdapter {
         let extension_planners: Vec<Arc<dyn ExtensionPlanner + Send + Sync>> = vec![
             Arc::new(table_scan_by_primary_key::Planner),
             Arc::new(prom_align::PromAlignPlanner),
+            Arc::new(iox_query::exec::context::IOxExtensionPlanner {}),
         ];
 
         let physical_planner = DefaultPhysicalPlanner::with_extension_planners(extension_planners);


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
Fill syntax is part of influxql.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Bump iox, which contains changes to support ms time unit
- Register GapFill datafusion extension
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

Yes, fill is supported, like this:
```sql
SELECT count(water_level) FROM "h2o_feet"
where time < 1439828400000ms
group by location, time(5m) fill(1)
```

And we can query influxql in grafana directly.

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/3848910/231088874-ac9322f7-738f-46f9-8753-d3224d5d41a0.png">

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

New integration testcase 
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

