### PR TITLE
feat: replace bg runtime with default and compact runtime

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -568,7 +568,7 @@ impl Instance {
             let sst_write_options = sst_write_options.clone();
 
             // spawn build sst
-            let handler = self.runtimes.bg_runtime.spawn(async move {
+            let handler = self.runtimes.write_runtime.spawn(async move {
                 let mut writer = store
                     .sst_factory
                     .create_writer(&sst_write_options, &sst_file_path, store.store_picker())

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -69,10 +69,10 @@ impl Instance {
             background_read_parallelism: 1,
             max_record_batches_in_flight: MAX_RECORD_BATCHES_IN_FLIGHT_WHEN_COMPACTION_READ,
         };
-        let compaction_runtime = ctx.runtimes.compaction_runtime.clone();
+        let compaction_runtime = ctx.runtimes.compact_runtime.clone();
         let compaction_scheduler = Arc::new(SchedulerImpl::new(
             space_store.clone(),
-            compaction_runtime.clone(),
+            compaction_runtime,
             scheduler_config,
             ctx.config.write_sst_max_buffer_size.as_byte() as usize,
             scan_options_for_compaction,

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -65,20 +65,21 @@ impl Instance {
         });
 
         let scheduler_config = ctx.config.compaction_config.clone();
-        let bg_runtime = ctx.runtimes.bg_runtime.clone();
         let scan_options_for_compaction = ScanOptions {
             background_read_parallelism: 1,
             max_record_batches_in_flight: MAX_RECORD_BATCHES_IN_FLIGHT_WHEN_COMPACTION_READ,
         };
+        let compaction_runtime = ctx.runtimes.compaction_runtime.clone();
         let compaction_scheduler = Arc::new(SchedulerImpl::new(
             space_store.clone(),
-            bg_runtime.clone(),
+            compaction_runtime.clone(),
             scheduler_config,
             ctx.config.write_sst_max_buffer_size.as_byte() as usize,
             scan_options_for_compaction,
         ));
 
-        let file_purger = FilePurger::start(&bg_runtime, store_picker.default_store().clone());
+        let default_runtime = ctx.runtimes.default_runtime.clone();
+        let file_purger = FilePurger::start(&default_runtime, store_picker.default_store().clone());
 
         let scan_options = ScanOptions {
             background_read_parallelism: ctx.config.sst_background_read_parallelism,

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -288,7 +288,7 @@ impl WalsOpener for KafkaWalsOpener {
             }
         };
 
-        let bg_runtime = &engine_runtimes.bg_runtime;
+        let default_runtime = &engine_runtimes.default_runtime;
 
         let kafka = KafkaImpl::new(kafka_wal_config.kafka.clone())
             .await
@@ -296,14 +296,14 @@ impl WalsOpener for KafkaWalsOpener {
         let data_wal = MessageQueueImpl::new(
             WAL_DIR_NAME.to_string(),
             kafka.clone(),
-            bg_runtime.clone(),
+            default_runtime.clone(),
             kafka_wal_config.data_namespace,
         );
 
         let manifest_wal = MessageQueueImpl::new(
             MANIFEST_DIR_NAME.to_string(),
             kafka,
-            bg_runtime.clone(),
+            default_runtime.clone(),
             kafka_wal_config.meta_namespace,
         );
 
@@ -322,7 +322,7 @@ async fn open_wal_and_manifest_with_table_kv<T: TableKv>(
     let runtimes = WalRuntimes {
         read_runtime: engine_runtimes.read_runtime.clone(),
         write_runtime: engine_runtimes.write_runtime.clone(),
-        bg_runtime: engine_runtimes.bg_runtime.clone(),
+        default_runtime: engine_runtimes.default_runtime.clone(),
     };
 
     let data_wal = WalNamespaceImpl::open(

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -409,7 +409,7 @@ impl TestEnv {
     }
 
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        self.runtimes.bg_runtime.block_on(future)
+        self.runtimes.default_runtime.block_on(future)
     }
 }
 
@@ -454,7 +454,7 @@ impl Builder {
                 read_runtime: runtime.clone(),
                 write_runtime: runtime.clone(),
                 meta_runtime: runtime.clone(),
-                bg_runtime: runtime,
+                default_runtime: runtime,
             }),
         }
     }

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -454,6 +454,7 @@ impl Builder {
                 read_runtime: runtime.clone(),
                 write_runtime: runtime.clone(),
                 meta_runtime: runtime.clone(),
+                compact_runtime: runtime.clone(),
                 default_runtime: runtime,
             }),
         }

--- a/benchmarks/src/wal_write_bench.rs
+++ b/benchmarks/src/wal_write_bench.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! WalManager write  bench.
 
@@ -62,7 +62,7 @@ impl WalWriteBench {
             let runtimes = WalRuntimes {
                 read_runtime: self.runtime.clone(),
                 write_runtime: self.runtime.clone(),
-                bg_runtime: self.runtime.clone(),
+                default_runtime: self.runtime.clone(),
             };
 
             let wal = WalNamespaceImpl::open(

--- a/docs/example-standalone-static-routing.toml
+++ b/docs/example-standalone-static-routing.toml
@@ -9,7 +9,8 @@ level = "info"
 [runtime]
 read_thread_num = 4
 write_thread_num = 4
-background_thread_num = 4
+compact_thread_num = 2
+default_thread_num = 4
 
 [analytic]
 write_group_worker_num = 4

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Grpc services
 
@@ -335,7 +335,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
 
         let forward_config = self.forward_config.unwrap_or_default();
         let hotspot_config = self.hotspot_config.unwrap_or_default();
-        let runtime = runtimes.bg_runtime.clone();
+        let runtime = runtimes.default_runtime.clone();
         let proxy = Proxy::try_new(
             router,
             instance,

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Http service
 
@@ -165,7 +165,7 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
             },
         );
 
-        self.engine_runtimes.bg_runtime.spawn(server);
+        self.engine_runtimes.default_runtime.spawn(server);
 
         Ok(())
     }
@@ -536,7 +536,7 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
             .default_schema_name()
             .to_string();
         //TODO(boyan) use read/write runtime by sql type.
-        let runtime = self.engine_runtimes.bg_runtime.clone();
+        let runtime = self.engine_runtimes.default_runtime.clone();
         let timeout = self.config.timeout;
         let router = self.router.clone();
 

--- a/server/src/mysql/service.rs
+++ b/server/src/mysql/service.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
@@ -54,7 +54,7 @@ impl<Q: QueryExecutor + 'static> MysqlService<Q> {
 
         info!("MySQL server tries to listen on {}", self.socket_addr);
 
-        self.join_handler = Some(rt.bg_runtime.spawn(Self::loop_accept(
+        self.join_handler = Some(rt.default_runtime.spawn(Self::loop_accept(
             self.instance.clone(),
             self.runtimes.clone(),
             self.router.clone(),

--- a/server/src/mysql/worker.rs
+++ b/server/src/mysql/worker.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use std::{marker::PhantomData, sync::Arc, time::Duration};
 
@@ -140,7 +140,7 @@ where
             .catalog_manager
             .default_schema_name()
             .to_string();
-        let runtime = self.runtimes.bg_runtime.clone();
+        let runtime = self.runtimes.default_runtime.clone();
 
         RequestContext::builder()
             .catalog(default_catalog)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 // Config for ceresdb server.
 
@@ -77,14 +77,16 @@ pub enum ClusterDeployment {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct RuntimeConfig {
-    // Runtime for reading data
+    /// Runtime for reading data
     pub read_thread_num: usize,
-    // Runtime for writing data
+    /// Runtime for writing data
     pub write_thread_num: usize,
-    // Runtime for communicating with meta cluster
+    /// Runtime for communicating with meta cluster
     pub meta_thread_num: usize,
-    // Runtime for background tasks
-    pub background_thread_num: usize,
+    /// Runtime for compaction
+    pub compact_thread_num: usize,
+    /// Runtime for other tasks which may not important
+    pub default_thread_num: usize,
 }
 
 impl Default for RuntimeConfig {
@@ -93,7 +95,8 @@ impl Default for RuntimeConfig {
             read_thread_num: 8,
             write_thread_num: 8,
             meta_thread_num: 2,
-            background_thread_num: 8,
+            compact_thread_num: 4,
+            default_thread_num: 8,
         }
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -65,8 +65,9 @@ fn build_engine_runtimes(config: &RuntimeConfig) -> EngineRuntimes {
     EngineRuntimes {
         read_runtime: Arc::new(build_runtime("ceres-read", config.read_thread_num)),
         write_runtime: Arc::new(build_runtime("ceres-write", config.write_thread_num)),
+        compaction_runtime: Arc::new(build_runtime("ceres-compact", config.compact_thread_num)),
         meta_runtime: Arc::new(build_runtime("ceres-meta", config.meta_thread_num)),
-        bg_runtime: Arc::new(build_runtime("ceres-bg", config.background_thread_num)),
+        default_runtime: Arc::new(build_runtime("ceres-default", config.default_thread_num)),
     }
 }
 
@@ -78,7 +79,7 @@ pub fn run_server(config: Config, log_runtime: RuntimeLevel) {
 
     info!("Server starts up, config:{:#?}", config);
 
-    runtimes.bg_runtime.block_on(async {
+    runtimes.default_runtime.block_on(async {
         match config.analytic.wal {
             WalStorageConfig::RocksDB(_) => {
                 run_server_with_runtimes::<RocksDBWalsOpener>(config, engine_runtimes, log_runtime)

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -65,7 +65,7 @@ fn build_engine_runtimes(config: &RuntimeConfig) -> EngineRuntimes {
     EngineRuntimes {
         read_runtime: Arc::new(build_runtime("ceres-read", config.read_thread_num)),
         write_runtime: Arc::new(build_runtime("ceres-write", config.write_thread_num)),
-        compaction_runtime: Arc::new(build_runtime("ceres-compact", config.compact_thread_num)),
+        compact_runtime: Arc::new(build_runtime("ceres-compact", config.compact_thread_num)),
         meta_runtime: Arc::new(build_runtime("ceres-meta", config.meta_thread_num)),
         default_runtime: Arc::new(build_runtime("ceres-default", config.default_thread_num)),
     }

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -305,7 +305,7 @@ pub type TableEngineRef = Arc<dyn TableEngine>;
 pub struct EngineRuntimes {
     pub read_runtime: Arc<Runtime>,
     pub write_runtime: Arc<Runtime>,
-    pub compaction_runtime: Arc<Runtime>,
+    pub compact_runtime: Arc<Runtime>,
     pub meta_runtime: Arc<Runtime>,
     pub default_runtime: Arc<Runtime>,
 }

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -305,6 +305,7 @@ pub type TableEngineRef = Arc<dyn TableEngine>;
 pub struct EngineRuntimes {
     pub read_runtime: Arc<Runtime>,
     pub write_runtime: Arc<Runtime>,
+    pub compaction_runtime: Arc<Runtime>,
     pub meta_runtime: Arc<Runtime>,
-    pub bg_runtime: Arc<Runtime>,
+    pub default_runtime: Arc<Runtime>,
 }

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -303,9 +303,14 @@ pub type TableEngineRef = Arc<dyn TableEngine>;
 
 #[derive(Clone, Debug)]
 pub struct EngineRuntimes {
+    /// Runtime for reading data
     pub read_runtime: Arc<Runtime>,
+    /// Runtime for writing data
     pub write_runtime: Arc<Runtime>,
+    /// Runtime for compacting data
     pub compact_runtime: Arc<Runtime>,
+    /// Runtime for ceresmeta communication
     pub meta_runtime: Arc<Runtime>,
+    /// Runtime for some other tasks which are not so important
     pub default_runtime: Arc<Runtime>,
 }

--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Namespace of wal on message queue
 
@@ -152,12 +152,15 @@ impl<M: MessageQueue> Namespace<M> {
     pub fn open(
         namespace: String,
         message_queue: Arc<M>,
-        bg_runtime: Arc<Runtime>,
+        default_runtime: Arc<Runtime>,
         config: Config,
     ) -> Self {
         let inner = Arc::new(NamespaceInner::new(namespace, message_queue));
-        let cleaner_handle =
-            start_log_cleaner(bg_runtime.as_ref(), config.clean_period.0, inner.clone());
+        let cleaner_handle = start_log_cleaner(
+            default_runtime.as_ref(),
+            config.clean_period.0,
+            inner.clone(),
+        );
 
         Self {
             inner,

--- a/wal/src/message_queue_impl/wal.rs
+++ b/wal/src/message_queue_impl/wal.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Wal based on message queue
 
@@ -29,13 +29,13 @@ impl<M: MessageQueue> MessageQueueImpl<M> {
     pub fn new(
         namespace: String,
         message_queue: M,
-        bg_runtime: Arc<Runtime>,
+        default_runtime: Arc<Runtime>,
         config: Config,
     ) -> Self {
         MessageQueueImpl(Namespace::open(
             namespace,
             Arc::new(message_queue),
-            bg_runtime,
+            default_runtime,
             config,
         ))
     }

--- a/wal/src/table_kv_impl/mod.rs
+++ b/wal/src/table_kv_impl/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Wal implementation based on TableKv.
 
@@ -26,5 +26,5 @@ mod consts {
 pub struct WalRuntimes {
     pub read_runtime: Arc<Runtime>,
     pub write_runtime: Arc<Runtime>,
-    pub bg_runtime: Arc<Runtime>,
+    pub default_runtime: Arc<Runtime>,
 }

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Wal namespace.
 
@@ -349,7 +349,7 @@ impl<T: TableKv> NamespaceInner<T> {
         let namespace = self.name().to_string();
         let meta_table_name = self.meta_table_name.clone();
         let table_kv = self.table_kv.clone();
-        self.runtimes.bg_runtime.spawn_blocking(move || {
+        self.runtimes.default_runtime.spawn_blocking(move || {
             let outdated_buckets = outdated_buckets.into_iter().map(Arc::new).collect();
             if let Err(e) = purge_buckets(outdated_buckets, &namespace, &meta_table_name, &table_kv)
             {
@@ -1031,7 +1031,7 @@ impl<T: TableKv> Namespace<T> {
 
             // Has ttl, we need to periodically create/purge buckets.
             monitor_handle = Some(start_bucket_monitor(
-                &runtimes.bg_runtime,
+                &runtimes.default_runtime,
                 BUCKET_MONITOR_PERIOD,
                 inner.clone(),
             ));
@@ -1040,7 +1040,7 @@ impl<T: TableKv> Namespace<T> {
 
             // Start a cleaner if wal has no ttl.
             cleaner_handle = Some(start_log_cleaner(
-                &runtimes.bg_runtime,
+                &runtimes.default_runtime,
                 LOG_CLEANER_PERIOD,
                 inner.clone(),
             ));
@@ -1495,7 +1495,7 @@ mod tests {
         WalRuntimes {
             read_runtime: runtime.clone(),
             write_runtime: runtime.clone(),
-            bg_runtime: runtime,
+            default_runtime: runtime,
         }
     }
 

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Table unit in wal.
 
@@ -209,7 +209,7 @@ impl TableUnit {
     ) -> Result<Option<TableUnit>> {
         let table_kv = table_kv.clone();
         let table_unit_meta_table = table_unit_meta_table.to_string();
-        let rt = runtimes.bg_runtime.clone();
+        let rt = runtimes.default_runtime.clone();
 
         rt.spawn_blocking(move || {
             // Load of create table unit entry.
@@ -264,7 +264,7 @@ impl TableUnit {
     ) -> Result<TableUnit> {
         let table_kv = table_kv.clone();
         let table_unit_meta_table = table_unit_meta_table.to_string();
-        let rt = runtimes.bg_runtime.clone();
+        let rt = runtimes.default_runtime.clone();
 
         rt.spawn_blocking(move || {
             // Load of create table unit entry.

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Wal based on namespace.
 
@@ -53,7 +53,7 @@ impl<T: TableKv> WalNamespaceImpl<T> {
         name: &str,
         config: NamespaceConfig,
     ) -> Result<NamespaceRef<T>> {
-        let rt = runtimes.bg_runtime.clone();
+        let rt = runtimes.default_runtime.clone();
         let table_kv = table_kv.clone();
         let namespace_name = name.to_string();
 

--- a/wal/src/tests/util.rs
+++ b/wal/src/tests/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! utilities for testing wal module.
 
@@ -88,7 +88,7 @@ impl WalBuilder for MemoryTableWalBuilder {
         let wal_runtimes = WalRuntimes {
             read_runtime: runtime.clone(),
             write_runtime: runtime.clone(),
-            bg_runtime: runtime.clone(),
+            default_runtime: runtime.clone(),
         };
         let namespace_wal =
             WalNamespaceImpl::open(self.table_kv.clone(), wal_runtimes, WAL_NAMESPACE, config)


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, the `bg_runtime` is used for many scenarios, e.g. grpc service, hotspot recording, and so on. And `bg_runtime` is also used heavily by compaction, that is to say, the other scenarios will be hungry to run, leading to blocking in the key paths, e.g. write procedure.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Replace the bg_runtime with default_runtime and compact_runtime.

<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
The runtime config will be updated.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
By manually tests, it is found written rows per second changes from 4K(1 bg thread) -> 100K(1 default thread + 1 compact thread).
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->