### PR TITLE
feat: add metrics for write procedure

### DIFF
--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -292,6 +292,7 @@ impl Instance {
         table_data: &TableDataRef,
         request: WriteRequest,
     ) -> Result<usize> {
+        let _timer = table_data.metrics.start_table_write_timer();
         let mut encode_ctx = EncodeContext::new(request.row_group);
 
         self.preprocess_write(worker_local, space, table_data, &mut encode_ctx)
@@ -443,7 +444,7 @@ impl Instance {
         table_data: &TableDataRef,
         encode_ctx: &mut EncodeContext,
     ) -> Result<()> {
-        let _timer = table_data.metrics.start_table_write_preprocess_timer();
+        let _total_timer = table_data.metrics.start_table_write_preprocess_timer();
         ensure!(
             !table_data.is_dropped(),
             WriteDroppedTable {

--- a/analytic_engine/src/table/metrics.rs
+++ b/analytic_engine/src/table/metrics.rs
@@ -144,6 +144,7 @@ pub struct Metrics {
     table_write_space_flush_wait_duration: Histogram,
     table_write_instance_flush_wait_duration: Histogram,
     table_write_flush_wait_duration: Histogram,
+    table_write_total_duration: Histogram,
 }
 
 impl Default for Metrics {
@@ -174,6 +175,8 @@ impl Default for Metrics {
                 .with_label_values(&["wait_instance_flush"]),
             table_write_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
                 .with_label_values(&["wait_flush"]),
+            table_write_total_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["total"]),
         }
     }
 }
@@ -204,6 +207,11 @@ impl Metrics {
     pub fn on_write_stall(&self, duration: Duration) {
         self.table_write_stall_duration
             .observe(duration.as_secs_f64());
+    }
+
+    #[inline]
+    pub fn start_table_write_timer(&self) -> HistogramTimer {
+        self.table_write_total_duration.start_timer()
     }
 
     #[inline]

--- a/analytic_engine/src/table/metrics.rs
+++ b/analytic_engine/src/table/metrics.rs
@@ -29,9 +29,9 @@ lazy_static! {
     )
     .unwrap();
 
-    static ref TABLE_WRITE_BATCH_HISTGRAM: Histogram = register_histogram!(
+    static ref TABLE_WRITE_BATCH_HISTOGRAM: Histogram = register_histogram!(
         "table_write_batch_size",
-        "Histgram of write batch size",
+        "Histogram of write batch size",
         vec![10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0]
     )
     .unwrap();
@@ -96,9 +96,10 @@ lazy_static! {
     ).unwrap();
 
     // Buckets: 0, 0.01, .., 0.01 * 2^12
-    static ref TABLE_WRITE_STALL_DURATION_HISTOGRAM: Histogram = register_histogram!(
-        "table_write_stall_duration",
+    static ref TABLE_WRITE_DURATION_HISTOGRAM: HistogramVec = register_histogram_vec!(
+        "table_write_duration",
         "Histogram for write stall duration of the table in seconds",
+        &["type"],
         exponential_buckets(0.01, 2.0, 13).unwrap()
     ).unwrap();
 
@@ -134,6 +135,15 @@ pub struct Metrics {
     compaction_output_sst_size_histogram: Histogram,
     compaction_input_sst_row_num_histogram: Histogram,
     compaction_output_sst_row_num_histogram: Histogram,
+
+    table_write_stall_duration: Histogram,
+    table_write_encode_duration: Histogram,
+    table_write_wal_duration: Histogram,
+    table_write_memtable_duration: Histogram,
+    table_write_preprocess_duration: Histogram,
+    table_write_space_flush_wait_duration: Histogram,
+    table_write_instance_flush_wait_duration: Histogram,
+    table_write_flush_wait_duration: Histogram,
 }
 
 impl Default for Metrics {
@@ -148,6 +158,22 @@ impl Default for Metrics {
                 .with_label_values(&["input"]),
             compaction_output_sst_row_num_histogram: TABLE_COMPACTION_SST_ROW_NUM_HISTOGRAM
                 .with_label_values(&["output"]),
+
+            table_write_stall_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["stall"]),
+            table_write_encode_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["encode"]),
+            table_write_wal_duration: TABLE_WRITE_DURATION_HISTOGRAM.with_label_values(&["wal"]),
+            table_write_memtable_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["memtable"]),
+            table_write_preprocess_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["preprocess"]),
+            table_write_space_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["space_flush_wait"]),
+            table_write_instance_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["instance_flush_wait"]),
+            table_write_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["flush_wait"]),
         }
     }
 }
@@ -165,7 +191,7 @@ impl Metrics {
 
     #[inline]
     pub fn on_write_request_done(&self, num_rows: usize) {
-        TABLE_WRITE_BATCH_HISTGRAM.observe(num_rows as f64);
+        TABLE_WRITE_BATCH_HISTOGRAM.observe(num_rows as f64);
     }
 
     #[inline]
@@ -176,7 +202,43 @@ impl Metrics {
 
     #[inline]
     pub fn on_write_stall(&self, duration: Duration) {
-        TABLE_WRITE_STALL_DURATION_HISTOGRAM.observe(duration.as_secs_f64());
+        self.table_write_stall_duration
+            .observe(duration.as_secs_f64());
+    }
+
+    #[inline]
+    pub fn start_table_write_encode_timer(&self) -> HistogramTimer {
+        self.table_write_encode_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_memtable_timer(&self) -> HistogramTimer {
+        self.table_write_memtable_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_wal_timer(&self) -> HistogramTimer {
+        self.table_write_wal_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_preprocess_timer(&self) -> HistogramTimer {
+        self.table_write_preprocess_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_space_flush_wait_timer(&self) -> HistogramTimer {
+        self.table_write_space_flush_wait_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_instance_flush_wait_timer(&self) -> HistogramTimer {
+        self.table_write_instance_flush_wait_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_flush_wait_timer(&self) -> HistogramTimer {
+        self.table_write_flush_wait_duration.start_timer()
     }
 
     #[inline]

--- a/analytic_engine/src/table/metrics.rs
+++ b/analytic_engine/src/table/metrics.rs
@@ -169,11 +169,11 @@ impl Default for Metrics {
             table_write_preprocess_duration: TABLE_WRITE_DURATION_HISTOGRAM
                 .with_label_values(&["preprocess"]),
             table_write_space_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
-                .with_label_values(&["space_flush_wait"]),
+                .with_label_values(&["wait_space_flush"]),
             table_write_instance_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
-                .with_label_values(&["instance_flush_wait"]),
+                .with_label_values(&["wait_instance_flush"]),
             table_write_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
-                .with_label_values(&["flush_wait"]),
+                .with_label_values(&["wait_flush"]),
         }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 In order to improve the write performance, some metrics for the write procedure are necessary but missing now.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Add metrics for all stages during the write procedure.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Manual test.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

This is what the metrics looks like:
```
table_write_duration_bucket{type="encode",le="0.01"} 32
table_write_duration_bucket{type="encode",le="0.02"} 43
table_write_duration_bucket{type="encode",le="0.04"} 45
table_write_duration_bucket{type="encode",le="0.08"} 45
table_write_duration_bucket{type="encode",le="0.16"} 45
table_write_duration_bucket{type="encode",le="0.32"} 45
table_write_duration_bucket{type="encode",le="0.64"} 45
table_write_duration_bucket{type="encode",le="1.28"} 45
table_write_duration_bucket{type="encode",le="2.56"} 45
table_write_duration_bucket{type="encode",le="5.12"} 45
table_write_duration_bucket{type="encode",le="10.24"} 45
table_write_duration_bucket{type="encode",le="20.48"} 45
table_write_duration_bucket{type="encode",le="40.96"} 45
table_write_duration_bucket{type="encode",le="+Inf"} 45
table_write_duration_sum{type="encode"} 0.454472457
table_write_duration_count{type="encode"} 45
table_write_duration_bucket{type="flush_wait",le="0.01"} 4
table_write_duration_bucket{type="flush_wait",le="0.02"} 4
table_write_duration_bucket{type="flush_wait",le="0.04"} 4
table_write_duration_bucket{type="flush_wait",le="0.08"} 4
table_write_duration_bucket{type="flush_wait",le="0.16"} 4
table_write_duration_bucket{type="flush_wait",le="0.32"} 4
table_write_duration_bucket{type="flush_wait",le="0.64"} 5
table_write_duration_bucket{type="flush_wait",le="1.28"} 5
table_write_duration_bucket{type="flush_wait",le="2.56"} 5
table_write_duration_bucket{type="flush_wait",le="5.12"} 5
table_write_duration_bucket{type="flush_wait",le="10.24"} 5
table_write_duration_bucket{type="flush_wait",le="20.48"} 5
table_write_duration_bucket{type="flush_wait",le="40.96"} 5
table_write_duration_bucket{type="flush_wait",le="+Inf"} 5
table_write_duration_sum{type="flush_wait"} 0.374436524
table_write_duration_count{type="flush_wait"} 5
table_write_duration_bucket{type="instance_flush_wait",le="0.01"} 0
table_write_duration_bucket{type="instance_flush_wait",le="0.02"} 0
table_write_duration_bucket{type="instance_flush_wait",le="0.04"} 0
table_write_duration_bucket{type="instance_flush_wait",le="0.08"} 0
table_write_duration_bucket{type="instance_flush_wait",le="0.16"} 0
table_write_duration_bucket{type="instance_flush_wait",le="0.32"} 0
table_write_duration_bucket{type="instance_flush_wait",le="0.64"} 0
table_write_duration_bucket{type="instance_flush_wait",le="1.28"} 0
table_write_duration_bucket{type="instance_flush_wait",le="2.56"} 0
table_write_duration_bucket{type="instance_flush_wait",le="5.12"} 0
table_write_duration_bucket{type="instance_flush_wait",le="10.24"} 0
table_write_duration_bucket{type="instance_flush_wait",le="20.48"} 0
table_write_duration_bucket{type="instance_flush_wait",le="40.96"} 0
table_write_duration_bucket{type="instance_flush_wait",le="+Inf"} 0
table_write_duration_sum{type="instance_flush_wait"} 0
table_write_duration_count{type="instance_flush_wait"} 0
table_write_duration_bucket{type="memtable",le="0.01"} 35
table_write_duration_bucket{type="memtable",le="0.02"} 39
table_write_duration_bucket{type="memtable",le="0.04"} 43
table_write_duration_bucket{type="memtable",le="0.08"} 45
table_write_duration_bucket{type="memtable",le="0.16"} 45
table_write_duration_bucket{type="memtable",le="0.32"} 45
table_write_duration_bucket{type="memtable",le="0.64"} 45
table_write_duration_bucket{type="memtable",le="1.28"} 45
table_write_duration_bucket{type="memtable",le="2.56"} 45
table_write_duration_bucket{type="memtable",le="5.12"} 45
table_write_duration_bucket{type="memtable",le="10.24"} 45
table_write_duration_bucket{type="memtable",le="20.48"} 45
table_write_duration_bucket{type="memtable",le="40.96"} 45
table_write_duration_bucket{type="memtable",le="+Inf"} 45
table_write_duration_sum{type="memtable"} 0.5338555669999999
table_write_duration_count{type="memtable"} 45
table_write_duration_bucket{type="preprocess",le="0.01"} 44
table_write_duration_bucket{type="preprocess",le="0.02"} 44
table_write_duration_bucket{type="preprocess",le="0.04"} 44
table_write_duration_bucket{type="preprocess",le="0.08"} 44
table_write_duration_bucket{type="preprocess",le="0.16"} 44
table_write_duration_bucket{type="preprocess",le="0.32"} 44
table_write_duration_bucket{type="preprocess",le="0.64"} 45
table_write_duration_bucket{type="preprocess",le="1.28"} 45
table_write_duration_bucket{type="preprocess",le="2.56"} 45
table_write_duration_bucket{type="preprocess",le="5.12"} 45
table_write_duration_bucket{type="preprocess",le="10.24"} 45
table_write_duration_bucket{type="preprocess",le="20.48"} 45
table_write_duration_bucket{type="preprocess",le="40.96"} 45
table_write_duration_bucket{type="preprocess",le="+Inf"} 45
table_write_duration_sum{type="preprocess"} 0.38392951199999986
table_write_duration_count{type="preprocess"} 45
table_write_duration_bucket{type="space_flush_wait",le="0.01"} 0
table_write_duration_bucket{type="space_flush_wait",le="0.02"} 0
table_write_duration_bucket{type="space_flush_wait",le="0.04"} 0
table_write_duration_bucket{type="space_flush_wait",le="0.08"} 0
table_write_duration_bucket{type="space_flush_wait",le="0.16"} 0
table_write_duration_bucket{type="space_flush_wait",le="0.32"} 0
table_write_duration_bucket{type="space_flush_wait",le="0.64"} 0
table_write_duration_bucket{type="space_flush_wait",le="1.28"} 0
table_write_duration_bucket{type="space_flush_wait",le="2.56"} 0
table_write_duration_bucket{type="space_flush_wait",le="5.12"} 0
table_write_duration_bucket{type="space_flush_wait",le="10.24"} 0
table_write_duration_bucket{type="space_flush_wait",le="20.48"} 0
table_write_duration_bucket{type="space_flush_wait",le="40.96"} 0
table_write_duration_bucket{type="space_flush_wait",le="+Inf"} 0
table_write_duration_sum{type="space_flush_wait"} 0
table_write_duration_count{type="space_flush_wait"} 0
table_write_duration_bucket{type="stall",le="0.01"} 0
table_write_duration_bucket{type="stall",le="0.02"} 0
table_write_duration_bucket{type="stall",le="0.04"} 0
table_write_duration_bucket{type="stall",le="0.08"} 0
table_write_duration_bucket{type="stall",le="0.16"} 0
table_write_duration_bucket{type="stall",le="0.32"} 0
table_write_duration_bucket{type="stall",le="0.64"} 1
table_write_duration_bucket{type="stall",le="1.28"} 1
table_write_duration_bucket{type="stall",le="2.56"} 1
table_write_duration_bucket{type="stall",le="5.12"} 1
table_write_duration_bucket{type="stall",le="10.24"} 1
table_write_duration_bucket{type="stall",le="20.48"} 1
table_write_duration_bucket{type="stall",le="40.96"} 1
table_write_duration_bucket{type="stall",le="+Inf"} 1
table_write_duration_sum{type="stall"} 0.374154946
table_write_duration_count{type="stall"} 1
table_write_duration_bucket{type="wal",le="0.01"} 32
table_write_duration_bucket{type="wal",le="0.02"} 44
table_write_duration_bucket{type="wal",le="0.04"} 45
table_write_duration_bucket{type="wal",le="0.08"} 45
table_write_duration_bucket{type="wal",le="0.16"} 45
table_write_duration_bucket{type="wal",le="0.32"} 45
table_write_duration_bucket{type="wal",le="0.64"} 45
table_write_duration_bucket{type="wal",le="1.28"} 45
table_write_duration_bucket{type="wal",le="2.56"} 45
table_write_duration_bucket{type="wal",le="5.12"} 45
table_write_duration_bucket{type="wal",le="10.24"} 45
table_write_duration_bucket{type="wal",le="20.48"} 45
table_write_duration_bucket{type="wal",le="40.96"} 45
table_write_duration_bucket{type="wal",le="+Inf"} 45
table_write_duration_sum{type="wal"} 0.37082901800000007
table_write_duration_count{type="wal"} 45
```
