### PR TITLE
fix: improve remote write performance by using separate runtime

### DIFF
--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -455,7 +455,8 @@ impl Builder {
                 write_runtime: runtime.clone(),
                 meta_runtime: runtime.clone(),
                 compact_runtime: runtime.clone(),
-                default_runtime: runtime,
+                default_runtime: runtime.clone(),
+                io_runtime: runtime,
             }),
         }
     }

--- a/partition_table_engine/src/lib.rs
+++ b/partition_table_engine/src/lib.rs
@@ -9,7 +9,7 @@ mod partition;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use common_util::error::BoxError;
+use common_util::{error::BoxError, runtime::Runtime};
 use snafu::{OptionExt, ResultExt};
 use table_engine::{
     engine::{
@@ -26,11 +26,15 @@ use crate::partition::{PartitionTableImpl, TableData};
 /// Partition table engine implementation.
 pub struct PartitionTableEngine {
     remote_engine_ref: RemoteEngineRef,
+    io_runtime: Arc<Runtime>,
 }
 
 impl PartitionTableEngine {
-    pub fn new(remote_engine_ref: RemoteEngineRef) -> Self {
-        Self { remote_engine_ref }
+    pub fn new(remote_engine_ref: RemoteEngineRef, io_runtime: Arc<Runtime>) -> Self {
+        Self {
+            remote_engine_ref,
+            io_runtime,
+        }
     }
 }
 
@@ -58,9 +62,13 @@ impl TableEngine for PartitionTableEngine {
             engine_type: request.engine,
         };
         Ok(Arc::new(
-            PartitionTableImpl::new(table_data, self.remote_engine_ref.clone())
-                .box_err()
-                .context(Unexpected)?,
+            PartitionTableImpl::new(
+                table_data,
+                self.remote_engine_ref.clone(),
+                self.io_runtime.clone(),
+            )
+            .box_err()
+            .context(Unexpected)?,
         ))
     }
 

--- a/remote_engine_client/src/cached_router.rs
+++ b/remote_engine_client/src/cached_router.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Cached router
 
@@ -43,14 +43,14 @@ impl CachedRouter {
             cache.get(table_ident).cloned()
         };
 
-        let channel = if let Some(channel) = channel_opt {
+        if let Some(channel) = channel_opt {
             // If found, return it.
             debug!(
                 "CachedRouter found channel in cache, table_ident:{:?}",
                 table_ident
             );
 
-            channel
+            Ok(channel)
         } else {
             // If not found, do real route work, and try to put it into cache(may have been
             // put by other threads).
@@ -63,7 +63,7 @@ impl CachedRouter {
             {
                 let mut cache = self.cache.write().unwrap();
                 // Double check here, if still not found, we put it.
-                let channel_opt = cache.get(table_ident).cloned();
+                let channel_opt = cache.get(table_ident);
                 if channel_opt.is_none() {
                     debug!(
                         "CachedRouter put the new channel to cache, table_ident:{:?}",
@@ -73,10 +73,8 @@ impl CachedRouter {
                 }
             }
 
-            channel
-        };
-
-        Ok(channel)
+            Ok(channel)
+        }
     }
 
     pub async fn evict(&self, table_ident: &TableIdentifier) {

--- a/remote_engine_client/src/channel.rs
+++ b/remote_engine_client/src/channel.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Channel pool
 
@@ -35,10 +35,7 @@ impl ChannelPool {
             }
         }
 
-        let channel = self
-            .builder
-            .build(endpoint.clone().to_string().as_str())
-            .await?;
+        let channel = self.builder.build(&endpoint.to_string()).await?;
         let mut inner = self.channels.write().unwrap();
         // Double check here.
         if let Some(channel) = inner.get(endpoint) {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -318,7 +318,10 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             router.clone(),
         ));
 
-        let partition_table_engine = Arc::new(PartitionTableEngine::new(remote_engine_ref.clone()));
+        let partition_table_engine = Arc::new(PartitionTableEngine::new(
+            remote_engine_ref.clone(),
+            engine_runtimes.io_runtime.clone(),
+        ));
 
         let instance = {
             let instance = Instance {

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,8 @@ pub struct RuntimeConfig {
     pub compact_thread_num: usize,
     /// Runtime for other tasks which may not important
     pub default_thread_num: usize,
+    /// Runtime for io
+    pub io_thread_num: usize,
 }
 
 impl Default for RuntimeConfig {
@@ -97,6 +99,7 @@ impl Default for RuntimeConfig {
             meta_thread_num: 2,
             compact_thread_num: 4,
             default_thread_num: 8,
+            io_thread_num: 4,
         }
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -68,6 +68,7 @@ fn build_engine_runtimes(config: &RuntimeConfig) -> EngineRuntimes {
         compact_runtime: Arc::new(build_runtime("ceres-compact", config.compact_thread_num)),
         meta_runtime: Arc::new(build_runtime("ceres-meta", config.meta_thread_num)),
         default_runtime: Arc::new(build_runtime("ceres-default", config.default_thread_num)),
+        io_runtime: Arc::new(build_runtime("ceres-io", config.io_thread_num)),
     }
 }
 

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -313,4 +313,6 @@ pub struct EngineRuntimes {
     pub meta_runtime: Arc<Runtime>,
     /// Runtime for some other tasks which are not so important
     pub default_runtime: Arc<Runtime>,
+    /// Runtime for io task
+    pub io_runtime: Arc<Runtime>,
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, the write runtime is also used for the remote engine client's network io, which may lead to extra time cost because of the scheduling overhead.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Use separate runtime for the io operations.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
New config option `io_thread_num` in the runtime.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Manually tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
