### PR TITLE
feat: tsbs support more write options

### DIFF
--- a/scripts/run-tsbs.sh
+++ b/scripts/run-tsbs.sh
@@ -6,6 +6,8 @@
 # - LOG_DIR
 # - CERESDB_CONFIG_FILE
 # - CERESDB_ADDR
+# - WRITE_WORKER_NUM
+# - WRITE_BATCH_SIZE
 
 export CURR_DIR=$(pwd)
 export DEFAULT_RESULT_FILE=${CURR_DIR}/tsbs/result.md
@@ -14,6 +16,8 @@ export CERESDB_CONFIG_FILE=${CERESDB_CONFIG_FILE:-docs/minimal.toml}
 export LOG_DIR=${LOG_DIR:-${CURR_DIR}/logs}
 export CERESDB_ADDR=${CERESDB_ADDR:-127.0.0.1:8831}
 export CERESDB_PID_FILE=${CURR_DIR}/ceresdb-server.pid
+export WRITE_WORKER_NUM=${WRITE_WORKER_NUM:-36}
+export WRITE_BATCH_SIZE=${WRITE_BATCH_SIZE:500}
 # Where generated data stored
 export DATA_FILE=${DATA_FILE:-data.out}
 # How many values in host tag
@@ -83,7 +87,7 @@ fi
 
 
 # Write data to ceresdb
-./tsbs_load_ceresdb --ceresdb-addr=${CERESDB_ADDR} --file ${DATA_FILE} | tee ${LOG_DIR}/write.log
+./tsbs_load_ceresdb --ceresdb-addr=${CERESDB_ADDR} --file ${DATA_FILE} --batch-size ${WRITE_BATH_SIZE} --workers ${WRITE_WORKER_NUM} | tee ${LOG_DIR}/write.log
     
 
 # Generate queries for query


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, TSBS only supports default params for writing and reading. But different machines may prefer different params because of their different resources.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Support two more params for TSBS:
- WRITE_BATCH_SIZE
- WRITE_WORKER_NUM
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
test by manual.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
