### PR TITLE
feat: support write batch in remote engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "common_types",
  "common_util",
  "datafusion",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "1.0.1"
-source = "git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776#e39526cf180cbd89c30a014a910484d50b4d8776"
+source = "git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190#8eb3497e1a71bc4be6f2795349b20294cc623190"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1343,7 +1343,7 @@ name = "cluster"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "common_types",
  "common_util",
  "log",
@@ -1393,7 +1393,7 @@ dependencies = [
  "arrow_ext",
  "byteorder",
  "bytes_ext",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "chrono",
  "datafusion",
  "murmur3",
@@ -1411,7 +1411,7 @@ version = "1.1.0"
 dependencies = [
  "arrow 36.0.0",
  "backtrace",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "chrono",
  "common_types",
  "crossbeam-utils 0.8.15",
@@ -3522,7 +3522,7 @@ name = "meta_client"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -4032,7 +4032,7 @@ version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "chrono",
  "clru",
  "common_util",
@@ -5264,7 +5264,7 @@ version = "1.1.0"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -5390,7 +5390,7 @@ name = "router"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "cluster",
  "common_types",
  "common_util",
@@ -5745,7 +5745,7 @@ dependencies = [
  "async-trait",
  "bytes 1.4.0",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "clru",
  "cluster",
  "common_types",
@@ -6079,7 +6079,7 @@ dependencies = [
  "arrow 36.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "cluster",
  "common_types",
  "common_util",
@@ -6327,7 +6327,7 @@ dependencies = [
  "arrow 36.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -6346,7 +6346,7 @@ dependencies = [
  "arrow 36.0.0",
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "common_types",
  "common_util",
  "datafusion",
@@ -7188,7 +7188,7 @@ name = "wal"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
  "chrono",
  "common_types",
  "common_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "common_types",
  "common_util",
  "datafusion",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "1.0.1"
-source = "git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190#8eb3497e1a71bc4be6f2795349b20294cc623190"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a#9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1343,7 +1343,7 @@ name = "cluster"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "common_types",
  "common_util",
  "log",
@@ -1393,7 +1393,7 @@ dependencies = [
  "arrow_ext",
  "byteorder",
  "bytes_ext",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "chrono",
  "datafusion",
  "murmur3",
@@ -1411,7 +1411,7 @@ version = "1.1.0"
 dependencies = [
  "arrow 36.0.0",
  "backtrace",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "chrono",
  "common_types",
  "crossbeam-utils 0.8.15",
@@ -3522,7 +3522,7 @@ name = "meta_client"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -4032,7 +4032,7 @@ version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "chrono",
  "clru",
  "common_util",
@@ -5264,7 +5264,7 @@ version = "1.1.0"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -5390,7 +5390,7 @@ name = "router"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "cluster",
  "common_types",
  "common_util",
@@ -5745,7 +5745,7 @@ dependencies = [
  "async-trait",
  "bytes 1.4.0",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "clru",
  "cluster",
  "common_types",
@@ -6079,7 +6079,7 @@ dependencies = [
  "arrow 36.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "cluster",
  "common_types",
  "common_util",
@@ -6327,7 +6327,7 @@ dependencies = [
  "arrow 36.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -6346,7 +6346,7 @@ dependencies = [
  "arrow 36.0.0",
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "common_types",
  "common_util",
  "datafusion",
@@ -7188,7 +7188,7 @@ name = "wal"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=8eb3497e1a71bc4be6f2795349b20294cc623190)",
+ "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a)",
  "chrono",
  "common_types",
  "common_util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "common_types",
  "common_util",
  "datafusion",
@@ -1181,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "ceresdbproto"
 version = "1.0.1"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b#1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b"
+source = "git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776#e39526cf180cbd89c30a014a910484d50b4d8776"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1343,7 +1343,7 @@ name = "cluster"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "common_types",
  "common_util",
  "log",
@@ -1393,7 +1393,7 @@ dependencies = [
  "arrow_ext",
  "byteorder",
  "bytes_ext",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "chrono",
  "datafusion",
  "murmur3",
@@ -1411,7 +1411,7 @@ version = "1.1.0"
 dependencies = [
  "arrow 36.0.0",
  "backtrace",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "chrono",
  "common_types",
  "crossbeam-utils 0.8.15",
@@ -3522,7 +3522,7 @@ name = "meta_client"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -4032,7 +4032,7 @@ version = "1.1.0"
 dependencies = [
  "async-trait",
  "bytes 1.4.0",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "chrono",
  "clru",
  "common_util",
@@ -5264,7 +5264,7 @@ version = "1.1.0"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -5390,7 +5390,7 @@ name = "router"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "cluster",
  "common_types",
  "common_util",
@@ -5745,7 +5745,7 @@ dependencies = [
  "async-trait",
  "bytes 1.4.0",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "clru",
  "cluster",
  "common_types",
@@ -6079,7 +6079,7 @@ dependencies = [
  "arrow 36.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "cluster",
  "common_types",
  "common_util",
@@ -6327,7 +6327,7 @@ dependencies = [
  "arrow 36.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "common_types",
  "common_util",
  "futures 0.3.28",
@@ -6346,7 +6346,7 @@ dependencies = [
  "arrow 36.0.0",
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "common_types",
  "common_util",
  "datafusion",
@@ -7188,7 +7188,7 @@ name = "wal"
 version = "1.1.0"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.1 (git+https://github.com/CeresDB/ceresdbproto.git?rev=1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b)",
+ "ceresdbproto 1.0.1 (git+https://github.com/Rachelint/ceresdbproto.git?rev=e39526cf180cbd89c30a014a910484d50b4d8776)",
  "chrono",
  "common_types",
  "common_util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,9 @@ toml = { workspace = true }
 tracing_util = { workspace = true }
 
 [workspace.dependencies.ceresdbproto]
-git = "https://github.com/CeresDB/ceresdbproto.git"
-rev = "1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b"
+git = "https://github.com/Rachelint/ceresdbproto.git"
+#rev = "1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b"
+rev = "e39526cf180cbd89c30a014a910484d50b4d8776"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ tracing_util = { workspace = true }
 [workspace.dependencies.ceresdbproto]
 git = "https://github.com/Rachelint/ceresdbproto.git"
 #rev = "1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b"
-rev = "e39526cf180cbd89c30a014a910484d50b4d8776"
+rev = "8eb3497e1a71bc4be6f2795349b20294cc623190"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,9 +151,8 @@ toml = { workspace = true }
 tracing_util = { workspace = true }
 
 [workspace.dependencies.ceresdbproto]
-git = "https://github.com/Rachelint/ceresdbproto.git"
-#rev = "1c3bf4e803ef8b7a1fbc8c3d4a07fdd372e1830b"
-rev = "8eb3497e1a71bc4be6f2795349b20294cc623190"
+git = "https://github.com/CeresDB/ceresdbproto.git"
+rev = "9e0e70f6574e4e1e2b3f7f45c0a055c54327fb4a"
 
 [build-dependencies]
 vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }

--- a/partition_table_engine/src/lib.rs
+++ b/partition_table_engine/src/lib.rs
@@ -9,7 +9,7 @@ mod partition;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use common_util::{error::BoxError, runtime::Runtime};
+use common_util::error::BoxError;
 use snafu::{OptionExt, ResultExt};
 use table_engine::{
     engine::{
@@ -26,15 +26,11 @@ use crate::partition::{PartitionTableImpl, TableData};
 /// Partition table engine implementation.
 pub struct PartitionTableEngine {
     remote_engine_ref: RemoteEngineRef,
-    io_runtime: Arc<Runtime>,
 }
 
 impl PartitionTableEngine {
-    pub fn new(remote_engine_ref: RemoteEngineRef, io_runtime: Arc<Runtime>) -> Self {
-        Self {
-            remote_engine_ref,
-            io_runtime,
-        }
+    pub fn new(remote_engine_ref: RemoteEngineRef) -> Self {
+        Self { remote_engine_ref }
     }
 }
 
@@ -62,13 +58,9 @@ impl TableEngine for PartitionTableEngine {
             engine_type: request.engine,
         };
         Ok(Arc::new(
-            PartitionTableImpl::new(
-                table_data,
-                self.remote_engine_ref.clone(),
-                self.io_runtime.clone(),
-            )
-            .box_err()
-            .context(Unexpected)?,
+            PartitionTableImpl::new(table_data, self.remote_engine_ref.clone())
+                .box_err()
+                .context(Unexpected)?,
         ))
     }
 

--- a/partition_table_engine/src/partition.rs
+++ b/partition_table_engine/src/partition.rs
@@ -2,14 +2,14 @@
 
 //! Distributed Table implementation
 
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{collections::HashMap, fmt};
 
 use async_trait::async_trait;
 use common_types::{
     row::{Row, RowGroupBuilder},
     schema::Schema,
 };
-use common_util::{error::BoxError, runtime::Runtime};
+use common_util::error::BoxError;
 use futures::future::try_join_all;
 use snafu::ResultExt;
 use table_engine::{
@@ -51,19 +51,13 @@ pub struct TableData {
 pub struct PartitionTableImpl {
     table_data: TableData,
     remote_engine: RemoteEngineRef,
-    io_runtime: Arc<Runtime>,
 }
 
 impl PartitionTableImpl {
-    pub fn new(
-        table_data: TableData,
-        remote_engine: RemoteEngineRef,
-        io_runtime: Arc<Runtime>,
-    ) -> Result<Self> {
+    pub fn new(table_data: TableData, remote_engine: RemoteEngineRef) -> Result<Self> {
         Ok(Self {
             table_data,
             remote_engine,
-            io_runtime,
         })
     }
 

--- a/remote_engine_client/src/lib.rs
+++ b/remote_engine_client/src/lib.rs
@@ -12,12 +12,13 @@ mod status_code;
 
 use std::{
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
 use async_trait::async_trait;
 use common_types::{record_batch::RecordBatch, schema::RecordSchema};
-use common_util::error::BoxError;
+use common_util::{error::BoxError, runtime::Runtime};
 pub use config::Config;
 use futures::{Stream, StreamExt};
 use router::RouterRef;
@@ -25,7 +26,7 @@ use snafu::ResultExt;
 use table_engine::{
     remote::{
         self,
-        model::{GetTableInfoRequest, ReadRequest, TableInfo, WriteRequest},
+        model::{GetTableInfoRequest, ReadRequest, TableInfo, WriteBatchResult, WriteRequest},
         RemoteEngine,
     },
     stream::{self, ErrWithSource, RecordBatchStream, SendableRecordBatchStream},
@@ -61,29 +62,11 @@ pub mod error {
         #[snafu(display("Failed to convert msg:{}, err:{}", msg, source))]
         Convert { msg: String, source: GenericError },
 
-        #[snafu(display(
-            "Failed to connect, table_ident:{:?}, msg:{}, err:{}",
-            table_ident,
-            msg,
-            source
-        ))]
-        Rpc {
-            table_ident: TableIdentifier,
-            msg: String,
-            source: tonic::Status,
-        },
+        #[snafu(display("Failed to connect, msg:{}, err:{}", msg, source))]
+        Rpc { msg: String, source: tonic::Status },
 
-        #[snafu(display(
-            "Failed to query from table in server, table_ident:{:?}, code:{}, msg:{}",
-            table_ident,
-            code,
-            msg
-        ))]
-        Server {
-            table_ident: TableIdentifier,
-            code: u32,
-            msg: String,
-        },
+        #[snafu(display("Failed to query from table in server, code:{}, msg:{}", code, msg))]
+        Server { code: u32, msg: String },
 
         #[snafu(display("Failed to route table, table_ident:{:?}, err:{}", table_ident, source,))]
         RouteWithCause {
@@ -104,8 +87,8 @@ pub mod error {
 pub struct RemoteEngineImpl(Client);
 
 impl RemoteEngineImpl {
-    pub fn new(config: Config, router: RouterRef) -> Self {
-        let client = Client::new(config, router);
+    pub fn new(config: Config, router: RouterRef, worker_runtime: Arc<Runtime>) -> Self {
+        let client = Client::new(config, router, worker_runtime);
 
         Self(client)
     }
@@ -120,6 +103,17 @@ impl RemoteEngine for RemoteEngineImpl {
 
     async fn write(&self, request: WriteRequest) -> remote::Result<usize> {
         self.0.write(request).await.box_err().context(remote::Write)
+    }
+
+    async fn write_batch(
+        &self,
+        requests: Vec<WriteRequest>,
+    ) -> remote::Result<Vec<WriteBatchResult>> {
+        self.0
+            .write_batch(requests)
+            .await
+            .box_err()
+            .context(remote::Write)
     }
 
     async fn get_table_info(&self, request: GetTableInfoRequest) -> remote::Result<TableInfo> {

--- a/remote_engine_client/src/lib.rs
+++ b/remote_engine_client/src/lib.rs
@@ -62,11 +62,29 @@ pub mod error {
         #[snafu(display("Failed to convert msg:{}, err:{}", msg, source))]
         Convert { msg: String, source: GenericError },
 
-        #[snafu(display("Failed to connect, msg:{}, err:{}", msg, source))]
-        Rpc { msg: String, source: tonic::Status },
+        #[snafu(display(
+            "Failed to connect, table_idents:{:?}, msg:{}, err:{}",
+            table_idents,
+            msg,
+            source
+        ))]
+        Rpc {
+            table_idents: Vec<TableIdentifier>,
+            msg: String,
+            source: tonic::Status,
+        },
 
-        #[snafu(display("Failed to query from table in server, code:{}, msg:{}", code, msg))]
-        Server { code: u32, msg: String },
+        #[snafu(display(
+            "Failed to query from table in server, table_idents:{:?}, code:{}, msg:{}",
+            table_idents,
+            code,
+            msg
+        ))]
+        Server {
+            table_idents: Vec<TableIdentifier>,
+            code: u32,
+            msg: String,
+        },
 
         #[snafu(display("Failed to route table, table_ident:{:?}, err:{}", table_ident, source,))]
         RouteWithCause {

--- a/server/src/grpc/metrics.rs
+++ b/server/src/grpc/metrics.rs
@@ -25,6 +25,7 @@ make_auto_flush_static_metric! {
         stream_read,
         write,
         get_table_info,
+        write_batch,
     }
 
     pub struct RemoteEngineGrpcHandlerDurationHistogramVec: LocalHistogram {

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -18,7 +18,7 @@ use ceresdbproto::{
 use common_types::record_batch::RecordBatch;
 use common_util::{error::BoxError, time::InstantExt};
 use futures::{
-    future::{join_all, try_join_all},
+    future::try_join_all,
     stream::{self, BoxStream, StreamExt},
 };
 use log::error;
@@ -44,11 +44,6 @@ pub(crate) mod error;
 
 const STREAM_QUERY_CHANNEL_LEN: usize = 20;
 const DEFAULT_COMPRESS_MIN_LENGTH: usize = 80 * 1024;
-
-struct TableWriteResult {
-    table_ident: TableIdentifier,
-    result: Result<WriteResponse>,
-}
 
 #[derive(Clone)]
 pub struct RemoteEngineServiceImpl<Q: QueryExecutor + 'static> {

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -10,14 +10,17 @@ use catalog::{manager::ManagerRef, schema::SchemaRef};
 use ceresdbproto::{
     remote_engine::{
         read_response::Output::Arrow, remote_engine_service_server::RemoteEngineService,
-        GetTableInfoRequest, GetTableInfoResponse, ReadRequest, ReadResponse, WriteRequest,
-        WriteResponse,
+        GetTableInfoRequest, GetTableInfoResponse, ReadRequest, ReadResponse, WriteBatchRequest,
+        WriteRequest, WriteResponse,
     },
     storage::{arrow_payload, ArrowPayload},
 };
 use common_types::record_batch::RecordBatch;
 use common_util::{error::BoxError, time::InstantExt};
-use futures::stream::{self, BoxStream, StreamExt};
+use futures::{
+    future::{join_all, try_join_all},
+    stream::{self, BoxStream, StreamExt},
+};
 use log::error;
 use query_engine::executor::Executor as QueryExecutor;
 use snafu::{OptionExt, ResultExt};
@@ -41,6 +44,11 @@ pub(crate) mod error;
 
 const STREAM_QUERY_CHANNEL_LEN: usize = 20;
 const DEFAULT_COMPRESS_MIN_LENGTH: usize = 80 * 1024;
+
+struct TableWriteResult {
+    table_ident: TableIdentifier,
+    result: Result<WriteResponse>,
+}
 
 #[derive(Clone)]
 pub struct RemoteEngineServiceImpl<Q: QueryExecutor + 'static> {
@@ -155,6 +163,45 @@ impl<Q: QueryExecutor + 'static> RemoteEngineServiceImpl<Q> {
         Ok(Response::new(resp))
     }
 
+    async fn write_batch_internal(
+        &self,
+        request: Request<WriteBatchRequest>,
+    ) -> std::result::Result<Response<WriteResponse>, Status> {
+        let begin_instant = Instant::now();
+        let request = request.into_inner();
+        let mut write_table_futures = Vec::with_capacity(request.batch.len());
+        for one_request in request.batch {
+            let ctx = self.handler_ctx();
+            write_table_futures.push(async move { handle_write(ctx, one_request).await });
+        }
+
+        let handle = self
+            .runtimes
+            .write_runtime
+            .spawn(try_join_all(write_table_futures));
+        let batch_result = handle.await.box_err().context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: "fail to run the join task",
+        });
+
+        let mut batch_resp = WriteResponse::default();
+        match batch_result {
+            Ok(Ok(v)) => {
+                batch_resp.header = Some(error::build_ok_header());
+                batch_resp.affected_rows = v.into_iter().map(|resp| resp.affected_rows).sum();
+            }
+            Ok(Err(e)) | Err(e) => {
+                batch_resp.header = Some(error::build_err_header(e));
+            }
+        };
+
+        REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC
+            .write_batch
+            .observe(begin_instant.saturating_elapsed().as_secs_f64());
+
+        Ok(Response::new(batch_resp))
+    }
+
     fn handler_ctx(&self) -> HandlerContext {
         HandlerContext {
             catalog_manager: self.instance.catalog_manager.clone(),
@@ -163,6 +210,7 @@ impl<Q: QueryExecutor + 'static> RemoteEngineServiceImpl<Q> {
 }
 
 /// Context for handling all kinds of remote engine service.
+#[derive(Clone)]
 struct HandlerContext {
     catalog_manager: ManagerRef,
 }
@@ -251,10 +299,9 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
 
     async fn write_batch(
         &self,
-        _: tonic::Request<ceresdbproto::remote_engine::WriteBatchRequest>,
-    ) -> std::result::Result<Response<ceresdbproto::remote_engine::WriteBatchResponse>, Status>
-    {
-        todo!()
+        request: Request<WriteBatchRequest>,
+    ) -> std::result::Result<Response<WriteResponse>, Status> {
+        self.write_batch_internal(request).await
     }
 }
 

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -248,6 +248,14 @@ impl<Q: QueryExecutor + 'static> RemoteEngineService for RemoteEngineServiceImpl
     ) -> std::result::Result<Response<GetTableInfoResponse>, Status> {
         self.get_table_info_internal(request).await
     }
+
+    async fn write_batch(
+        &self,
+        _: tonic::Request<ceresdbproto::remote_engine::WriteBatchRequest>,
+    ) -> std::result::Result<Response<ceresdbproto::remote_engine::WriteBatchResponse>, Status>
+    {
+        todo!()
+    }
 }
 
 async fn handle_stream_read(

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -319,10 +319,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             engine_runtimes.io_runtime.clone(),
         ));
 
-        let partition_table_engine = Arc::new(PartitionTableEngine::new(
-            remote_engine_ref.clone(),
-            engine_runtimes.io_runtime.clone(),
-        ));
+        let partition_table_engine = Arc::new(PartitionTableEngine::new(remote_engine_ref.clone()));
 
         let instance = {
             let instance = Instance {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -316,6 +316,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
         let remote_engine_ref = Arc::new(RemoteEngineImpl::new(
             self.remote_engine_client_config.clone(),
             router.clone(),
+            engine_runtimes.io_runtime.clone(),
         ));
 
         let partition_table_engine = Arc::new(PartitionTableEngine::new(

--- a/table_engine/src/remote/mod.rs
+++ b/table_engine/src/remote/mod.rs
@@ -12,7 +12,7 @@ use model::{ReadRequest, WriteRequest};
 use snafu::Snafu;
 
 use crate::{
-    remote::model::{GetTableInfoRequest, TableInfo},
+    remote::model::{GetTableInfoRequest, TableInfo, WriteBatchResult},
     stream::SendableRecordBatchStream,
 };
 
@@ -39,6 +39,8 @@ pub trait RemoteEngine: Send + Sync {
 
     /// Write to the remote engine.
     async fn write(&self, request: WriteRequest) -> Result<usize>;
+
+    async fn write_batch(&self, requests: Vec<WriteRequest>) -> Result<Vec<WriteBatchResult>>;
 
     async fn get_table_info(&self, request: GetTableInfoRequest) -> Result<TableInfo>;
 }

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -152,7 +152,7 @@ impl TryFrom<ceresdbproto::remote_engine::WriteBatchRequest> for WriteBatchReque
         let batch = pb
             .batch
             .into_iter()
-            .map(|req| WriteRequest::try_from(req))
+            .map(WriteRequest::try_from)
             .collect::<std::result::Result<Vec<_>, Self::Error>>()?;
 
         Ok(WriteBatchRequest { batch })
@@ -166,7 +166,7 @@ impl TryFrom<WriteBatchRequest> for ceresdbproto::remote_engine::WriteBatchReque
         let batch = batch_request
             .batch
             .into_iter()
-            .map(|req| remote_engine::WriteRequest::try_from(req))
+            .map(remote_engine::WriteRequest::try_from)
             .collect::<std::result::Result<Vec<_>, Self::Error>>()?;
 
         Ok(remote_engine::WriteBatchRequest { batch })
@@ -275,12 +275,7 @@ impl TryFrom<WriteRequest> for ceresdbproto::remote_engine::WriteRequest {
 
 pub struct WriteBatchResult {
     pub table_idents: Vec<TableIdentifier>,
-    pub result: GenericResult<WriteBatchStatus>,
-}
-
-pub struct WriteBatchStatus {
-    pub success: u64,
-    pub failed: u64,
+    pub result: GenericResult<u64>,
 }
 
 pub struct GetTableInfoRequest {

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Table abstraction
 
@@ -84,7 +84,7 @@ pub enum Error {
     #[snafu(display("Invalid arguments, err:{}", source))]
     InvalidArguments { table: String, source: GenericError },
 
-    #[snafu(display("Failed to write table, table:{}, err:{}", table, source))]
+    #[snafu(display("Failed to write tables, table:{}, err:{}", table, source))]
     Write { table: String, source: GenericError },
 
     #[snafu(display("Failed to scan table, table:{}, err:{}", table, source))]
@@ -128,6 +128,12 @@ pub enum Error {
 
     #[snafu(display("Failed to locate partitions, err:{}", source))]
     LocatePartitions { source: GenericError },
+
+    #[snafu(display("Failed to write tables in batch, tables:{:?}, err:{}", tables, source))]
+    WriteBatch {
+        tables: Vec<String>,
+        source: GenericError,
+    },
 }
 
 define_result!(Error);


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Support `write_batch` in  `RemoteEngine`(using for partitioned table), that will send all write requests in the same node in once to reduce the rpc calls.

<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
+ Add `write_batch` in `RemoteEngineClient`.
+ Add `write_batch` in `RemoteEngineService`.
+ Modify `write` in `PartitionTable` to make use of `write_batch` method. 
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Test by integration tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
