### PR TITLE
feat: avoid frequent write stall

### DIFF
--- a/analytic_engine/src/instance/create.rs
+++ b/analytic_engine/src/instance/create.rs
@@ -60,6 +60,7 @@ impl Instance {
                 request,
                 table_opts,
                 &self.file_purger,
+                self.preflush_write_buffer_size_ratio,
                 space.mem_usage_collector.clone(),
             )
             .context(CreateTableData {

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -174,6 +174,8 @@ pub struct Instance {
     pub(crate) db_write_buffer_size: usize,
     /// Space write buffer size
     pub(crate) space_write_buffer_size: usize,
+    /// The ratio of table's write buffer size to trigger preflush
+    pub(crate) preflush_write_buffer_size_ratio: f32,
     /// Replay wal batch size
     pub(crate) replay_batch_size: usize,
     /// Write sst max buffer size

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -383,14 +383,15 @@ impl Instance {
                             table_id: table_data.id,
                         })?;
 
+                    let flush_scheduler = serial_exec.flush_scheduler();
+                    let in_flush = flush_scheduler.is_in_flush();
                     // Flush the table if necessary.
-                    if table_data.should_flush_table() {
+                    if table_data.should_flush_table(in_flush) {
                         let opts = TableFlushOptions {
                             res_sender: None,
                             compact_after_flush: None,
                         };
                         let flusher = self.make_flusher();
-                        let flush_scheduler = serial_exec.flush_scheduler();
                         flusher
                             .schedule_flush(flush_scheduler, table_data, opts)
                             .await

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -91,6 +91,11 @@ impl TableOpSerialExecutor {
 }
 
 impl TableFlushScheduler {
+    pub fn is_in_flush(&self) -> bool {
+        let state = self.schedule_sync.state.lock().unwrap();
+        matches!(&*state, FlushState::Flushing)
+    }
+
     /// Control the flush procedure and ensure multiple flush procedures to be
     /// sequential.
     ///

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -535,8 +535,7 @@ impl<'a> Writer<'a> {
             }
         }
 
-        let in_flush = self.serial_exec.flush_scheduler().is_in_flush();
-        if self.table_data.should_flush_table(in_flush) {
+        if self.table_data.should_flush_table(self.serial_exec) {
             let table_data = self.table_data.clone();
             let _timer = table_data.metrics.start_table_write_flush_wait_timer();
             self.handle_memtable_flush(&table_data).await?;

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -535,7 +535,8 @@ impl<'a> Writer<'a> {
             }
         }
 
-        if self.table_data.should_flush_table() {
+        let in_flush = self.serial_exec.flush_scheduler().is_in_flush();
+        if self.table_data.should_flush_table(in_flush) {
             let table_data = self.table_data.clone();
             let _timer = table_data.metrics.start_table_write_flush_wait_timer();
             self.handle_memtable_flush(&table_data).await?;

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -60,12 +60,13 @@ pub struct Config {
     /// Manifest options
     pub manifest: ManifestOptions,
 
-    // Global write buffer options:
     /// The maximum write buffer size used for single space.
     pub space_write_buffer_size: usize,
     /// The maximum size of all Write Buffers across all spaces.
     pub db_write_buffer_size: usize,
-    /// End of global write buffer options.
+    /// The ratio of table's write buffer size to trigger preflush, and it
+    /// should be in the range (0, 1].
+    pub preflush_write_buffer_size_ratio: f32,
 
     // Iterator scanning options
     /// Batch size for iterator.
@@ -112,6 +113,7 @@ impl Default for Config {
             /// Zero means disabling this param, give a positive value to enable
             /// it.
             db_write_buffer_size: 0,
+            preflush_write_buffer_size_ratio: 0.75,
             scan_batch_size: None,
             sst_background_read_parallelism: 8,
             scan_max_record_batches_in_flight: 1024,

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -182,7 +182,8 @@ fn compute_mutable_limit(
     mutable_limit_write_buffer_size_ratio: f32,
 ) -> u32 {
     assert!(
-        mutable_limit_write_buffer_size_ratio > 0.0 && mutable_limit_write_buffer_size_ratio <= 1.0
+        mutable_limit_write_buffer_size_ratio >= 0.0
+            && mutable_limit_write_buffer_size_ratio <= 1.0
     );
 
     let limit = write_buffer_size as f32 * mutable_limit_write_buffer_size_ratio;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, once the flush is triggered by reaching the mutable_limit (7/8 write buffer size), the next write must be stalled because the flush trigger condition is still valid, and this is unreasonable because the mutable_limit is used to avoid write stall rather than impose write stall.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- For the flush case where the mutable limit is reached, flush won't be triggered if the table is in flushing;
- Adjust the mutable limit to 5/8, to trigger an earlier flush;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
