### PR TITLE
fix: wrong default write batch size for run_tsbs

### DIFF
--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -181,10 +181,7 @@ fn compute_mutable_limit(
     write_buffer_size: u32,
     mutable_limit_write_buffer_size_ratio: f32,
 ) -> u32 {
-    assert!(
-        mutable_limit_write_buffer_size_ratio >= 0.0
-            && mutable_limit_write_buffer_size_ratio <= 1.0
-    );
+    assert!((0.0..=1.0).contains(&mutable_limit_write_buffer_size_ratio));
 
     let limit = write_buffer_size as f32 * mutable_limit_write_buffer_size_ratio;
     // This is safe because the limit won't be larger than the write_buffer_size.

--- a/scripts/run-tsbs.sh
+++ b/scripts/run-tsbs.sh
@@ -17,7 +17,7 @@ export LOG_DIR=${LOG_DIR:-${CURR_DIR}/logs}
 export CERESDB_ADDR=${CERESDB_ADDR:-127.0.0.1:8831}
 export CERESDB_PID_FILE=${CURR_DIR}/ceresdb-server.pid
 export WRITE_WORKER_NUM=${WRITE_WORKER_NUM:-36}
-export WRITE_BATCH_SIZE=${WRITE_BATCH_SIZE:500}
+export WRITE_BATCH_SIZE=${WRITE_BATCH_SIZE:-500}
 # Where generated data stored
 export DATA_FILE=${DATA_FILE:-data.out}
 # How many values in host tag
@@ -87,8 +87,7 @@ fi
 
 
 # Write data to ceresdb
-./tsbs_load_ceresdb --ceresdb-addr=${CERESDB_ADDR} --file ${DATA_FILE} --batch-size ${WRITE_BATH_SIZE} --workers ${WRITE_WORKER_NUM} | tee ${LOG_DIR}/write.log
-    
+./tsbs_load_ceresdb --ceresdb-addr=${CERESDB_ADDR} --file ${DATA_FILE} --batch-size ${WRITE_BATCH_SIZE} --workers ${WRITE_WORKER_NUM} | tee ${LOG_DIR}/write.log
 
 # Generate queries for query
 ./scripts/generate_queries.sh


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 A bug in the run_tsbs.sh
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Fix the wrong syntax of the default write batch size in `run_tsbs.sh`.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
