### PR TITLE
feat: compaction support different level

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -432,6 +432,16 @@ pub struct TableCompactionRequest {
 }
 
 impl TableCompactionRequest {
+    pub fn new(table_data: TableDataRef) -> (Self, oneshot::Receiver<WaitResult<()>>) {
+        let (tx, rx) = oneshot::channel::<WaitResult<()>>();
+        let req = Self {
+            table_data,
+            waiter: Some(tx),
+        };
+
+        (req, rx)
+    }
+
     pub fn no_waiter(table_data: TableDataRef) -> Self {
         TableCompactionRequest {
             table_data,

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -100,9 +100,7 @@ impl CommonCompactionPicker {
         levels_controller: &LevelsController,
         expire_time: Option<Timestamp>,
     ) -> Option<CompactionInputFiles> {
-        let num_levels = levels_controller.num_levels();
-        for level in 0..num_levels {
-            let level = Level::from(level);
+        for level in levels_controller.levels() {
             if let Some(files) = self.level_picker.pick_candidates_at_level(
                 ctx,
                 levels_controller,

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -101,8 +101,8 @@ impl CommonCompactionPicker {
         expire_time: Option<Timestamp>,
     ) -> Option<CompactionInputFiles> {
         let num_levels = levels_controller.num_levels();
-        //TODO(boyan) level compaction strategy
         for level in 0..num_levels {
+            let level = Level::from(level);
             if let Some(files) = self.level_picker.pick_candidates_at_level(
                 ctx,
                 levels_controller,
@@ -112,8 +112,7 @@ impl CommonCompactionPicker {
                 return Some(CompactionInputFiles {
                     level,
                     files,
-                    // Now, we always output to the same level.
-                    output_level: level,
+                    output_level: level.next(),
                 });
             }
         }

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -34,7 +34,7 @@ use crate::{
     space::SpaceId,
     sst::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReadOptions},
-        file::FileHandle,
+        file::{FileHandle, Level},
         manager::MAX_LEVEL,
     },
     table::version::{MemTableVec, SamplingMemTable},
@@ -151,8 +151,8 @@ impl<'a> MergeBuilder<'a> {
     }
 
     /// Returns file handles in `level`, panic if level >= MAX_LEVEL
-    pub fn mut_ssts_of_level(&mut self, level: u16) -> &mut Vec<FileHandle> {
-        &mut self.ssts[usize::from(level)]
+    pub fn mut_ssts_of_level(&mut self, level: Level) -> &mut Vec<FileHandle> {
+        &mut self.ssts[level.as_usize()]
     }
 
     pub async fn build(self) -> Result<MergeIterator> {

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -34,7 +34,7 @@ use crate::{
     space::SpaceId,
     sst::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReadOptions},
-        file::{FileHandle, Level},
+        file::{FileHandle, Level, SST_LEVEL_NUM},
     },
     table::version::{MemTableVec, SamplingMemTable},
 };
@@ -126,7 +126,7 @@ impl<'a> MergeBuilder<'a> {
             config,
             sampling_mem: None,
             memtables: Vec::new(),
-            ssts: vec![Vec::new(); Level::TOTAL_NUM],
+            ssts: vec![Vec::new(); SST_LEVEL_NUM],
         }
     }
 

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -35,7 +35,6 @@ use crate::{
     sst::{
         factory::{FactoryRef as SstFactoryRef, ObjectStorePickerRef, SstReadOptions},
         file::{FileHandle, Level},
-        manager::MAX_LEVEL,
     },
     table::version::{MemTableVec, SamplingMemTable},
 };
@@ -127,7 +126,7 @@ impl<'a> MergeBuilder<'a> {
             config,
             sampling_mem: None,
             memtables: Vec::new(),
-            ssts: vec![Vec::new(); MAX_LEVEL],
+            ssts: vec![Vec::new(); Level::TOTAL_NUM],
         }
     }
 

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -14,6 +14,7 @@ use trace_metric::MetricsCollector;
 
 use crate::{
     sst::{
+        file::Level,
         header,
         header::HeaderParser,
         meta_data::cache::MetaCacheRef,
@@ -74,6 +75,7 @@ pub trait Factory: Send + Sync + Debug {
         options: &SstWriteOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
+        level: Level,
     ) -> Result<Box<dyn SstWriter + Send + 'a>>;
 }
 
@@ -178,6 +180,7 @@ impl Factory for FactoryImpl {
         options: &SstWriteOptions,
         path: &'a Path,
         store_picker: &'a ObjectStorePickerRef,
+        level: Level,
     ) -> Result<Box<dyn SstWriter + Send + 'a>> {
         let hybrid_encoding = match options.storage_format_hint {
             StorageFormatHint::Specific(format) => matches!(format, StorageFormat::Hybrid),
@@ -187,6 +190,7 @@ impl Factory for FactoryImpl {
 
         Ok(Box::new(ParquetSstWriter::new(
             path,
+            level,
             hybrid_encoding,
             store_picker,
             options,

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -56,8 +56,8 @@ impl Level {
         Self::MAX.0.min(self.0 + 1).into()
     }
 
-    pub fn is_smallest(&self) -> bool {
-        self.0.is_zero()
+    pub fn is_min(&self) -> bool {
+        self == &Self::MIN
     }
 
     pub fn as_usize(&self) -> usize {
@@ -112,7 +112,7 @@ impl LevelHandler {
     }
 
     pub fn pick_ssts(&self, time_range: TimeRange) -> Vec<FileHandle> {
-        if self.level.is_smallest() {
+        if self.level.is_min() {
             self.files.files_by_time_range(time_range)
         } else {
             Vec::new()

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -14,7 +14,6 @@ use std::{
     },
 };
 
-use arrow::datatypes::ArrowNativeTypeOp;
 use common_types::{
     time::{TimeRange, Timestamp},
     SequenceNumber,
@@ -51,6 +50,7 @@ impl Level {
     // Currently there are only two levels: 0, 1.
     pub const MAX: Self = Self(1);
     pub const MIN: Self = Self(0);
+    pub const TOTAL_NUM: usize = 2;
 
     pub fn next(&self) -> Self {
         Self::MAX.0.min(self.0 + 1).into()

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -112,11 +112,7 @@ impl LevelHandler {
     }
 
     pub fn pick_ssts(&self, time_range: TimeRange) -> Vec<FileHandle> {
-        if self.level.is_min() {
-            self.files.files_by_time_range(time_range)
-        } else {
-            Vec::new()
-        }
+        self.files.files_by_time_range(time_range)
     }
 
     #[inline]

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -14,6 +14,7 @@ use std::{
     },
 };
 
+use arrow::datatypes::ArrowNativeTypeOp;
 use common_types::{
     time::{TimeRange, Timestamp},
     SequenceNumber,
@@ -43,7 +44,46 @@ pub enum Error {
 
 define_result!(Error);
 
-pub type Level = u16;
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Level(u16);
+
+impl Level {
+    // Currently there are only two levels: 0, 1.
+    pub const MAX: Self = Self(1);
+    pub const MIN: Self = Self(0);
+
+    pub fn next(&self) -> Self {
+        Self::MAX.0.min(self.0 + 1).into()
+    }
+
+    pub fn is_smallest(&self) -> bool {
+        self.0.is_zero()
+    }
+
+    pub fn as_usize(&self) -> usize {
+        self.0 as usize
+    }
+
+    pub fn as_u32(&self) -> u32 {
+        self.0 as u32
+    }
+
+    pub fn as_u16(&self) -> u16 {
+        self.0
+    }
+}
+
+impl From<u16> for Level {
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for Level {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 // TODO(yingwen): Order or split file by time range to speed up filter (even in
 //  level 0).
@@ -55,7 +95,7 @@ pub struct LevelHandler {
 }
 
 impl LevelHandler {
-    pub fn new(level: u16) -> Self {
+    pub fn new(level: Level) -> Self {
         Self {
             level,
             files: FileHandleSet::default(),
@@ -72,7 +112,7 @@ impl LevelHandler {
     }
 
     pub fn pick_ssts(&self, time_range: TimeRange) -> Vec<FileHandle> {
-        if self.level == 0 {
+        if self.level.is_smallest() {
             self.files.files_by_time_range(time_range)
         } else {
             Vec::new()

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -43,6 +43,8 @@ pub enum Error {
 
 define_result!(Error);
 
+pub const SST_LEVEL_NUM: usize = 2;
+
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Level(u16);
 
@@ -50,7 +52,6 @@ impl Level {
     // Currently there are only two levels: 0, 1.
     pub const MAX: Self = Self(1);
     pub const MIN: Self = Self(0);
-    pub const TOTAL_NUM: usize = 2;
 
     pub fn next(&self) -> Self {
         Self::MAX.0.min(self.0 + 1).into()

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -11,8 +11,6 @@ use crate::{
 
 /// Id for a sst file
 pub type FileId = u64;
-/// We use two level merge tree, the max level should less than u16::MAX
-pub const MAX_LEVEL: usize = 2;
 
 /// A table level manager that manages all the sst files of the table
 pub struct LevelsController {

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -30,13 +30,11 @@ impl Drop for LevelsController {
 impl LevelsController {
     /// Create an empty LevelsController
     pub fn new(purge_queue: FilePurgeQueue) -> Self {
-        let mut levels = Vec::with_capacity(MAX_LEVEL);
-        for level in 0..MAX_LEVEL {
-            levels.push(LevelHandler::new(level as Level));
-        }
-
         Self {
-            levels,
+            levels: (Level::MIN.as_u16()..=Level::MAX.as_u16())
+                .into_iter()
+                .map(|v| LevelHandler::new(v.into()))
+                .collect::<Vec<_>>(),
             purge_queue,
         }
     }
@@ -45,14 +43,14 @@ impl LevelsController {
     ///
     /// Panic: If the level is greater than the max level
     pub fn add_sst_to_level(&mut self, level: Level, file_meta: FileMeta) {
-        let level_handler = &mut self.levels[usize::from(level)];
+        let level_handler = &mut self.levels[level.as_usize()];
         let file = FileHandle::new(file_meta, self.purge_queue.clone());
 
         level_handler.insert(file);
     }
 
     pub fn latest_sst(&self, level: Level) -> Option<FileHandle> {
-        self.levels[usize::from(level)].latest_sst()
+        self.levels[level.as_usize()].latest_sst()
     }
 
     /// Pick the ssts and collect it by `append_sst`.
@@ -71,20 +69,20 @@ impl LevelsController {
     ///
     /// Panic: If the level is greater than the max level
     pub fn remove_ssts_from_level(&mut self, level: Level, file_ids: &[FileId]) {
-        let level_handler = &mut self.levels[usize::from(level)];
+        let level_handler = &mut self.levels[level.as_usize()];
         level_handler.remove_ssts(file_ids);
     }
 
     /// Total number of levels.
-    pub fn num_levels(&self) -> Level {
-        self.levels.len() as Level
+    pub fn num_levels(&self) -> u16 {
+        self.levels.len() as u16
     }
 
     /// Iter ssts at given `level`.
     ///
     /// Panic if level is out of bound.
     pub fn iter_ssts_at_level(&self, level: Level) -> Iter {
-        let level_handler = &self.levels[usize::from(level)];
+        let level_handler = &self.levels[level.as_usize()];
         level_handler.iter_ssts()
     }
 
@@ -93,7 +91,7 @@ impl LevelsController {
         level: Level,
         expire_time: Option<Timestamp>,
     ) -> Vec<FileHandle> {
-        let level_handler = &self.levels[usize::from(level)];
+        let level_handler = &self.levels[level.as_usize()];
         let mut expired = Vec::new();
         level_handler.collect_expired(expire_time, &mut expired);
 
@@ -107,14 +105,15 @@ impl LevelsController {
     }
 
     pub fn expired_ssts(&self, expire_time: Option<Timestamp>) -> Vec<ExpiredFiles> {
-        let mut expired = Vec::new();
         let num_levels = self.num_levels();
-        for level in 0..num_levels {
-            let files = self.collect_expired_at_level(level, expire_time);
-            expired.push(ExpiredFiles { level, files });
-        }
-
-        expired
+        (0..num_levels)
+            .into_iter()
+            .map(|level| {
+                let level = Level::from(level);
+                let files = self.collect_expired_at_level(level, expire_time);
+                ExpiredFiles { level, files }
+            })
+            .collect::<Vec<_>>()
     }
 }
 
@@ -125,7 +124,7 @@ pub mod tests {
 
     use crate::{
         sst::{
-            file::{FileMeta, FilePurgeQueue},
+            file::{FileMeta, FilePurgeQueue, Level},
             manager::{FileId, LevelsController},
             meta_data::SstMetaData,
         },
@@ -150,7 +149,7 @@ pub mod tests {
             let mut levels_controller = LevelsController::new(file_purge_queue);
             for (id, sst_meta) in self.sst_meta_vec.into_iter().enumerate() {
                 levels_controller.add_sst_to_level(
-                    0,
+                    Level::MIN,
                     FileMeta {
                         id: id as FileId,
                         size: 0,

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -30,7 +30,6 @@ impl LevelsController {
     pub fn new(purge_queue: FilePurgeQueue) -> Self {
         Self {
             levels: (Level::MIN.as_u16()..=Level::MAX.as_u16())
-                .into_iter()
                 .map(|v| LevelHandler::new(v.into()))
                 .collect::<Vec<_>>(),
             purge_queue,
@@ -105,7 +104,6 @@ impl LevelsController {
     pub fn expired_ssts(&self, expire_time: Option<Timestamp>) -> Vec<ExpiredFiles> {
         let num_levels = self.num_levels();
         (0..num_levels)
-            .into_iter()
             .map(|level| {
                 let level = Level::from(level);
                 let files = self.collect_expired_at_level(level, expire_time);

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -71,8 +71,8 @@ impl LevelsController {
     }
 
     /// Total number of levels.
-    pub fn num_levels(&self) -> u16 {
-        self.levels.len() as u16
+    pub fn levels(&self) -> Vec<Level> {
+        self.levels.iter().map(|v| v.level).collect()
     }
 
     /// Iter ssts at given `level`.
@@ -102,10 +102,9 @@ impl LevelsController {
     }
 
     pub fn expired_ssts(&self, expire_time: Option<Timestamp>) -> Vec<ExpiredFiles> {
-        let num_levels = self.num_levels();
-        (0..num_levels)
+        self.levels()
+            .into_iter()
             .map(|level| {
-                let level = Level::from(level);
                 let files = self.collect_expired_at_level(level, expire_time);
                 ExpiredFiles { level, files }
             })

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -108,7 +108,7 @@ impl LevelsController {
                 let files = self.collect_expired_at_level(level, expire_time);
                 ExpiredFiles { level, files }
             })
-            .collect::<Vec<_>>()
+            .collect()
     }
 }
 

--- a/analytic_engine/src/sst/manager.rs
+++ b/analytic_engine/src/sst/manager.rs
@@ -70,9 +70,8 @@ impl LevelsController {
         level_handler.remove_ssts(file_ids);
     }
 
-    /// Total number of levels.
-    pub fn levels(&self) -> Vec<Level> {
-        self.levels.iter().map(|v| v.level).collect()
+    pub fn levels(&self) -> impl Iterator<Item = Level> + '_ {
+        self.levels.iter().map(|v| v.level)
     }
 
     /// Iter ssts at given `level`.
@@ -103,7 +102,6 @@ impl LevelsController {
 
     pub fn expired_ssts(&self, expire_time: Option<Timestamp>) -> Vec<ExpiredFiles> {
         self.levels()
-            .into_iter()
             .map(|level| {
                 let files = self.collect_expired_at_level(level, expire_time);
                 ExpiredFiles { level, files }

--- a/analytic_engine/src/sst/parquet/row_group_pruner.rs
+++ b/analytic_engine/src/sst/parquet/row_group_pruner.rs
@@ -60,7 +60,7 @@ impl<'a> RowGroupPruner<'a> {
     ) -> Result<Self> {
         if let Some(f) = parquet_filter {
             ensure!(f.len() == row_groups.len(), OtherNoCause {
-                msg: format!("expect the same number of ss_filter as the number of row groups, num_parquet_filters:{}, num_row_groups:{}", f.len(), row_groups.len()),
+                msg: format!("expect sst_filters.len() == row_groups.len(), num_sst_filters:{}, num_row_groups:{}", f.len(), row_groups.len()),
             });
         }
 

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -195,7 +195,7 @@ impl RecordBatchGroupWriter {
                 break;
             }
 
-            if !self.level.is_smallest() {
+            if !self.level.is_min() {
                 self.update_parquet_filter(&row_group)?;
             }
 
@@ -420,7 +420,12 @@ mod tests {
             }));
 
             let mut writer = sst_factory
-                .create_writer(&sst_write_options, &sst_file_path, &store_picker)
+                .create_writer(
+                    &sst_write_options,
+                    &sst_file_path,
+                    &store_picker,
+                    Level::MAX,
+                )
                 .await
                 .unwrap();
             let sst_info = writer

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -662,14 +662,16 @@ impl TableVersion {
 
         // Add sst files to level first.
         for add_file in edit.files_to_add {
-            inner.levels.add_sst_to_level(add_file.level, add_file.file);
+            inner
+                .levels
+                .add_sst_to_level(add_file.level.into(), add_file.file);
         }
 
         // Remove ssts from level.
         for delete_file in edit.files_to_delete {
             inner
                 .levels
-                .remove_ssts_from_level(delete_file.level, &[delete_file.file_id]);
+                .remove_ssts_from_level(delete_file.level.into(), &[delete_file.file_id]);
         }
 
         // Remove immutable memtables.
@@ -685,7 +687,9 @@ impl TableVersion {
         inner.flushed_sequence = cmp::max(inner.flushed_sequence, meta.flushed_sequence);
 
         for add_file in meta.files.into_values() {
-            inner.levels.add_sst_to_level(add_file.level, add_file.file);
+            inner
+                .levels
+                .add_sst_to_level(add_file.level.into(), add_file.file);
         }
     }
 
@@ -704,7 +708,7 @@ impl TableVersion {
 
             // Pick ssts for read.
             inner.levels.pick_ssts(time_range, |level, ssts| {
-                leveled_ssts[level as usize].extend_from_slice(ssts)
+                leveled_ssts[level.as_usize()].extend_from_slice(ssts)
             });
         }
 

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -662,16 +662,14 @@ impl TableVersion {
 
         // Add sst files to level first.
         for add_file in edit.files_to_add {
-            inner
-                .levels
-                .add_sst_to_level(add_file.level.into(), add_file.file);
+            inner.levels.add_sst_to_level(add_file.level, add_file.file);
         }
 
         // Remove ssts from level.
         for delete_file in edit.files_to_delete {
             inner
                 .levels
-                .remove_ssts_from_level(delete_file.level.into(), &[delete_file.file_id]);
+                .remove_ssts_from_level(delete_file.level, &[delete_file.file_id]);
         }
 
         // Remove immutable memtables.
@@ -687,9 +685,7 @@ impl TableVersion {
         inner.flushed_sequence = cmp::max(inner.flushed_sequence, meta.flushed_sequence);
 
         for add_file in meta.files.into_values() {
-            inner
-                .levels
-                .add_sst_to_level(add_file.level.into(), add_file.file);
+            inner.levels.add_sst_to_level(add_file.level, add_file.file);
         }
     }
 
@@ -754,6 +750,7 @@ impl TableVersion {
         let num_levels = levels.num_levels();
         let files = (0..num_levels)
             .flat_map(|level| {
+                let level = Level::from(level);
                 let ssts = levels.iter_ssts_at_level(level);
                 ssts.map(move |file| {
                     let add_file = AddFile {

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -28,7 +28,7 @@ use crate::{
     memtable::{self, key::KeySequence, MemTableRef, PutContext},
     sampler::{DefaultSampler, SamplerRef},
     sst::{
-        file::{FileHandle, FilePurgeQueue, Level},
+        file::{FileHandle, FilePurgeQueue, SST_LEVEL_NUM},
         manager::{FileId, LevelsController},
     },
     table::{
@@ -487,7 +487,7 @@ impl Default for ReadView {
         Self {
             sampling_mem: None,
             memtables: Vec::new(),
-            leveled_ssts: vec![Vec::new(); Level::TOTAL_NUM],
+            leveled_ssts: vec![Vec::new(); SST_LEVEL_NUM],
         }
     }
 }
@@ -696,7 +696,7 @@ impl TableVersion {
     pub fn pick_read_view(&self, time_range: TimeRange) -> ReadView {
         let mut sampling_mem = None;
         let mut memtables = MemTableVec::new();
-        let mut leveled_ssts = vec![Vec::new(); Level::TOTAL_NUM];
+        let mut leveled_ssts = vec![Vec::new(); SST_LEVEL_NUM];
 
         {
             // Pick memtables for read.

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -755,7 +755,6 @@ impl TableVersion {
         let controller = &inner.levels_controller;
         let files = controller
             .levels()
-            .into_iter()
             .flat_map(|level| {
                 let ssts = controller.iter_ssts_at_level(level);
                 ssts.map(move |file| {

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -28,8 +28,8 @@ use crate::{
     memtable::{self, key::KeySequence, MemTableRef, PutContext},
     sampler::{DefaultSampler, SamplerRef},
     sst::{
-        file::{FileHandle, FilePurgeQueue},
-        manager::{FileId, LevelsController, MAX_LEVEL},
+        file::{FileHandle, FilePurgeQueue, Level},
+        manager::{FileId, LevelsController},
     },
     table::{
         data::MemTableId,
@@ -487,7 +487,7 @@ impl Default for ReadView {
         Self {
             sampling_mem: None,
             memtables: Vec::new(),
-            leveled_ssts: vec![Vec::new(); MAX_LEVEL],
+            leveled_ssts: vec![Vec::new(); Level::TOTAL_NUM],
         }
     }
 }
@@ -696,7 +696,7 @@ impl TableVersion {
     pub fn pick_read_view(&self, time_range: TimeRange) -> ReadView {
         let mut sampling_mem = None;
         let mut memtables = MemTableVec::new();
-        let mut leveled_ssts = vec![Vec::new(); MAX_LEVEL];
+        let mut leveled_ssts = vec![Vec::new(); Level::TOTAL_NUM];
 
         {
             // Pick memtables for read.

--- a/analytic_engine/src/table/version_edit.rs
+++ b/analytic_engine/src/table/version_edit.rs
@@ -170,7 +170,7 @@ pub mod tests {
 
         pub fn build(&self) -> AddFile {
             AddFile {
-                level: 0,
+                level: Level::MIN,
                 file: FileMeta {
                     id: self.file_id,
                     size: 0,

--- a/analytic_engine/src/table/version_edit.rs
+++ b/analytic_engine/src/table/version_edit.rs
@@ -2,7 +2,7 @@
 
 //! Version edits
 
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use ceresdbproto::manifest as manifest_pb;
 use common_types::{time::TimeRange, SequenceNumber};
@@ -10,7 +10,10 @@ use common_util::define_result;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 
 use crate::{
-    sst::{file::FileMeta, manager::FileId},
+    sst::{
+        file::{FileMeta, Level},
+        manager::FileId,
+    },
     table::data::MemTableId,
     table_options::StorageFormat,
 };
@@ -43,7 +46,7 @@ define_result!(Error);
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddFile {
     /// The level of the file intended to add.
-    pub level: u16,
+    pub level: Level,
     /// Meta data of the file to add.
     pub file: FileMeta,
 }
@@ -52,7 +55,7 @@ impl From<AddFile> for manifest_pb::AddFileMeta {
     /// Convert into protobuf struct
     fn from(v: AddFile) -> manifest_pb::AddFileMeta {
         manifest_pb::AddFileMeta {
-            level: v.level as u32,
+            level: v.level.as_u32(),
             file_id: v.file.id,
             time_range: Some(v.file.time_range.into()),
             max_seq: v.file.max_seq,
@@ -74,10 +77,7 @@ impl TryFrom<manifest_pb::AddFileMeta> for AddFile {
         };
 
         let target = Self {
-            level: src
-                .level
-                .try_into()
-                .context(InvalidLevel { level: src.level })?,
+            level: (src.level as u16).into(),
             file: FileMeta {
                 id: src.file_id,
                 size: src.size,
@@ -96,7 +96,7 @@ impl TryFrom<manifest_pb::AddFileMeta> for AddFile {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeleteFile {
     /// The level of the file intended to delete.
-    pub level: u16,
+    pub level: Level,
     /// Id of the file to delete.
     pub file_id: FileId,
 }
@@ -104,7 +104,7 @@ pub struct DeleteFile {
 impl From<DeleteFile> for manifest_pb::DeleteFileMeta {
     fn from(v: DeleteFile) -> Self {
         manifest_pb::DeleteFileMeta {
-            level: v.level as u32,
+            level: v.level.as_u32(),
             file_id: v.file_id,
         }
     }
@@ -114,10 +114,7 @@ impl TryFrom<manifest_pb::DeleteFileMeta> for DeleteFile {
     type Error = Error;
 
     fn try_from(src: manifest_pb::DeleteFileMeta) -> Result<Self> {
-        let level = src
-            .level
-            .try_into()
-            .context(InvalidLevel { level: src.level })?;
+        let level = (src.level as u16).into();
 
         Ok(Self {
             level,

--- a/analytic_engine/src/tests/compaction_test.rs
+++ b/analytic_engine/src/tests/compaction_test.rs
@@ -38,7 +38,8 @@ fn test_table_compact_current_segment<T: EngineBuildContext>(engine_context: T) 
         let mut expect_rows = Vec::new();
 
         let start_ms = test_ctx.start_ms();
-        // Write more than ensure compaction will be triggered.
+        // Write max_threshold*2 sst to ensure level0->level1, level1->level1 compaction
+        // will be triggered.
         for offset in 0..default_opts.max_threshold as i64 * 2 {
             let rows = [
                 (
@@ -86,6 +87,8 @@ fn test_table_compact_current_segment<T: EngineBuildContext>(engine_context: T) 
             &expect_rows,
         )
         .await;
+
+        common_util::tests::init_log_for_test();
 
         // Trigger a compaction.
         test_ctx.compact_table(test_table1).await;

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -18,7 +18,7 @@ use analytic_engine::{
             FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
             ScanOptions, SstReadOptions,
         },
-        file::{FileHandle, FilePurgeQueue, Request},
+        file::{FileHandle, FilePurgeQueue, Level, Request},
         meta_data::cache::MetaCacheRef,
     },
     table::sst_util,
@@ -146,7 +146,8 @@ impl MergeSstBench {
         });
 
         builder
-            .mut_ssts_of_level(0)
+            // make level configurable
+            .mut_ssts_of_level(Level::MIN)
             .extend_from_slice(&self.file_handles);
 
         self.runtime.block_on(async {

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -146,7 +146,7 @@ impl MergeSstBench {
         });
 
         builder
-            // make level configurable
+            // TODO: make level configurable
             .mut_ssts_of_level(Level::MIN)
             .extend_from_slice(&self.file_handles);
 

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -17,7 +17,7 @@ use analytic_engine::{
             Factory, FactoryImpl, FactoryRef as SstFactoryRef, ObjectStorePickerRef, ReadFrequency,
             ScanOptions, SstReadHint, SstReadOptions, SstWriteOptions,
         },
-        file::FilePurgeQueue,
+        file::{FilePurgeQueue, Level},
         manager::FileId,
         meta_data::SstMetaReader,
         writer::{MetaData, RecordBatchStream},
@@ -65,7 +65,12 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
     let sst_file_path = Path::from(config.sst_file_name);
 
     let mut writer = sst_factory
-        .create_writer(&sst_write_options, &sst_file_path, &store_picker)
+        .create_writer(
+            &sst_write_options,
+            &sst_file_path,
+            &store_picker,
+            Level::MAX,
+        )
         .await
         .unwrap();
     writer
@@ -240,7 +245,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
             reverse: false,
         });
         builder
-            .mut_ssts_of_level(0)
+            .mut_ssts_of_level(Level::MAX)
             .extend_from_slice(&file_handles);
 
         builder.build().await.unwrap()

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -245,7 +245,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
             reverse: false,
         });
         builder
-            .mut_ssts_of_level(Level::MAX)
+            .mut_ssts_of_level(Level::MIN)
             .extend_from_slice(&file_handles);
 
         builder.build().await.unwrap()

--- a/common_util/src/lib.rs
+++ b/common_util/src/lib.rs
@@ -23,13 +23,25 @@ pub mod toml;
 
 #[cfg(any(test, feature = "test"))]
 pub mod tests {
-    use std::sync::Once;
+    use std::{io::Write, sync::Once};
 
     static INIT_LOG: Once = Once::new();
 
     pub fn init_log_for_test() {
         INIT_LOG.call_once(|| {
-            env_logger::init();
+            env_logger::Builder::from_default_env()
+                .format(|buf, record| {
+                    writeln!(
+                        buf,
+                        "{} {} [{}:{}] {}",
+                        chrono::Local::now().format("%Y-%m-%dT%H:%M:%S.%3f"),
+                        buf.default_styled_level(record.level()),
+                        record.file().unwrap_or("unknown"),
+                        record.line().unwrap_or(0),
+                        record.args()
+                    )
+                })
+                .init();
         });
     }
 }

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -5,9 +5,12 @@
 use std::{error::Error, sync::Arc};
 
 use analytic_engine::{
-    sst::factory::{
-        Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, ScanOptions, SstReadHint,
-        SstReadOptions, SstWriteOptions,
+    sst::{
+        factory::{
+            Factory, FactoryImpl, ObjectStorePickerRef, ReadFrequency, ScanOptions, SstReadHint,
+            SstReadOptions, SstWriteOptions,
+        },
+        file::Level,
     },
     table_options::{Compression, StorageFormatHint},
 };
@@ -108,7 +111,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
     };
     let output = Path::from(args.output);
     let mut writer = factory
-        .create_writer(&builder_opts, &output, &store_picker)
+        .create_writer(&builder_opts, &output, &store_picker, Level::MAX)
         .await
         .expect("no sst writer found");
     let sst_stream = reader


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
Currently all sst are in level0, and we find that when flush memtable-> sst0,
build parquet filter cost lots of CPU, which affect write throughout indirectly.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

Introduce SST at level 1, this is how data is moved between different components:
- memtable -> level0
- level0 -> level1
- level1 -> level1

Flush memtable will only output sst at level 0, and it will skip parquet filter building. 

Fow now, compaction strategy is same for 0->1 and 1->1, later we need to investigate different strategy for them.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

CI
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

