### PR TITLE
chore: bump obkv client version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4043,7 +4043,7 @@ dependencies = [
 [[package]]
 name = "obkv-table-client-rs"
 version = "0.1.0"
-source = "git+https://github.com/oceanbase/obkv-table-client-rs.git?rev=70708a8e5adbaddc53c28a9582ef3656ca1caf2a#70708a8e5adbaddc53c28a9582ef3656ca1caf2a"
+source = "git+https://github.com/oceanbase/obkv-table-client-rs.git?rev=4fe127145e21f7d0283405e002aa61fd7791371f#4fe127145e21f7d0283405e002aa61fd7791371f"
 dependencies = [
  "byteorder",
  "bytes 0.4.12",

--- a/components/table_kv/Cargo.toml
+++ b/components/table_kv/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 common_util = { workspace = true }
 log = { workspace = true }
-obkv-table-client-rs = { git = "https://github.com/oceanbase/obkv-table-client-rs.git", rev = "70708a8e5adbaddc53c28a9582ef3656ca1caf2a" }
+obkv-table-client-rs = { git = "https://github.com/oceanbase/obkv-table-client-rs.git", rev = "4fe127145e21f7d0283405e002aa61fd7791371f" }
 serde = { workspace = true }
 
 snafu = { workspace = true }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 
Currently the connection will be closed when querying to ob server with new version. To address this issue, so we need to  bump obkv client version.
see detail in:https://github.com/oceanbase/obkv-table-client-rs/pull/38

## What changes are included in this PR?

bump obkv client version  

## Are there any user-facing changes?

<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

Have been tested in [Oceanbase client repo](https://github.com/oceanbase/obkv-table-client-rs/pull/38)
