### PR TITLE
feat: support domain name as the ceresdb node addr

### DIFF
--- a/src/bin/ceresdb-server.rs
+++ b/src/bin/ceresdb-server.rs
@@ -2,7 +2,7 @@
 
 //! The main entry point to start the server
 
-use std::{env, net::IpAddr};
+use std::env;
 
 use ceresdb::{
     config::{ClusterDeployment, Config},

--- a/src/bin/ceresdb-server.rs
+++ b/src/bin/ceresdb-server.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! The main entry point to start the server
 
@@ -12,8 +12,11 @@ use clap::{App, Arg};
 use common_util::{panic, toml};
 use log::info;
 
-/// The ip address of current node.
+/// By this environment variable, the address of current node can be overridden.
+/// And it could be domain name or ip address, but no port follows it.
 const NODE_ADDR: &str = "CERESDB_SERVER_ADDR";
+/// By this environment variable, the cluster name of current node can be
+/// overridden.
 const CLUSTER_NAME: &str = "CLUSTER_NAME";
 
 fn fetch_version() -> String {
@@ -34,14 +37,6 @@ fn fetch_version() -> String {
     .map(|(label, value)| format!("{label}: {value}"))
     .collect::<Vec<_>>()
     .join("\n")
-}
-
-// Parse the raw addr and panic if it is invalid.
-fn parse_node_addr_or_fail(raw_addr: &str) -> IpAddr {
-    let socket_addr: IpAddr = raw_addr
-        .parse()
-        .unwrap_or_else(|_| panic!("invalid node addr, raw_addr:{raw_addr}"));
-    socket_addr
 }
 
 fn main() {
@@ -67,8 +62,7 @@ fn main() {
     };
 
     if let Ok(node_addr) = env::var(NODE_ADDR) {
-        let ip = parse_node_addr_or_fail(&node_addr);
-        config.node.addr = ip.to_string();
+        config.node.addr = node_addr;
     }
     if let Ok(cluster) = env::var(CLUSTER_NAME) {
         if let Some(ClusterDeployment::WithMeta(v)) = &mut config.cluster_deployment {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ use server::{
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
 pub struct NodeInfo {
+    /// The address of the ceresdb node. It can be a domain name or an IP
+    /// address without port followed.
     pub addr: String,
     pub zone: String,
     pub idc: String,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, the node address reported to CeresMeta is not allowed to be a domain name, but it is necessary for k8s deployment.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Allow the node address reported to CeresMeta to be anything.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
