### PR TITLE
feat: only collecting all tables on demand in influxql planner

### DIFF
--- a/query_frontend/src/frontend.rs
+++ b/query_frontend/src/frontend.rs
@@ -4,7 +4,7 @@
 
 use std::{sync::Arc, time::Instant};
 
-use catalog::manager::ManagerRef;
+
 use ceresdbproto::{prometheus::Expr as PromExpr, storage::WriteTableRequest};
 use cluster::config::SchemaConfig;
 use common_types::request_id::RequestId;
@@ -146,7 +146,6 @@ impl<P: MetaProvider> Frontend<P> {
         &self,
         ctx: &mut Context,
         stmt: InfluxqlStatement,
-        _manager: ManagerRef,
     ) -> Result<Plan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
         planner.influxql_stmt_to_plan(stmt).context(CreatePlan)

--- a/query_frontend/src/frontend.rs
+++ b/query_frontend/src/frontend.rs
@@ -4,7 +4,6 @@
 
 use std::{sync::Arc, time::Instant};
 
-
 use ceresdbproto::{prometheus::Expr as PromExpr, storage::WriteTableRequest};
 use cluster::config::SchemaConfig;
 use common_types::request_id::RequestId;

--- a/query_frontend/src/frontend.rs
+++ b/query_frontend/src/frontend.rs
@@ -8,7 +8,7 @@ use catalog::manager::ManagerRef;
 use ceresdbproto::{prometheus::Expr as PromExpr, storage::WriteTableRequest};
 use cluster::config::SchemaConfig;
 use common_types::request_id::RequestId;
-use common_util::error::{BoxError, GenericError};
+use common_util::error::GenericError;
 use influxql_parser::statement::Statement as InfluxqlStatement;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use sqlparser::ast::{SetExpr, Statement as SqlStatement, TableFactor};
@@ -146,39 +146,10 @@ impl<P: MetaProvider> Frontend<P> {
         &self,
         ctx: &mut Context,
         stmt: InfluxqlStatement,
-        manager: ManagerRef,
+        _manager: ManagerRef,
     ) -> Result<Plan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
-        let catalog_name = self.provider.default_catalog_name();
-        let catalog = manager
-            .catalog_by_name(catalog_name)
-            .box_err()
-            .context(InfluxqlPlanWithCause {
-                msg: format!("get catalog failed, value:{catalog_name}"),
-            })?
-            .context(InfluxqlPlan {
-                msg: format!("catalog is none, value:{catalog_name}"),
-            })?;
-        let schema_name = self.provider.default_schema_name();
-        let schema = catalog
-            .schema_by_name(schema_name)
-            .box_err()
-            .context(InfluxqlPlanWithCause {
-                msg: format!("get schema failed, value:{schema_name}"),
-            })?
-            .context(InfluxqlPlan {
-                msg: format!("schema is none, value:{schema_name}"),
-            })?;
-        let all_tables = schema
-            .all_tables()
-            .box_err()
-            .context(InfluxqlPlanWithCause {
-                msg: format!("get all tables failed, catalog:{catalog_name}, schema:{schema_name}"),
-            })?;
-
-        planner
-            .influxql_stmt_to_plan(stmt, all_tables)
-            .context(CreatePlan)
+        planner.influxql_stmt_to_plan(stmt).context(CreatePlan)
     }
 
     pub fn write_req_to_plan(

--- a/query_frontend/src/influxql/planner.rs
+++ b/query_frontend/src/influxql/planner.rs
@@ -7,9 +7,7 @@ use std::{cell::OnceCell, sync::Arc};
 use arrow::datatypes::SchemaRef as ArrowSchemaRef;
 use common_util::error::BoxError;
 use datafusion::{
-    error::DataFusionError,
-    logical_expr::TableSource,
-    sql::{planner::ContextProvider, TableReference},
+    error::DataFusionError, logical_expr::TableSource, sql::planner::ContextProvider,
 };
 use influxql_logical_planner::plan::{
     ceresdb_schema_to_influxdb, InfluxQLToLogicalPlan, SchemaProvider,

--- a/query_frontend/src/influxql/planner.rs
+++ b/query_frontend/src/influxql/planner.rs
@@ -48,7 +48,9 @@ impl<'a, P: MetaProvider> SchemaProvider for InfluxQLSchemaProvider<'a, P> {
         self.context_provider
             .get_table_provider(table_ref.into())
             .map_err(|e| {
-                DataFusionError::Plan(format!("measurement does not exist: {name}, source:{e}"))
+                DataFusionError::Plan(format!(
+                    "measurement does not exist, measurement:{name}, source:{e}"
+                ))
             })
     }
 
@@ -72,7 +74,7 @@ impl<'a, P: MetaProvider> SchemaProvider for InfluxQLSchemaProvider<'a, P> {
             Err(e) => {
                 // Restricted by the external interface of iox, we can just print error log here
                 // and return empty `Vec`.
-                error!("Influxql planner occurred error while trying to get all tables, err:{e}");
+                error!("Influxql planner failed to get all tables, err:{e}");
                 return Vec::default();
             }
         };
@@ -86,7 +88,7 @@ impl<'a, P: MetaProvider> SchemaProvider for InfluxQLSchemaProvider<'a, P> {
             Err(e) => {
                 // Restricted by the external interface of iox, we can just print error log here
                 // and return None.
-                error!("Influxql planner occurred error while trying to get table schema, name:{name}, err:{e}");
+                error!("Influxql planner failed to get table schema, name:{name}, err:{e}");
                 return None;
             }
         };
@@ -96,7 +98,7 @@ impl<'a, P: MetaProvider> SchemaProvider for InfluxQLSchemaProvider<'a, P> {
             Ok(schema) => schema,
             Err(e) => {
                 // Same as above here.
-                error!("Influxql planner occurred error while converting schema to influxql schema, schema:{ceresdb_arrow_schema}, err:{e}");
+                error!("Influxql planner failed to convert schema to influxql schema, schema:{ceresdb_arrow_schema}, err:{e}");
                 return None;
             }
         };

--- a/query_frontend/src/influxql/planner.rs
+++ b/query_frontend/src/influxql/planner.rs
@@ -114,6 +114,9 @@ impl<'a, P: MetaProvider> SchemaProvider for InfluxQLSchemaProvider<'a, P> {
     }
 }
 
+/// Influxql logical planner
+///
+/// NOTICE: planner will be built for each influxql query.
 pub(crate) struct Planner<'a, P: MetaProvider> {
     schema_provider: InfluxQLSchemaProvider<'a, P>,
 }
@@ -128,13 +131,13 @@ fn convert_to_influxql_schema(ceresdb_arrow_schema: ArrowSchemaRef) -> Result<Sc
 }
 
 impl<'a, P: MetaProvider> Planner<'a, P> {
-    pub fn new(context_provider: ContextProviderAdapter<'a, P>) -> Result<Self> {
-        Ok(Self {
+    pub fn new(context_provider: ContextProviderAdapter<'a, P>) -> Self {
+        Self {
             schema_provider: InfluxQLSchemaProvider {
                 context_provider,
                 tables_cache: OnceCell::new(),
             },
-        })
+        }
     }
 
     /// Build sql logical plan from [InfluxqlStatement].

--- a/query_frontend/src/lib.rs
+++ b/query_frontend/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
+#![feature(once_cell)]
 
 //! SQL frontend
 //!

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -332,8 +332,9 @@ impl<'a, P: MetaProvider> Planner<'a, P> {
 
     pub fn influxql_stmt_to_plan(&self, statement: InfluxqlStatement) -> Result<Plan> {
         let adapter = ContextProviderAdapter::new(self.provider, self.read_parallelism);
-        crate::influxql::planner::Planner::new(adapter)
-            .and_then(|planner| planner.statement_to_plan(statement))
+        let planner = crate::influxql::planner::Planner::new(adapter);
+        planner
+            .statement_to_plan(statement)
             .context(BuildInfluxqlPlan)
     }
 

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -330,14 +330,9 @@ impl<'a, P: MetaProvider> Planner<'a, P> {
             .context(BuildPromPlanError)
     }
 
-    pub fn influxql_stmt_to_plan(
-        &self,
-        statement: InfluxqlStatement,
-        all_tables: Vec<TableRef>,
-    ) -> Result<Plan> {
+    pub fn influxql_stmt_to_plan(&self, statement: InfluxqlStatement) -> Result<Plan> {
         let adapter = ContextProviderAdapter::new(self.provider, self.read_parallelism);
-
-        crate::influxql::planner::Planner::try_new(adapter, all_tables)
+        crate::influxql::planner::Planner::new(adapter)
             .and_then(|planner| planner.statement_to_plan(statement))
             .context(BuildInfluxqlPlan)
     }

--- a/query_frontend/src/provider.rs
+++ b/query_frontend/src/provider.rs
@@ -89,6 +89,10 @@ pub trait MetaProvider {
     fn aggregate_udf(&self, name: &str) -> Result<Option<AggregateUdf>>;
 
     /// Return all tables.
+    ///
+    /// Note that it may incur expensive cost.
+    /// Now it is used in `table_names` method in `SchemaProvider`(introduced by
+    /// influxql).
     fn all_tables(&self) -> Result<Vec<TableRef>>;
 }
 

--- a/query_frontend/src/provider.rs
+++ b/query_frontend/src/provider.rs
@@ -154,8 +154,8 @@ impl<'a> MetaProvider for CatalogMetaProvider<'a> {
         self.function_registry.find_udaf(name).context(FindUdf)
     }
 
-    // TODO: when support not only default catalog and schema, we should refactor
-    // the tables collecting procedure.
+    // TODO: after supporting not only default catalog and schema, we should
+    // refactor the tables collecting procedure.
     fn all_tables(&self) -> Result<Vec<TableRef>> {
         let catalog = match self
             .manager

--- a/query_frontend/src/provider.rs
+++ b/query_frontend/src/provider.rs
@@ -6,7 +6,6 @@ use std::{any::Any, borrow::Cow, cell::RefCell, collections::HashMap, sync::Arc}
 
 use async_trait::async_trait;
 use catalog::manager::ManagerRef;
-use common_util::error::BoxError;
 use datafusion::{
     catalog::{catalog::CatalogProvider, schema::SchemaProvider},
     common::DataFusionError,
@@ -54,7 +53,7 @@ pub enum Error {
     GetAllTables {
         catalog_name: String,
         schema_name: String,
-        source: Box<catalog::schema::Error>,
+        source: catalog::schema::Error,
     },
 
     #[snafu(display("Failed to find udf, err:{}", source))]
@@ -86,7 +85,7 @@ pub trait MetaProvider {
     /// Get udaf by name.
     fn aggregate_udf(&self, name: &str) -> Result<Option<AggregateUdf>>;
 
-    /// Return all table names.
+    /// Return all tables.
     fn all_tables(&self) -> Result<Vec<TableRef>>;
 }
 
@@ -177,13 +176,10 @@ impl<'a> MetaProvider for CatalogMetaProvider<'a> {
             None => return Ok(Vec::default()),
         };
 
-        schema
-            .all_tables()
-            .map_err(|e| Box::new(e))
-            .with_context(|| GetAllTables {
-                catalog_name: self.default_catalog,
-                schema_name: self.default_schema,
-            })
+        schema.all_tables().with_context(|| GetAllTables {
+            catalog_name: self.default_catalog,
+            schema_name: self.default_schema,
+        })
     }
 }
 

--- a/query_frontend/src/tests.rs
+++ b/query_frontend/src/tests.rs
@@ -78,4 +78,8 @@ impl MetaProvider for MockMetaProvider {
     fn aggregate_udf(&self, _name: &str) -> crate::provider::Result<Option<AggregateUdf>> {
         todo!()
     }
+
+    fn all_tables(&self) -> crate::provider::Result<Vec<TableRef>> {
+        todo!()
+    }
 }

--- a/server/src/handlers/query.rs
+++ b/server/src/handlers/query.rs
@@ -187,11 +187,7 @@ pub async fn handle_query<Q: QueryExecutor + 'static>(
             );
 
             frontend
-                .influxql_stmt_to_plan(
-                    &mut sql_ctx,
-                    stmts.remove(0),
-                    instance.catalog_manager.clone(),
-                )
+                .influxql_stmt_to_plan(&mut sql_ctx, stmts.remove(0))
                 .context(CreatePlan {
                     query: &request.query,
                 })?

--- a/server/src/proxy/http/query.rs
+++ b/server/src/proxy/http/query.rs
@@ -148,11 +148,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
                 );
 
                 frontend
-                    .influxql_stmt_to_plan(
-                        &mut sql_ctx,
-                        stmts.remove(0),
-                        self.instance.catalog_manager.clone(),
-                    )
+                    .influxql_stmt_to_plan(&mut sql_ctx, stmts.remove(0))
                     .box_err()
                     .with_context(|| ErrWithCause {
                         code: StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## Which issue does this PR close?

Closes #
Part of #830 

## Rationale for this change
Now, we collect and keep all tables in influxql planner even though it is unused.
It is wasteful to do this. So in this pr, I make it just do such works on demand.
 
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
+ Add `all_tables` method in `MetaProvider`.
+ Just call `MetaProvider::all_tables` to get tables while they are actually needed(such as while influxql's `SchemaProvider::table_names` is called).
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
