### PR TITLE
refactor: implement prom remote query by convert to datafusion plan directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4923,6 +4923,7 @@ dependencies = [
  "lazy_static",
  "log",
  "paste 1.0.12",
+ "prom-remote-api",
  "regex",
  "regex-syntax",
  "schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ parquet = { version = "36.0.0" }
 paste = "1.0"
 pin-project-lite = "0.2.8"
 profile = { path = "components/profile" }
+prom-remote-api = { version = "0.2.1" }
 prometheus = "0.12"
 prometheus-static-metric = "0.5"
 prost = "0.11"

--- a/common_types/src/tests.rs
+++ b/common_types/src/tests.rs
@@ -13,7 +13,7 @@ use crate::{
         Row,
     },
     schema,
-    schema::{IndexInWriterSchema, Schema},
+    schema::{IndexInWriterSchema, Schema, TSID_COLUMN},
     string::StringBytes,
     time::Timestamp,
 };
@@ -143,6 +143,54 @@ pub fn build_schema() -> Schema {
 /// field5(uint32, default field4 + 2)
 pub fn build_default_value_schema() -> Schema {
     default_value_schema_builder().build().unwrap()
+}
+
+/// Build a schema for testing:
+/// (tsid(uint64), key2(timestamp), tag1(string), tag2(string), value(int8),
+/// field2(float))
+pub fn build_schema_for_cpu() -> Schema {
+    let builder = schema::Builder::new()
+        .auto_increment_column_id(true)
+        .add_key_column(
+            column_schema::Builder::new(TSID_COLUMN.to_string(), DatumKind::UInt64)
+                .build()
+                .unwrap(),
+        )
+        .unwrap()
+        .add_key_column(
+            column_schema::Builder::new("time".to_string(), DatumKind::Timestamp)
+                .build()
+                .unwrap(),
+        )
+        .unwrap()
+        .add_normal_column(
+            column_schema::Builder::new("tag1".to_string(), DatumKind::String)
+                .is_tag(true)
+                .build()
+                .unwrap(),
+        )
+        .unwrap()
+        .add_normal_column(
+            column_schema::Builder::new("tag2".to_string(), DatumKind::String)
+                .is_tag(true)
+                .build()
+                .unwrap(),
+        )
+        .unwrap()
+        .add_normal_column(
+            column_schema::Builder::new("value".to_string(), DatumKind::Int8)
+                .build()
+                .unwrap(),
+        )
+        .unwrap()
+        .add_normal_column(
+            column_schema::Builder::new("field2".to_string(), DatumKind::Float)
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+
+    builder.build().unwrap()
 }
 
 pub fn build_projected_schema() -> ProjectedSchema {

--- a/query_frontend/Cargo.toml
+++ b/query_frontend/Cargo.toml
@@ -32,8 +32,8 @@ influxql-schema = { git = "https://github.com/CeresDB/influxql", package = "sche
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-prom-remote-api = { workspace = true }
 paste = { workspace = true }
+prom-remote-api = { workspace = true }
 regex = "1"
 regex-syntax = "0.6.28"
 snafu = { workspace = true }

--- a/query_frontend/Cargo.toml
+++ b/query_frontend/Cargo.toml
@@ -32,6 +32,7 @@ influxql-schema = { git = "https://github.com/CeresDB/influxql", package = "sche
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
+prom-remote-api = { workspace = true }
 paste = { workspace = true }
 regex = "1"
 regex-syntax = "0.6.28"

--- a/query_frontend/src/frontend.rs
+++ b/query_frontend/src/frontend.rs
@@ -9,6 +9,7 @@ use cluster::config::SchemaConfig;
 use common_types::request_id::RequestId;
 use common_util::error::GenericError;
 use influxql_parser::statement::Statement as InfluxqlStatement;
+use prom_remote_api::types::Query as PromRemoteQuery;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use sqlparser::ast::{SetExpr, Statement as SqlStatement, TableFactor};
 use table_engine::table;
@@ -131,6 +132,7 @@ impl<P: MetaProvider> Frontend<P> {
         planner.statement_to_plan(stmt).context(CreatePlan)
     }
 
+    /// Experimental promql support natively, not used in production yet.
     pub fn promql_expr_to_plan(
         &self,
         ctx: &mut Context,
@@ -148,6 +150,15 @@ impl<P: MetaProvider> Frontend<P> {
     ) -> Result<Plan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
         planner.influxql_stmt_to_plan(stmt).context(CreatePlan)
+    }
+
+    pub fn prom_remote_query_to_plan(
+        &self,
+        ctx: &mut Context,
+        query: PromRemoteQuery,
+    ) -> Result<Plan> {
+        let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
+        planner.remote_prom_req_to_plan(query).context(CreatePlan)
     }
 
     pub fn write_req_to_plan(

--- a/query_frontend/src/frontend.rs
+++ b/query_frontend/src/frontend.rs
@@ -19,7 +19,7 @@ use crate::{
     parser::Parser,
     plan::Plan,
     planner::Planner,
-    promql::{ColumnNames, Expr},
+    promql::{ColumnNames, Expr, RemoteQueryPlan},
     provider::MetaProvider,
 };
 
@@ -148,7 +148,7 @@ impl<P: MetaProvider> Frontend<P> {
         &self,
         ctx: &mut Context,
         query: PromRemoteQuery,
-    ) -> Result<Plan> {
+    ) -> Result<RemoteQueryPlan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
         planner.remote_prom_req_to_plan(query).context(CreatePlan)
     }

--- a/query_frontend/src/frontend.rs
+++ b/query_frontend/src/frontend.rs
@@ -132,7 +132,7 @@ impl<P: MetaProvider> Frontend<P> {
         planner.statement_to_plan(stmt).context(CreatePlan)
     }
 
-    /// Experimental promql support natively, not used in production yet.
+    /// Experimental native promql support, not used in production yet.
     pub fn promql_expr_to_plan(
         &self,
         ctx: &mut Context,
@@ -143,15 +143,7 @@ impl<P: MetaProvider> Frontend<P> {
         planner.promql_expr_to_plan(expr).context(CreatePlan)
     }
 
-    pub fn influxql_stmt_to_plan(
-        &self,
-        ctx: &mut Context,
-        stmt: InfluxqlStatement,
-    ) -> Result<Plan> {
-        let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
-        planner.influxql_stmt_to_plan(stmt).context(CreatePlan)
-    }
-
+    /// Prometheus remote query support
     pub fn prom_remote_query_to_plan(
         &self,
         ctx: &mut Context,
@@ -159,6 +151,15 @@ impl<P: MetaProvider> Frontend<P> {
     ) -> Result<Plan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
         planner.remote_prom_req_to_plan(query).context(CreatePlan)
+    }
+
+    pub fn influxql_stmt_to_plan(
+        &self,
+        ctx: &mut Context,
+        stmt: InfluxqlStatement,
+    ) -> Result<Plan> {
+        let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
+        planner.influxql_stmt_to_plan(stmt).context(CreatePlan)
     }
 
     pub fn write_req_to_plan(

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -59,7 +59,7 @@ use crate::{
         ExistsTablePlan, InsertPlan, Plan, QueryPlan, QueryType, ShowCreatePlan, ShowPlan,
         ShowTablesPlan,
     },
-    promql::{remote_query_to_plan, ColumnNames, Expr as PromExpr},
+    promql::{remote_query_to_plan, ColumnNames, Expr as PromExpr, RemoteQueryPlan},
     provider::{ContextProviderAdapter, MetaProvider},
 };
 // We do not carry backtrace in sql error because it is mainly used in server
@@ -331,7 +331,7 @@ impl<'a, P: MetaProvider> Planner<'a, P> {
             .context(BuildPromPlanError)
     }
 
-    pub fn remote_prom_req_to_plan(&self, query: PromRemoteQuery) -> Result<Plan> {
+    pub fn remote_prom_req_to_plan(&self, query: PromRemoteQuery) -> Result<RemoteQueryPlan> {
         let adapter = ContextProviderAdapter::new(self.provider, self.read_parallelism);
         let planner = PlannerDelegate::new(adapter);
 

--- a/query_frontend/src/promql.rs
+++ b/query_frontend/src/promql.rs
@@ -2,9 +2,13 @@
 
 mod convert;
 mod datafusion_util;
+pub mod error;
 mod pushdown;
+mod remote;
 mod udf;
 
-pub use convert::{Error, Expr};
+pub use convert::Expr;
 pub use datafusion_util::{ColumnNames, PromAlignNode};
+pub use error::Error;
 pub use pushdown::{AlignParameter, Func};
+pub use remote::remote_query_to_plan;

--- a/query_frontend/src/promql.rs
+++ b/query_frontend/src/promql.rs
@@ -11,4 +11,4 @@ pub use convert::Expr;
 pub use datafusion_util::{ColumnNames, PromAlignNode};
 pub use error::Error;
 pub use pushdown::{AlignParameter, Func};
-pub use remote::remote_query_to_plan;
+pub use remote::{remote_query_to_plan, RemoteQueryPlan, DEFAULT_FIELD_COLUMN, NAME_LABEL};

--- a/query_frontend/src/promql/datafusion_util.rs
+++ b/query_frontend/src/promql/datafusion_util.rs
@@ -31,7 +31,7 @@ pub fn timerange_to_expr(query_range: TimeRange, column_name: &str) -> DataFusio
         expr: Box::new(col(column_name)),
         negated: false,
         low: Box::new(lit(query_range.inclusive_start().as_i64())),
-        high: Box::new(lit(query_range.exclusive_end().as_i64() + 1)),
+        high: Box::new(lit(query_range.exclusive_end().as_i64() - 1)),
     })
 }
 

--- a/query_frontend/src/promql/error.rs
+++ b/query_frontend/src/promql/error.rs
@@ -1,0 +1,53 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use ceresdbproto::prometheus::sub_expr::OperatorType;
+use datafusion::error::DataFusionError;
+use snafu::{Backtrace, Snafu};
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Snafu)]
+#[snafu(visibility = "pub")]
+pub enum Error {
+    #[snafu(display("Invalid expr, expected: {}, actual:{:?}", expected, actual))]
+    UnexpectedExpr { expected: String, actual: String },
+
+    #[snafu(display("Expr pushdown not implemented, expr_type:{:?}", expr_type))]
+    NotImplemented { expr_type: OperatorType },
+
+    #[snafu(display("MetaProvider {}, err:{}", msg, source))]
+    MetaProviderError {
+        msg: String,
+        source: crate::provider::Error,
+    },
+
+    #[snafu(display("Table not found, table:{}", name))]
+    TableNotFound { name: String },
+
+    #[snafu(display("Table provider not found, table:{}, err:{}", name, source))]
+    TableProviderNotFound {
+        name: String,
+        source: DataFusionError,
+    },
+
+    #[snafu(display("Failed to build schema, err:{}", source))]
+    BuildTableSchema { source: common_types::schema::Error },
+
+    #[snafu(display("Failed to build plan, source:{}", source,))]
+    BuildPlanError { source: DataFusionError },
+
+    #[snafu(display("Invalid expr, msg:{}\nBacktrace:\n{}", msg, backtrace))]
+    InvalidExpr { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to pushdown, source:{}", source))]
+    PushdownError {
+        source: crate::promql::pushdown::Error,
+    },
+}
+
+define_result!(Error);
+
+impl From<DataFusionError> for Error {
+    fn from(df_err: DataFusionError) -> Self {
+        Error::BuildPlanError { source: df_err }
+    }
+}

--- a/query_frontend/src/promql/remote.rs
+++ b/query_frontend/src/promql/remote.rs
@@ -1,0 +1,173 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! This module convert Prometheus remote query to datafusion plan
+
+use std::sync::Arc;
+
+use common_types::{schema::Schema, time::TimeRange};
+use datafusion::{
+    logical_expr::LogicalPlanBuilder,
+    optimizer::utils::conjunction,
+    prelude::{col, lit, Expr},
+    sql::{planner::ContextProvider, TableReference},
+};
+use prom_remote_api::types::{label_matcher, LabelMatcher, Query};
+use snafu::{OptionExt, ResultExt};
+
+use crate::{
+    plan::{Plan, QueryPlan},
+    promql::{
+        convert::Selector,
+        datafusion_util::{default_sort_exprs, timerange_to_expr},
+        error::*,
+    },
+    provider::{ContextProviderAdapter, MetaProvider},
+};
+
+const NAME_LABEL: &str = "__name__";
+const FIELD_LABEL: &str = "__ceresdb_field__";
+const DEFAULT_FIELD_COLUMN: &str = "value";
+
+/// Generate a plan like this
+/// ```
+/// Sort: (tsid, timestamp) asc
+///   Project:
+///     Filter:
+///       TableScan
+/// ```
+pub fn remote_query_to_plan<P: MetaProvider>(
+    query: Query,
+    meta_provider: ContextProviderAdapter<'_, P>,
+) -> Result<Plan> {
+    let (metric, field, mut filters) = normalize_matchers(query.matchers)?;
+    let table_ref = meta_provider
+        .table(TableReference::parse_str(&metric))
+        .context(MetaProviderError {
+            msg: "failed to find table".to_string(),
+        })?
+        .context(TableNotFound { name: &metric })?;
+    let table_provider = meta_provider
+        .get_table_provider(table_ref.name().into())
+        .context(TableProviderNotFound { name: &metric })?;
+    let schema = Schema::try_from(table_provider.schema()).context(BuildTableSchema)?;
+    let timestamp_column_name = schema.timestamp_name();
+    let query_range = TimeRange::new_unchecked(
+        query.start_timestamp_ms.into(),
+        (query.end_timestamp_ms + 1).into(), // end is inclusive
+    );
+    filters.push(timerange_to_expr(query_range, timestamp_column_name));
+
+    let (projection, _) = Selector::build_projection_tag_keys(&schema, &field)?;
+    let builder = LogicalPlanBuilder::scan(metric.clone(), table_provider, None)?
+        .filter(conjunction(filters).expect("at least one filter(timestamp)"))?
+        .project(projection)?
+        .sort(default_sort_exprs(timestamp_column_name))?;
+
+    let df_plan = builder.build().context(BuildPlanError)?;
+    let tables = Arc::new(
+        meta_provider
+            .try_into_container()
+            .context(MetaProviderError {
+                msg: "failed to find meta",
+            })?,
+    );
+    Ok(Plan::Query(QueryPlan { df_plan, tables }))
+}
+
+/// Separate metric, field from matchers, and convert remaining matchers to
+/// datafusion exprs
+fn normalize_matchers(matchers: Vec<LabelMatcher>) -> Result<(String, String, Vec<Expr>)> {
+    let mut metric = None;
+    let mut field = None;
+    let mut filters = Vec::with_capacity(matchers.len());
+    for m in matchers {
+        match m.name.as_str() {
+            NAME_LABEL => metric = Some(m.value),
+            FIELD_LABEL => field = Some(m.value),
+            _ => {
+                let expr = match m.r#type() {
+                    label_matcher::Type::Eq => col(m.name).eq(lit(m.value)),
+                    label_matcher::Type::Neq => col(m.name).not_eq(lit(m.value)),
+                    // https://github.com/prometheus/prometheus/blob/2ce94ac19673a3f7faf164e9e078a79d4d52b767/model/labels/regexp.go#L29
+                    label_matcher::Type::Re => col(m.name).like(lit(format!("^(?:{})", m.value))),
+                    label_matcher::Type::Nre => {
+                        col(m.name).not_like(lit(format!("^(?:{})", m.value)))
+                    }
+                };
+
+                filters.push(expr);
+            }
+        }
+    }
+
+    Ok((
+        metric.context(InvalidExpr {
+            msg: "Metric not found",
+        })?,
+        field.unwrap_or_else(|| DEFAULT_FIELD_COLUMN.to_string()),
+        filters,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use prom_remote_api::types::{label_matcher::Type, LabelMatcher};
+
+    use super::*;
+    use crate::promql::remote::NAME_LABEL;
+
+    fn make_matchers(tuples: Vec<(&str, &str, Type)>) -> Vec<LabelMatcher> {
+        tuples
+            .into_iter()
+            .map(|(name, value, matcher_type)| LabelMatcher {
+                name: name.to_string(),
+                value: value.to_string(),
+                r#type: matcher_type as i32,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_normailze_matchers() {
+        // no metric
+        assert!(normalize_matchers(vec![]).is_err());
+
+        // ok
+        {
+            let matchers = make_matchers(vec![
+                ("a", "1", Type::Eq),
+                ("b", "2", Type::Neq),
+                ("c", "3", Type::Re),
+                ("d", "4", Type::Nre),
+                (NAME_LABEL, "cpu", Type::Eq),
+            ]);
+
+            let (metric, field, filters) = normalize_matchers(matchers).unwrap();
+            assert_eq!("cpu", metric);
+            assert_eq!("value", field);
+            assert_eq!(
+                r#"a = Utf8("1")
+b != Utf8("2")
+c LIKE Utf8("^(?:3)")
+d NOT LIKE Utf8("^(?:4)")"#,
+                filters
+                    .iter()
+                    .map(|f| f.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+
+        {
+            let matchers = make_matchers(vec![
+                (NAME_LABEL, "cpu", Type::Eq),
+                (FIELD_LABEL, "another-field", Type::Eq),
+            ]);
+
+            let (metric, field, filters) = normalize_matchers(matchers).unwrap();
+            assert_eq!("cpu", metric);
+            assert_eq!("another-field", field);
+            assert!(filters.is_empty());
+        }
+    }
+}

--- a/query_frontend/src/tests.rs
+++ b/query_frontend/src/tests.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use catalog::consts::{DEFAULT_CATALOG, DEFAULT_SCHEMA};
-use common_types::tests::{build_default_value_schema, build_schema};
+use common_types::tests::{build_default_value_schema, build_schema, build_schema_for_cpu};
 use datafusion::catalog::TableReference;
 use df_operator::{scalar::ScalarUdf, udaf::AggregateUdf};
 use table_engine::{
@@ -44,6 +44,13 @@ impl Default for MockMetaProvider {
                     "__test_table".to_string(),
                     TableId::from(103),
                     build_schema(),
+                    ANALYTIC_ENGINE_TYPE.to_string(),
+                )),
+                // Used in `test_remote_query_to_plan`
+                Arc::new(MemoryTable::new(
+                    "cpu".to_string(),
+                    TableId::from(104),
+                    build_schema_for_cpu(),
                     ANALYTIC_ENGINE_TYPE.to_string(),
                 )),
             ],

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -37,7 +37,7 @@ partition_table_engine = { workspace = true }
 paste = { workspace = true }
 pprof = { version = "0.11.1", features = ["flamegraph"] }
 profile = { workspace = true }
-prom-remote-api = { version = "0.2.1", features = ["warp"] }
+prom-remote-api = { workspace = true, features = ["warp"] }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 prost = { workspace = true }

--- a/server/src/proxy/http/prom.rs
+++ b/server/src/proxy/http/prom.rs
@@ -123,10 +123,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
         let begin_instant = Instant::now();
         let deadline = ctx.timeout.map(|t| begin_instant + t);
 
-        debug!(
-            "Query handler try to process request, request_id:{}, request:{:?}",
-            request_id, query
-        );
+        debug!("Query handler try to process request, request_id:{request_id}, request:{query:?}");
 
         let provider = CatalogMetaProvider {
             manager: self.instance.catalog_manager.clone(),
@@ -167,12 +164,8 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
         )
         .await?;
 
-        debug!(
-            "Query handler finished, request_id:{}, cost:{}ms, query:{:?}",
-            request_id,
-            begin_instant.saturating_elapsed().as_millis(),
-            query
-        );
+        let cost = begin_instant.saturating_elapsed().as_millis();
+        debug!("Query handler finished, request_id:{request_id}, cost:{cost}ms, query:{query:?}");
 
         convert_query_result(metric, timestamp_col_name, field_col_name, output)
     }


### PR DESCRIPTION
## Which issue does this PR close?

Related to #855

## Rationale for this change
 
Currently prom requests is implemented based on sql, but there are some shortcomings:

1. Timestamp is hard-coded
2. Can't select column other than `value`
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?

- Convert prom request to datafusion plan directly 
- Add special label `__ceresdb_field__` to set field column other than `value`
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?

No
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test

CI and manually
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->

