### PR TITLE
feat: rename the compaction_config to compaction and adjust interval

### DIFF
--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -73,7 +73,7 @@ impl Default for SchedulerConfig {
         Self {
             schedule_channel_len: 16,
             // 30 minutes schedule interval.
-            schedule_interval: ReadableDuration(Duration::from_secs(60 * 30)),
+            schedule_interval: ReadableDuration(Duration::from_secs(60 * 5)),
             max_ongoing_tasks: MAX_GOING_COMPACTION_TASKS,
             // flush_interval default is 5h.
             max_unflushed_duration: ReadableDuration(Duration::from_secs(60 * 60 * 5)),

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -82,7 +82,7 @@ impl Instance {
             meta_cache: ctx.meta_cache.clone(),
         });
 
-        let scheduler_config = ctx.config.compaction_config.clone();
+        let scheduler_config = ctx.config.compaction.clone();
         let scan_options_for_compaction = ScanOptions {
             background_read_parallelism: 1,
             max_record_batches_in_flight: MAX_RECORD_BATCHES_IN_FLIGHT_WHEN_COMPACTION_READ,

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -50,7 +50,7 @@ pub struct Config {
     /// Default options for table
     pub table_opts: TableOptions,
 
-    pub compaction_config: SchedulerConfig,
+    pub compaction: SchedulerConfig,
 
     /// sst meta cache capacity
     pub sst_meta_cache_cap: Option<usize>,
@@ -103,7 +103,7 @@ impl Default for Config {
             replay_batch_size: 500,
             max_replay_tables_per_batch: 64,
             table_opts: TableOptions::default(),
-            compaction_config: SchedulerConfig::default(),
+            compaction: SchedulerConfig::default(),
             sst_meta_cache_cap: Some(1000),
             sst_data_cache_cap: Some(1000),
             manifest: ManifestOptions::default(),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
After #822, the compaction triggered by flush will take place less frequently. And #861, the filter won't be built for level0 sst, so the query performance may drop a little if we don't adjust the compaction frequency.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Rename the config name `compaction_config` to `compaction`, which is more elegant;
- Adjust the interval of periodic compaction from 30m to 5m;
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
The config name `compaction_config` is replaced with `compaction`.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Manually.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
