### PR TITLE
chore!: rename table name in table_kv based wal

### DIFF
--- a/wal/src/table_kv_impl/encoding.rs
+++ b/wal/src/table_kv_impl/encoding.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Constants and utils for encoding.
 
@@ -74,7 +74,7 @@ pub fn format_permanent_bucket_key(namespace: &str) -> String {
 
 #[inline]
 pub fn format_table_unit_meta_name(namespace: &str, shard_id: usize) -> String {
-    format!("table_unit_meta_{namespace}_{shard_id:0>6}")
+    format!("{namespace}_meta_{shard_id:0>6}")
 }
 
 #[inline]
@@ -91,7 +91,7 @@ pub fn format_timed_wal_name(
         Some(v) => v,
     };
     Ok(format!(
-        "wal_{}_{}_{:0>6}",
+        "{}_data_{}_{:0>6}",
         namespace,
         dt.format(WAL_SHARD_TIMESTAMP_FORMAT),
         shard_id
@@ -100,7 +100,7 @@ pub fn format_timed_wal_name(
 
 #[inline]
 pub fn format_permanent_wal_name(namespace: &str, shard_id: usize) -> String {
-    format!("wal_{namespace}_permanent_{shard_id:0>6}")
+    format!("{namespace}_data_permanent_{shard_id:0>6}")
 }
 
 #[inline]
@@ -143,32 +143,32 @@ mod tests {
     fn test_format_table_unit_meta() {
         let ns = "abcdef";
         let name = format_table_unit_meta_name(ns, 0);
-        assert_eq!("table_unit_meta_abcdef_000000", name);
+        assert_eq!("abcdef_meta_000000", name);
 
         let name = format_table_unit_meta_name(ns, 124);
-        assert_eq!("table_unit_meta_abcdef_000124", name);
+        assert_eq!("abcdef_meta_000124", name);
 
         let name = format_table_unit_meta_name(ns, 999999);
-        assert_eq!("table_unit_meta_abcdef_999999", name);
+        assert_eq!("abcdef_meta_999999", name);
 
         let name = format_table_unit_meta_name(ns, 1234567);
-        assert_eq!("table_unit_meta_abcdef_1234567", name);
+        assert_eq!("abcdef_meta_1234567", name);
     }
 
     #[test]
     fn test_format_permanent_wal_name() {
         let ns = "mywal";
         let name = format_permanent_wal_name(ns, 0);
-        assert_eq!("wal_mywal_permanent_000000", name);
+        assert_eq!("mywal_data_permanent_000000", name);
 
         let name = format_permanent_wal_name(ns, 124);
-        assert_eq!("wal_mywal_permanent_000124", name);
+        assert_eq!("mywal_data_permanent_000124", name);
 
         let name = format_permanent_wal_name(ns, 999999);
-        assert_eq!("wal_mywal_permanent_999999", name);
+        assert_eq!("mywal_data_permanent_999999", name);
 
         let name = format_permanent_wal_name(ns, 1234567);
-        assert_eq!("wal_mywal_permanent_1234567", name);
+        assert_eq!("mywal_data_permanent_1234567", name);
     }
 
     #[test]
@@ -176,19 +176,19 @@ mod tests {
         let ns = "mywal";
 
         let name = format_timed_wal_name(ns, Timestamp::ZERO, 0).unwrap();
-        assert_eq!("wal_mywal_19700101000000_000000", name);
+        assert_eq!("mywal_data_19700101000000_000000", name);
 
         // gmt time 2022-03-28T00:00:00
         let ts = Timestamp::new(1648425600000);
 
         let name = format_timed_wal_name(ns, ts, 124).unwrap();
-        assert_eq!("wal_mywal_20220328000000_000124", name);
+        assert_eq!("mywal_data_20220328000000_000124", name);
 
         let name = format_timed_wal_name(ns, ts, 999999).unwrap();
-        assert_eq!("wal_mywal_20220328000000_999999", name);
+        assert_eq!("mywal_data_20220328000000_999999", name);
 
         let name = format_timed_wal_name(ns, ts, 1234567).unwrap();
-        assert_eq!("wal_mywal_20220328000000_1234567", name);
+        assert_eq!("mywal_data_20220328000000_1234567", name);
     }
 
     #[test]

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1544,10 +1544,10 @@ mod tests {
         let bucket = Bucket::new("test", entry).unwrap();
         assert_eq!(4, bucket.wal_shard_names.len());
         let expect_names = [
-            "wal_test_20220328000000_000000",
-            "wal_test_20220328000000_000001",
-            "wal_test_20220328000000_000002",
-            "wal_test_20220328000000_000003",
+            "test_data_20220328000000_000000",
+            "test_data_20220328000000_000001",
+            "test_data_20220328000000_000002",
+            "test_data_20220328000000_000003",
         ];
         assert_eq!(&expect_names[..], &bucket.wal_shard_names[..]);
     }
@@ -1560,10 +1560,10 @@ mod tests {
         let bucket = Bucket::new("test", entry).unwrap();
         assert_eq!(4, bucket.wal_shard_names.len());
         let expect_names = [
-            "wal_test_permanent_000000",
-            "wal_test_permanent_000001",
-            "wal_test_permanent_000002",
-            "wal_test_permanent_000003",
+            "test_data_permanent_000000",
+            "test_data_permanent_000001",
+            "test_data_permanent_000002",
+            "test_data_permanent_000003",
         ];
         assert_eq!(&expect_names[..], &bucket.wal_shard_names[..]);
     }


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
The wal related table name in table_kv based wal is strange.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Rename related tables names.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
  BREAKING CHANGE, users using obkv based wal will lose the wal data.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Test by ut.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
