### PR TITLE
chore: remove udeps in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,10 @@ jobs:
           rustup component add clippy
           rustup component add rustfmt
           cargo install cargo-sort
-          cargo install cargo-udeps
       - name: Run Style Check
         run: |
           make check-license
           make clippy
-          make udeps
           make fmt
           make check-cargo-toml
       - name: Report Disk Usage


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 The running time of `udeps` is too long, so it is suitable to put it in CI.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Remove udeps in CI.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
No.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
