### PR TITLE
feat: support merge small write requests

### DIFF
--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -143,6 +143,7 @@ pub struct Instance {
     meta_cache: Option<MetaCacheRef>,
     /// Engine memtable memory usage collector
     mem_usage_collector: Arc<MemUsageCollector>,
+    pub(crate) max_rows_in_write_queue: usize,
     /// Engine write buffer size
     pub(crate) db_write_buffer_size: usize,
     /// Space write buffer size

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -117,6 +117,7 @@ impl Instance {
             file_purger,
             meta_cache: ctx.meta_cache.clone(),
             mem_usage_collector: Arc::new(MemUsageCollector::default()),
+            max_rows_in_write_queue: ctx.config.max_rows_in_write_queue,
             db_write_buffer_size: ctx.config.db_write_buffer_size,
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             preflush_write_buffer_size_ratio: ctx.config.preflush_write_buffer_size_ratio,

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -60,6 +60,8 @@ pub struct Config {
     /// Manifest options
     pub manifest: ManifestOptions,
 
+    /// The maximum rows in the write queue.
+    pub max_rows_in_write_queue: usize,
     /// The maximum write buffer size used for single space.
     pub space_write_buffer_size: usize,
     /// The maximum size of all Write Buffers across all spaces.
@@ -107,6 +109,7 @@ impl Default for Config {
             sst_meta_cache_cap: Some(1000),
             sst_data_cache_cap: Some(1000),
             manifest: ManifestOptions::default(),
+            max_rows_in_write_queue: 0,
             /// Zero means disabling this param, give a positive value to enable
             /// it.
             space_write_buffer_size: 0,

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -637,8 +637,7 @@ mod tests {
         let merged_rows = merged_request.row_group.take_rows();
         let original_rows = total_requests
             .iter_mut()
-            .map(|req| req.row_group.take_rows())
-            .flatten()
+            .flat_map(|req| req.row_group.take_rows())
             .collect::<Vec<_>>();
 
         assert_eq!(merged_rows, original_rows);

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -2,13 +2,18 @@
 
 //! Table implementation
 
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, sync::Mutex};
 
 use async_trait::async_trait;
-use common_types::{row::Row, schema::Schema, time::TimeRange};
+use common_types::{
+    row::{Row, RowGroup, RowGroupBuilder},
+    schema::Schema,
+    time::TimeRange,
+};
 use common_util::error::BoxError;
 use datafusion::{common::Column, logical_expr::Expr};
 use futures::TryStreamExt;
+use log::warn;
 use snafu::{ensure, OptionExt, ResultExt};
 use table_engine::{
     partition::PartitionInfo,
@@ -16,10 +21,12 @@ use table_engine::{
     stream::{PartitionedStreams, SendableRecordBatchStream},
     table::{
         AlterOptions, AlterSchema, AlterSchemaRequest, Compact, Flush, FlushRequest, Get,
-        GetInvalidPrimaryKey, GetNullPrimaryKey, GetRequest, ReadOptions, ReadOrder, ReadRequest,
-        Result, Scan, Table, TableId, TableStats, Write, WriteRequest,
+        GetInvalidPrimaryKey, GetNullPrimaryKey, GetRequest, MergeWrite, ReadOptions, ReadOrder,
+        ReadRequest, Result, Scan, Table, TableId, TableStats, WaitForPendingWrites, Write,
+        WriteRequest,
     },
 };
+use tokio::sync::oneshot::{self, Receiver, Sender};
 use trace_metric::MetricsCollector;
 
 use self::data::TableDataRef;
@@ -35,6 +42,8 @@ pub mod version;
 pub mod version_edit;
 
 const GET_METRICS_COLLECTOR_NAME: &str = "get";
+const DEFAULT_PENDING_WRITE_REQUESTS: usize = 32;
+const DEFAULT_MAX_PENDING_ROWS: usize = 10000;
 
 /// Table trait implementation
 pub struct TableImpl {
@@ -50,6 +59,9 @@ pub struct TableImpl {
     /// Holds a strong reference to prevent the underlying table from being
     /// dropped when this handle exist.
     table_data: TableDataRef,
+
+    /// Buffer for written rows.
+    pending_writes: Mutex<PendingWriteQueue>,
 }
 
 impl TableImpl {
@@ -68,6 +80,7 @@ impl TableImpl {
             space_id,
             table_id,
             table_data,
+            pending_writes: Mutex::new(PendingWriteQueue::new(DEFAULT_MAX_PENDING_ROWS)),
         }
     }
 }
@@ -79,6 +92,161 @@ impl fmt::Debug for TableImpl {
             .field("table_id", &self.table_id)
             .finish()
     }
+}
+
+struct PendingWriteQueue {
+    max_rows: usize,
+    pending_writes: PendingWrites,
+}
+
+#[derive(Default)]
+struct PendingWrites {
+    writes: Vec<WriteRequest>,
+    notifiers: Vec<Sender<Result<()>>>,
+    num_rows: usize,
+}
+
+impl PendingWrites {
+    /// Try to push the request into the pending queue.
+    ///
+    /// Original request will be returned if the schema is different.
+    fn try_push(
+        &mut self,
+        request: WriteRequest,
+    ) -> std::result::Result<Receiver<Result<()>>, WriteRequest> {
+        if !self.is_same_schema(request.row_group.schema()) {
+            return Err(request);
+        }
+
+        if self.is_empty() {
+            self.writes = Vec::with_capacity(DEFAULT_PENDING_WRITE_REQUESTS);
+            self.notifiers = Vec::with_capacity(DEFAULT_PENDING_WRITE_REQUESTS);
+        }
+
+        let (tx, rx) = oneshot::channel();
+        self.num_rows += request.row_group.num_rows();
+        self.writes.push(request);
+        self.notifiers.push(tx);
+
+        Ok(rx)
+    }
+
+    /// Check if the schema of the request is the same as the schema of the
+    /// pending write requests.
+    ///
+    /// Return true if the pending write requests is empty.
+    fn is_same_schema(&self, schema: &Schema) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        let request = &self.writes[0];
+        schema.version() == request.row_group.schema().version()
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.writes.is_empty()
+    }
+}
+
+struct MergePendingWritesResult {
+    merged_request: WriteRequest,
+    /// The request can't be merged into the `merged_request`.
+    different_request: Option<WriteRequest>,
+}
+
+impl PendingWriteQueue {
+    fn new(max_rows: usize) -> Self {
+        Self {
+            max_rows,
+            pending_writes: PendingWrites::default(),
+        }
+    }
+
+    /// Try to push the request into the queue.
+    ///
+    /// If the queue is full or the schema is different, return the request
+    /// back. Otherwise, return a receiver to let the caller wait for the write
+    /// result.
+    fn try_push(
+        &mut self,
+        request: WriteRequest,
+    ) -> std::result::Result<Receiver<Result<()>>, WriteRequest> {
+        if self.is_full() {
+            return Err(request);
+        }
+
+        self.pending_writes.try_push(request)
+    }
+
+    #[inline]
+    fn is_full(&self) -> bool {
+        self.pending_writes.num_rows >= self.max_rows
+    }
+
+    /// Clear the pending writes and reset the number of rows.
+    fn reset(&mut self) -> Option<PendingWrites> {
+        if self.pending_writes.is_empty() {
+            return None;
+        }
+
+        Some(std::mem::take(&mut self.pending_writes))
+    }
+}
+
+fn merge_pending_write_requests(
+    mut pending_writes: Vec<WriteRequest>,
+    new_request: WriteRequest,
+    num_pending_rows: usize,
+) -> MergePendingWritesResult {
+    if pending_writes.is_empty() {
+        return MergePendingWritesResult {
+            merged_request: new_request,
+            different_request: None,
+        };
+    }
+
+    // Clear the pending writes.
+    let mut total_rows = num_pending_rows;
+    let same_schema =
+        new_request.row_group.schema().version() == pending_writes[0].row_group.schema().version();
+    if same_schema {
+        total_rows += new_request.row_group.num_rows();
+        let row_group = build_row_group(pending_writes, new_request, total_rows);
+        MergePendingWritesResult {
+            merged_request: WriteRequest { row_group },
+            different_request: None,
+        }
+    } else {
+        let last_request = pending_writes.pop().unwrap();
+        let row_group = build_row_group(pending_writes, last_request, total_rows);
+        MergePendingWritesResult {
+            merged_request: WriteRequest { row_group },
+            different_request: Some(new_request),
+        }
+    }
+}
+
+fn build_row_group(
+    pending_writes: Vec<WriteRequest>,
+    mut additional_req: WriteRequest,
+    total_rows: usize,
+) -> RowGroup {
+    let additional_rows = additional_req.row_group.take_rows();
+    let schema = additional_req.row_group.into_schema();
+    let mut row_group_builder = RowGroupBuilder::with_capacity(schema, total_rows);
+
+    for mut pending_req in pending_writes {
+        let rows = pending_req.row_group.take_rows();
+        for row in rows {
+            row_group_builder.push_checked_row(row)
+        }
+    }
+    for row in additional_rows {
+        row_group_builder.push_checked_row(row);
+    }
+    row_group_builder.build()
 }
 
 #[async_trait]
@@ -112,18 +280,111 @@ impl Table for TableImpl {
     }
 
     async fn write(&self, request: WriteRequest) -> Result<usize> {
-        let mut serial_exec = self.table_data.serial_exec.lock().await;
+        let num_rows = request.row_group.num_rows();
+
+        let lock_res = self.table_data.serial_exec.try_lock();
+        let (request, mut serial_exec) = if let Ok(serial_exec) = lock_res {
+            (request, serial_exec)
+        } else {
+            // Failed to acquire the serial_exec, put the request into the
+            // pending queue.
+            let queue_res = {
+                let mut pending_queue = self.pending_writes.lock().unwrap();
+                pending_queue.try_push(request)
+            };
+            match queue_res {
+                Ok(rx) => {
+                    // The request is successfully pushed into the queue, and just wait for the
+                    // write result.
+                    match rx.await {
+                        Ok(res) => {
+                            res.box_err().context(Write { table: self.name() })?;
+                            return Ok(num_rows);
+                        }
+                        Err(_) => return WaitForPendingWrites { table: self.name() }.fail(),
+                    }
+                }
+                Err(request) => {
+                    // The queue is full, return error.
+                    warn!("Pending_writes queue is full, table:{}", self.name());
+                    let serial_exec = self.table_data.serial_exec.lock().await;
+                    (request, serial_exec)
+                }
+            }
+        };
+
+        // The `serial_exec` is acquired, let's merge the pending requests and write
+        // them all.
+        let pending_writes = {
+            let mut pending_queue = self.pending_writes.lock().unwrap();
+            pending_queue.reset()
+        };
         let mut writer = Writer::new(
             self.instance.clone(),
             self.space_table.clone(),
             &mut serial_exec,
         );
+        match pending_writes {
+            Some(PendingWrites {
+                writes: pending_writes,
+                notifiers,
+                num_rows: num_pending_rows,
+            }) => {
+                let merge_res =
+                    merge_pending_write_requests(pending_writes, request, num_pending_rows);
 
-        let num_rows = writer
-            .write(request)
-            .await
-            .box_err()
-            .context(Write { table: self.name() })?;
+                // write the merged request first.
+                let do_write = || async move {
+                    writer
+                        .write(merge_res.merged_request)
+                        .await
+                        .box_err()
+                        .context(Write { table: self.name() })?;
+
+                    if let Some(v) = merge_res.different_request {
+                        writer
+                            .write(v)
+                            .await
+                            .box_err()
+                            .context(Write { table: self.name() })?;
+                    }
+
+                    Result::<()>::Ok(())
+                };
+                match do_write().await {
+                    Ok(_) => {
+                        for notifier in notifiers {
+                            if notifier.send(Ok(())).is_err() {
+                                warn!(
+                                    "Failed to notify the ok result of pending writes, table:{}",
+                                    self.name()
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let err_msg = format!("Failed to do merge write, err:{e}");
+                        for notifier in notifiers {
+                            let err = MergeWrite { msg: &err_msg }.fail();
+                            if notifier.send(err).is_err() {
+                                warn!(
+                                    "Failed to notify the error result of pending writes, table:{}",
+                                    self.name()
+                                );
+                            }
+                        }
+                        return Err(e);
+                    }
+                }
+            }
+            None => {
+                writer
+                    .write(request)
+                    .await
+                    .box_err()
+                    .context(Write { table: self.name() })?;
+            }
+        }
         Ok(num_rows)
     }
 

--- a/common_types/src/row/mod.rs
+++ b/common_types/src/row/mod.rs
@@ -243,14 +243,14 @@ impl<'a> RowGroupSlicer<'a> {
 
 // TODO(yingwen): For multiple rows that share the same schema, no need to store
 // Datum for each row element, we can store the whole row as a binary and
-// provide more efficent way to convert rows into columns
+// provide more efficient way to convert rows into columns
 /// RowGroup
 ///
 /// The min/max timestamp of an empty RowGroup is 0.
 ///
 /// Rows in the RowGroup have the same schema. The internal representation of
 /// rows is not specific.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct RowGroup {
     /// Schema of the row group, all rows in the row group should have same
     /// schema

--- a/common_types/src/row/mod.rs
+++ b/common_types/src/row/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Row type
 
@@ -304,6 +304,16 @@ impl RowGroup {
     #[inline]
     pub fn schema(&self) -> &Schema {
         &self.schema
+    }
+
+    #[inline]
+    pub fn take_rows(&mut self) -> Vec<Row> {
+        std::mem::take(&mut self.rows)
+    }
+
+    #[inline]
+    pub fn into_schema(self) -> Schema {
+        self.schema
     }
 
     /// Iter the row group by rows

--- a/table_engine/src/engine.rs
+++ b/table_engine/src/engine.rs
@@ -36,8 +36,8 @@ pub enum Error {
     #[snafu(display("Unexpected error, err:{}", source))]
     Unexpected { source: GenericError },
 
-    #[snafu(display("Unexpected error, msg:{}", msg))]
-    UnexpectedNoCause { msg: String },
+    #[snafu(display("Unexpected error, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
+    UnexpectedNoCause { msg: String, backtrace: Backtrace },
 
     #[snafu(display(
         "Unknown engine type, type:{}.\nBacktrace:\n{}",

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -286,8 +286,7 @@ impl fmt::Display for TableId {
     }
 }
 
-// TODO(yingwen): Support DELETE/UPDATE... , a mutation type is needed.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct WriteRequest {
     /// rows to write
     pub row_group: RowGroup,

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -140,6 +140,9 @@ pub enum Error {
     ))]
     WaitForPendingWrites { table: String, backtrace: Backtrace },
 
+    #[snafu(display("Reject for too many pending writes, table:{table}"))]
+    TooManyPendingWrites { table: String },
+
     #[snafu(display("Failed to do merge write, msg:{}", msg))]
     MergeWrite { msg: String },
 }

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -134,6 +134,14 @@ pub enum Error {
         tables: Vec<String>,
         source: GenericError,
     },
+
+    #[snafu(display(
+        "Failed to wait for pending writes, table:{table}.\nBacktrace:\n{backtrace}"
+    ))]
+    WaitForPendingWrites { table: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to do merge write, msg:{}", msg))]
+    MergeWrite { msg: String },
 }
 
 define_result!(Error);


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 Currently, massive small write requests will lead to bad performance because of the lock contention for table writes. By buffering the write requests blocked by the write lock into a wait queue, these small write requests may be merged, leading to a much better performance.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
- Buffer the write requests blocked by the write lock and merge and write them when another write worker acquires the write lock.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
Existing tests and the newly added unit tests.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
