### PR TITLE
fix: remove explanation in PR tmpl

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,29 +3,9 @@
 Closes #
 
 ## Rationale for this change
- 
-<!---
- Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
- Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
--->
 
 ## What changes are included in this PR?
 
-<!---
-There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
--->
-
 ## Are there any user-facing changes?
 
-<!---
-Please mention if:
-
-- there are user-facing changes that need to update the documentation or configuration.
-- this is a breaking change to public APIs
--->
-
 ## How does this change test
-
-<!-- 
-Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
--->


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
 We plan to use the PR description as the extended commit message, but the explanation in the PR description should not be included.
<!---
 Why are you proposing this change? If this is already explained clearly in the issue, then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

## What changes are included in this PR?
Remove the explanation in the PR tmpl.
<!---
There is no need to duplicate the description in the issue here, but it is sometimes worth providing a summary of the individual changes in this PR to help reviewers understand the structure.
-->

## Are there any user-facing changes?
None.
<!---
Please mention if:

- there are user-facing changes that need to update the documentation or configuration.
- this is a breaking change to public APIs
-->

## How does this change test
No need.
<!-- 
Please describe how you test this change (like by unit test case, integration test or some other ways) if this change has touched the code.
-->
