### PR TITLE
fix: new multiple write requests when tag names are different

### DIFF
--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -407,7 +407,8 @@ fn convert_write_request(req: WriteRequest) -> Result<Vec<WriteTableRequest>> {
             .unzip();
 
         req_by_metric
-            .entry(metric.to_string())
+            // fields with same tag names will be grouped together
+            .entry((metric.clone(), tag_names.clone()))
             .or_insert_with(|| WriteTableRequest {
                 table: metric,
                 tag_names,

--- a/proxy/src/influxdb/types.rs
+++ b/proxy/src/influxdb/types.rs
@@ -491,12 +491,16 @@ pub(crate) fn convert_write_request(req: WriteRequest) -> Result<Vec<WriteTableR
         tag_set.sort_unstable_by(|a, b| a.0.cmp(&b.0));
         // sort by field key
         line.field_set.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-
+        let tag_names = tag_set
+            .iter()
+            .map(|(tagk, _)| tagk.to_string())
+            .collect::<Vec<_>>();
         let req_for_one_measurement = req_by_measurement
-            .entry(line.series.measurement.to_string())
+            // fields with same tag names will be grouped together
+            .entry((line.series.measurement.to_string(), tag_names.clone()))
             .or_insert_with(|| WriteTableRequest {
                 table: line.series.measurement.to_string(),
-                tag_names: tag_set.iter().map(|(tagk, _)| tagk.to_string()).collect(),
+                tag_names,
                 field_names: line
                     .field_set
                     .iter()


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
For one metric, when tag name is different, it cannot be in same write request

## What changes are included in this PR?

Use `(metric, tag_names)` as group key when new write requests
## Are there any user-facing changes?
No

## How does this change test

CI and manually

