### PR TITLE
chore: reflush memory tables after flush failed

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -96,11 +96,16 @@ pub enum Error {
     WriteSst { path: String, source: GenericError },
 
     #[snafu(display(
-        "Background flush failed, cannot write more data, err:{}.\nBacktrace:\n{}",
+        "Background flush failed, cannot write more data, retry_count:{}, err:{}.\nBacktrace:\n{}",
+        retry_count,
         msg,
         backtrace
     ))]
-    BackgroundFlushFailed { msg: String, backtrace: Backtrace },
+    BackgroundFlushFailed {
+        msg: String,
+        retry_count: usize,
+        backtrace: Backtrace,
+    },
 
     #[snafu(display("Failed to build merge iterator, table:{}, err:{}", table, source))]
     BuildMergeIterator {
@@ -144,10 +149,10 @@ pub struct TableFlushOptions {
     ///
     /// If it is [None], no compaction will be scheduled.
     pub compact_after_flush: Option<CompactionSchedulerRef>,
-    /// Shoud retry flush After flush failed
+    /// Max retry limit After flush failed
     ///
-    /// Default is False
-    pub retry_flush: bool,
+    /// Default is 0
+    pub max_retry_flush_limit: usize,
 }
 
 impl fmt::Debug for TableFlushOptions {

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -151,6 +151,8 @@ pub struct Instance {
     pub(crate) replay_batch_size: usize,
     /// Write sst max buffer size
     pub(crate) write_sst_max_buffer_size: usize,
+    /// Shoud retry flush After flush failed
+    pub(crate) retry_flush: bool,
     /// Max bytes per write batch
     pub(crate) max_bytes_per_write_batch: Option<usize>,
     /// Options for scanning sst
@@ -191,6 +193,7 @@ impl Instance {
             } else {
                 None
             },
+            retry_flush: false,
         };
 
         let flusher = self.make_flusher();
@@ -273,6 +276,11 @@ impl Instance {
             runtime: self.runtimes.write_runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
         }
+    }
+
+    #[inline]
+    fn should_retry_flush(&self) -> bool {
+        self.retry_flush
     }
 }
 

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -151,8 +151,8 @@ pub struct Instance {
     pub(crate) replay_batch_size: usize,
     /// Write sst max buffer size
     pub(crate) write_sst_max_buffer_size: usize,
-    /// Shoud retry flush After flush failed
-    pub(crate) retry_flush: bool,
+    /// Max retry limit to flush memtables
+    pub(crate) max_retry_flush_limit: usize,
     /// Max bytes per write batch
     pub(crate) max_bytes_per_write_batch: Option<usize>,
     /// Options for scanning sst
@@ -193,7 +193,7 @@ impl Instance {
             } else {
                 None
             },
-            retry_flush: false,
+            max_retry_flush_limit: 0,
         };
 
         let flusher = self.make_flusher();
@@ -279,8 +279,8 @@ impl Instance {
     }
 
     #[inline]
-    fn should_retry_flush(&self) -> bool {
-        self.retry_flush
+    fn max_retry_flush_limit(&self) -> usize {
+        self.max_retry_flush_limit
     }
 }
 

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -124,6 +124,7 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_byte() as usize,
+            retry_flush: ctx.config.retry_flush,
             max_bytes_per_write_batch: ctx
                 .config
                 .max_bytes_per_write_batch
@@ -325,6 +326,7 @@ impl Instance {
                         let opts = TableFlushOptions {
                             res_sender: None,
                             compact_after_flush: None,
+                            retry_flush: self.retry_flush,
                         };
                         let flusher = self.make_flusher();
                         let flush_scheduler = serial_exec.flush_scheduler();

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -124,7 +124,7 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_byte() as usize,
-            retry_flush: ctx.config.retry_flush,
+            max_retry_flush_limit: ctx.config.max_retry_flush_limit,
             max_bytes_per_write_batch: ctx
                 .config
                 .max_bytes_per_write_batch
@@ -326,7 +326,7 @@ impl Instance {
                         let opts = TableFlushOptions {
                             res_sender: None,
                             compact_after_flush: None,
-                            retry_flush: self.retry_flush,
+                            max_retry_flush_limit: self.max_retry_flush_limit,
                         };
                         let flusher = self.make_flusher();
                         let flush_scheduler = serial_exec.flush_scheduler();

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -7,7 +7,7 @@ use std::{
 
 use common_util::{runtime::Runtime, time::InstantExt};
 use futures::Future;
-use log::error;
+use log::{error, warn};
 use table_engine::table::TableId;
 use tokio::sync::{
     oneshot,
@@ -131,7 +131,10 @@ impl TableFlushScheduler {
                     }
                     FlushState::Flushing => (),
                     FlushState::Failed { err_msg } => {
-                        return BackgroundFlushFailed { msg: err_msg }.fail();
+                        // Mark the worker is flushing.
+                        *flush_state = FlushState::Flushing;
+                        warn!("Retry to flush memory tables after background flush failed:{err_msg}");
+                        break;
                     }
                 }
 

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -44,17 +44,19 @@ struct ScheduleSync {
 impl ScheduleSync {
     #[inline]
     pub fn should_retry_flush(&self, max_retry_limit: usize) -> bool {
-        self.continuous_flush_failure_count.load(Ordering::Relaxed) < max_retry_limit 
+        self.continuous_flush_failure_count.load(Ordering::Relaxed) < max_retry_limit
     }
 
     #[inline]
     pub fn reset_flush_failure_count(&self) {
-        self.continuous_flush_failure_count.store(0, Ordering::Relaxed);
+        self.continuous_flush_failure_count
+            .store(0, Ordering::Relaxed);
     }
 
     #[inline]
     pub fn inc_flush_failure_count(&self) {
-        self.continuous_flush_failure_count.fetch_add(1, Ordering::Relaxed);
+        self.continuous_flush_failure_count
+            .fetch_add(1, Ordering::Relaxed);
     }
 }
 

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -38,24 +38,23 @@ type ScheduleSyncRef = Arc<ScheduleSync>;
 struct ScheduleSync {
     state: Mutex<FlushState>,
     notifier: Sender<()>,
-    retry_flush_count: AtomicUsize,
+    continuous_flush_failure_count: AtomicUsize,
 }
 
 impl ScheduleSync {
     #[inline]
     pub fn should_retry_flush(&self, max_retry_limit: usize) -> bool {
-        if self.retry_flush_count.load(Ordering::Relaxed) < max_retry_limit {
-            self.retry_flush_count.fetch_add(1, Ordering::Relaxed);
-            return true;
-        }
-        false
+        self.continuous_flush_failure_count.load(Ordering::Relaxed) < max_retry_limit 
     }
 
     #[inline]
-    pub fn reset_retry_flush_count(&self) {
-        if self.retry_flush_count.load(Ordering::Relaxed) > 0 {
-            self.retry_flush_count.store(0, Ordering::Relaxed);
-        }
+    pub fn reset_flush_failure_count(&self) {
+        self.continuous_flush_failure_count.store(0, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn inc_flush_failure_count(&self) {
+        self.continuous_flush_failure_count.fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -70,7 +69,7 @@ impl Default for TableFlushScheduler {
         let schedule_sync = ScheduleSync {
             state: Mutex::new(FlushState::Ready),
             notifier: tx,
-            retry_flush_count: AtomicUsize::new(0),
+            continuous_flush_failure_count: AtomicUsize::new(0),
         };
         Self {
             schedule_sync: Arc::new(schedule_sync),
@@ -220,10 +219,11 @@ fn on_flush_finished(schedule_sync: ScheduleSyncRef, res: &Result<()>) {
         let mut flush_state = schedule_sync.state.lock().unwrap();
         match res {
             Ok(()) => {
-                schedule_sync.reset_retry_flush_count();
+                schedule_sync.reset_flush_failure_count();
                 *flush_state = FlushState::Ready;
             }
             Err(e) => {
+                schedule_sync.inc_flush_failure_count();
                 let err_msg = e.to_string();
                 *flush_state = FlushState::Failed { err_msg };
             }

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -15,7 +15,7 @@ use tokio::sync::{
 };
 
 use crate::{
-    instance::flush_compaction::{BackgroundFlushFailed, Other, Result},
+    instance::flush_compaction::{Other, Result},
     table::metrics::Metrics,
 };
 
@@ -131,9 +131,9 @@ impl TableFlushScheduler {
                     }
                     FlushState::Flushing => (),
                     FlushState::Failed { err_msg } => {
+                        warn!("Retry to flush memory tables after background flush failed:{err_msg}");
                         // Mark the worker is flushing.
                         *flush_state = FlushState::Flushing;
-                        warn!("Retry to flush memory tables after background flush failed:{err_msg}");
                         break;
                     }
                 }

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -131,7 +131,7 @@ impl TableFlushScheduler {
                     }
                     FlushState::Flushing => (),
                     FlushState::Failed { err_msg } => {
-                        warn!("Retry to flush memory tables after background flush failed:{err_msg}");
+                        warn!("Re-flush memory tables after background flush failed:{err_msg}");
                         // Mark the worker is flushing.
                         *flush_state = FlushState::Flushing;
                         break;

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -590,7 +590,11 @@ impl<'a> Writer<'a> {
     /// acquired in advance. And in order to avoid deadlock, we should not wait
     /// for the lock.
     async fn handle_memtable_flush(&mut self, table_data: &TableDataRef) -> Result<()> {
-        let opts = TableFlushOptions::default();
+        let opts = TableFlushOptions {
+            res_sender: None,
+            compact_after_flush: None,
+            retry_flush: self.instance.should_retry_flush(),
+        };
         let flusher = self.instance.make_flusher();
         if table_data.id == self.table_data.id {
             let flush_scheduler = self.serial_exec.flush_scheduler();

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -593,7 +593,7 @@ impl<'a> Writer<'a> {
         let opts = TableFlushOptions {
             res_sender: None,
             compact_after_flush: None,
-            retry_flush: self.instance.should_retry_flush(),
+            max_retry_flush_limit: self.instance.max_retry_flush_limit(),
         };
         let flusher = self.instance.make_flusher();
         if table_data.id == self.table_data.id {

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -121,7 +121,7 @@ impl Default for Config {
             sst_background_read_parallelism: 8,
             scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),
-            retry_flush: true,
+            retry_flush: false,
             max_bytes_per_write_batch: None,
             wal: WalStorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -81,8 +81,8 @@ pub struct Config {
     pub sst_background_read_parallelism: usize,
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
-    /// Shoud retry flush After flush failed
-    pub retry_flush: bool,
+    /// Max retry limit After flush failed
+    pub max_retry_flush_limit: usize,
     /// Max bytes per write batch.
     ///
     /// If this is set, the atomicity of write request will be broken.
@@ -121,7 +121,7 @@ impl Default for Config {
             sst_background_read_parallelism: 8,
             scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),
-            retry_flush: false,
+            max_retry_flush_limit: 0,
             max_bytes_per_write_batch: None,
             wal: WalStorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -81,6 +81,8 @@ pub struct Config {
     pub sst_background_read_parallelism: usize,
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
+    /// Shoud retry flush After flush failed
+    pub retry_flush: bool,
     /// Max bytes per write batch.
     ///
     /// If this is set, the atomicity of write request will be broken.
@@ -119,6 +121,7 @@ impl Default for Config {
             sst_background_read_parallelism: 8,
             scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),
+            retry_flush: true,
             max_bytes_per_write_batch: None,
             wal: WalStorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Currently, when a flush table operation fails, write requests would aways fail. Perhaps we should consider flushing the memory table again when the next write request coming to address this issue.

## What changes are included in this PR?
* flush memory table again after flush failed

## Are there any user-facing changes?
None

## How does this change test
