### PR TITLE
chore: bump datafusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,23 +447,6 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
-dependencies = [
- "ahash 0.8.3",
- "arrow 38.0.0",
- "chrono",
- "comfy-table",
- "hashbrown 0.13.2",
- "num-traits",
- "once_cell",
- "regex",
- "snafu 0.7.4",
- "uuid 1.3.0",
-]
-
-[[package]]
-name = "arrow_util"
-version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "ahash 0.8.3",
@@ -2010,26 +1993,12 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
-dependencies = [
- "async-trait",
- "datafusion",
- "futures 0.3.28",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "pin-project",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "datafusion_util"
-version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "async-trait",
  "datafusion",
  "futures 0.3.28",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "observability_deps",
  "pin-project",
  "tokio",
  "tokio-stream",
@@ -2573,7 +2542,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "pbjson",
  "pbjson-build",
@@ -2966,7 +2935,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3037,48 +3006,23 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
-dependencies = [
- "arrow 38.0.0",
- "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "async-trait",
- "chrono",
- "datafusion",
- "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "futures 0.3.28",
- "hashbrown 0.13.2",
- "log",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "once_cell",
- "parking_lot 0.12.1",
- "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "snafu 0.7.4",
- "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "iox_query"
-version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "arrow 38.0.0",
- "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "arrow_util",
  "async-trait",
  "chrono",
  "datafusion",
- "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "datafusion_util",
  "futures 0.3.28",
  "hashbrown 0.13.2",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "observability_deps",
  "once_cell",
  "parking_lot 0.12.1",
- "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql)",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "query_functions",
+ "schema",
  "snafu 0.7.4",
- "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "test_helpers",
  "tokio",
  "tokio-stream",
 ]
@@ -3086,22 +3030,22 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "arrow 38.0.0",
  "chrono",
  "chrono-tz",
  "datafusion",
- "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
+ "datafusion_util",
  "generated_types",
  "influxdb_influxql_parser",
- "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
+ "iox_query",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
+ "observability_deps",
  "once_cell",
- "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
+ "query_functions",
  "regex",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
+ "schema",
  "serde_json",
 ]
 
@@ -4157,14 +4101,6 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
-dependencies = [
- "tracing",
-]
-
-[[package]]
-name = "observability_deps"
-version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "tracing",
@@ -5009,7 +4945,7 @@ dependencies = [
  "datafusion",
  "df_operator",
  "futures 0.3.28",
- "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "iox_query",
  "log",
  "query_frontend",
  "serde",
@@ -5042,28 +4978,11 @@ dependencies = [
  "prom-remote-api",
  "regex",
  "regex-syntax 0.6.29",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
+ "schema",
  "snafu 0.6.10",
  "sqlparser",
  "table_engine",
  "tokio",
-]
-
-[[package]]
-name = "query_functions"
-version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
-dependencies = [
- "arrow 38.0.0",
- "chrono",
- "datafusion",
- "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "once_cell",
- "regex",
- "regex-syntax 0.6.29",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "snafu 0.7.4",
 ]
 
 [[package]]
@@ -5075,11 +4994,11 @@ dependencies = [
  "chrono",
  "datafusion",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "observability_deps",
  "once_cell",
  "regex",
  "regex-syntax 0.6.29",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "schema",
  "snafu 0.7.4",
 ]
 
@@ -5767,26 +5686,13 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
-dependencies = [
- "arrow 38.0.0",
- "hashbrown 0.13.2",
- "indexmap",
- "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "snafu 0.7.4",
-]
-
-[[package]]
-name = "schema"
-version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "arrow 38.0.0",
  "hashbrown 0.13.2",
  "indexmap",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "observability_deps",
  "snafu 0.7.4",
 ]
 
@@ -6589,23 +6495,10 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
-dependencies = [
- "dotenvy",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
- "parking_lot 0.12.1",
- "tempfile",
- "tracing-log",
- "tracing-subscriber 0.3.16",
-]
-
-[[package]]
-name = "test_helpers"
-version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "dotenvy",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "observability_deps",
  "parking_lot 0.12.1",
  "tempfile",
  "tracing-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "ahash 0.8.3",
  "arrow 38.0.0",
@@ -2010,12 +2010,12 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "async-trait",
  "datafusion",
  "futures 0.3.28",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "pin-project",
  "tokio",
  "tokio-stream",
@@ -2573,7 +2573,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "pbjson",
  "pbjson-build",
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3037,23 +3037,24 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "arrow 38.0.0",
- "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "async-trait",
  "chrono",
  "datafusion",
- "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "futures 0.3.28",
  "hashbrown 0.13.2",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "log",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "once_cell",
  "parking_lot 0.12.1",
- "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "snafu 0.7.4",
- "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "tokio",
  "tokio-stream",
 ]
@@ -3085,22 +3086,22 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "arrow 38.0.0",
  "chrono",
  "chrono-tz",
  "datafusion",
- "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "generated_types",
  "influxdb_influxql_parser",
- "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "once_cell",
- "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "regex",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "serde_json",
 ]
 
@@ -4156,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "tracing",
 ]
@@ -5041,7 +5042,7 @@ dependencies = [
  "prom-remote-api",
  "regex",
  "regex-syntax 0.6.29",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "snafu 0.6.10",
  "sqlparser",
  "table_engine",
@@ -5051,17 +5052,17 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "arrow 38.0.0",
  "chrono",
  "datafusion",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "once_cell",
  "regex",
  "regex-syntax 0.6.29",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "snafu 0.7.4",
 ]
 
@@ -5766,13 +5767,13 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "arrow 38.0.0",
  "hashbrown 0.13.2",
  "indexmap",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "snafu 0.7.4",
 ]
 
@@ -6588,10 +6589,10 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
+source = "git+https://github.com/CeresDB/influxql?branch=chore-log#0f589eae3c530ded4367ae667ed5c85bb68dd723"
 dependencies = [
  "dotenvy",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=chore-log)",
  "parking_lot 0.12.1",
  "tempfile",
  "tracing-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "ceresdbproto",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "env_logger",
  "futures 0.3.28",
  "lazy_static",
@@ -96,7 +96,7 @@ dependencies = [
  "lru",
  "message_queue",
  "object_store 1.2.0",
- "parquet 38.0.0",
+ "parquet",
  "parquet_ext",
  "pin-project-lite",
  "prometheus 0.12.0",
@@ -217,61 +217,24 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990dfa1a9328504aa135820da1c95066537b69ad94c04881b785f64328e0fa6b"
-dependencies = [
- "ahash 0.8.3",
- "arrow-arith 36.0.0",
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-cast 36.0.0",
- "arrow-csv 36.0.0",
- "arrow-data 36.0.0",
- "arrow-ipc 36.0.0",
- "arrow-json 36.0.0",
- "arrow-ord 36.0.0",
- "arrow-row 36.0.0",
- "arrow-schema 36.0.0",
- "arrow-select 36.0.0",
- "arrow-string 36.0.0",
-]
-
-[[package]]
-name = "arrow"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c107a57b5913d852da9d5a40e280e4695f2258b5b87733c13b770c63a7117287"
 dependencies = [
  "ahash 0.8.3",
- "arrow-arith 38.0.0",
- "arrow-array 38.0.0",
+ "arrow-arith",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-cast 38.0.0",
- "arrow-csv 38.0.0",
- "arrow-data 38.0.0",
- "arrow-ipc 38.0.0",
- "arrow-json 38.0.0",
- "arrow-ord 38.0.0",
- "arrow-row 38.0.0",
- "arrow-schema 38.0.0",
- "arrow-select 38.0.0",
- "arrow-string 38.0.0",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b2e52de0ab54173f9b08232b7184c26af82ee7ab4ac77c83396633c90199fa"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "chrono",
- "half 2.2.1",
- "num",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
@@ -280,29 +243,12 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace6aa3d5617c5d03041a05e01c6819428a8ddf49dd0b055df9b40fef9d96094"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half 2.2.1",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10849b60c17dbabb334be1f4ef7550701aa58082b71335ce1ed586601b2f423"
-dependencies = [
- "ahash 0.8.3",
- "arrow-buffer 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "chrono",
- "chrono-tz",
- "half 2.2.1",
- "hashbrown 0.13.2",
  "num",
 ]
 
@@ -314,8 +260,8 @@ checksum = "104a04520692cc674e6afd7682f213ca41f9b13ff1873f63a5a2857a590b87b3"
 dependencies = [
  "ahash 0.8.3",
  "arrow-buffer 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
  "half 2.2.1",
@@ -335,16 +281,6 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0746ae991b186be39933147117f8339eb1c4bbbea1c8ad37e7bf5851a1a06ba"
-dependencies = [
- "half 2.2.1",
- "num",
-]
-
-[[package]]
-name = "arrow-buffer"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c875bcb9530ec403998fb0b2dc6d180a7c64563ca4bc22b90eafb84b113143"
@@ -355,55 +291,19 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88897802515d7b193e38b27ddd9d9e43923d410a9e46307582d756959ee9595"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "arrow-select 36.0.0",
- "chrono",
- "comfy-table",
- "lexical-core 0.8.5",
- "num",
-]
-
-[[package]]
-name = "arrow-cast"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6d6e18281636c8fc0b93be59834da6bf9a72bb70fd0c98ddfdaf124da466c28"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
- "arrow-select 38.0.0",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "chrono",
  "comfy-table",
  "lexical-core 0.8.5",
  "num",
-]
-
-[[package]]
-name = "arrow-csv"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8220d9741fc37961262710ceebd8451a5b393de57c464f0267ffdda1775c0a"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-cast 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "lexical-core 0.8.5",
- "regex",
 ]
 
 [[package]]
@@ -412,29 +312,17 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3197dab0963a236ff8e7c82e2272535745955ac1321eb740c29f2f88b353f54e"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-cast 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
  "lazy_static",
  "lexical-core 0.8.5",
  "regex",
-]
-
-[[package]]
-name = "arrow-data"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f937efa1aaad9dc86f6a0e382c2fa736a4943e2090c946138079bdf060cef"
-dependencies = [
- "arrow-buffer 36.0.0",
- "arrow-schema 36.0.0",
- "half 2.2.1",
- "num",
 ]
 
 [[package]]
@@ -444,23 +332,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb68113d6ecdbe8bba48b2c4042c151bf9e1c61244e45072a50250a6fc59bafe"
 dependencies = [
  "arrow-buffer 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-schema",
  "half 2.2.1",
  "num",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b75296ff01833f602552dff26a423fc213db8e5049b540ca4a00b1c957e41c"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-cast 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "flatbuffers 23.1.21",
 ]
 
 [[package]]
@@ -469,31 +343,12 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab4bbf2dd3078facb5ce0a9641316a64f42bfd8cf357e6775c8a5e6708e3a8d"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-cast 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "flatbuffers 23.1.21",
-]
-
-[[package]]
-name = "arrow-json"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e501d3de4d612c90677594896ca6c0fa075665a7ff980dc4189bb531c17e19f6"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-cast 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "chrono",
- "half 2.2.1",
- "indexmap",
- "lexical-core 0.8.5",
- "num",
- "serde_json",
 ]
 
 [[package]]
@@ -502,11 +357,11 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c5b650d23746a494665d914a7fa3d21d939153cff9d53bdebe39bffa88f263"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-cast 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half 2.2.1",
  "indexmap",
@@ -518,47 +373,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d2671eb3793f9410230ac3efb0e6d36307be8a2dac5fad58ac9abde8e9f01e"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "arrow-select 36.0.0",
- "half 2.2.1",
- "num",
-]
-
-[[package]]
-name = "arrow-ord"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68c6fce28e5011e30acc7466b5efcb8ed0197c396240bd2b10e167f275a3c208"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
- "arrow-select 38.0.0",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "half 2.2.1",
  "num",
-]
-
-[[package]]
-name = "arrow-row"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc11fa039338cebbf4e29cf709c8ac1d6a65c7540063d4a25f991ab255ca85c8"
-dependencies = [
- "ahash 0.8.3",
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "half 2.2.1",
- "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -568,19 +393,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f20a421f19799d8b93eb8edde5217e910fa1e2d6ceb3c529f000e57b6db144c0"
 dependencies = [
  "ahash 0.8.3",
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-data",
+ "arrow-schema",
  "half 2.2.1",
  "hashbrown 0.13.2",
 ]
-
-[[package]]
-name = "arrow-schema"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04f17f7b86ded0b5baf98fe6123391c4343e031acc3ccc5fa604cc180bff220"
 
 [[package]]
 name = "arrow-schema"
@@ -590,43 +409,15 @@ checksum = "bc85923d8d6662cc66ac6602c7d1876872e671002d60993dfdf492a6badeae92"
 
 [[package]]
 name = "arrow-select"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "163e35de698098ff5f5f672ada9dc1f82533f10407c7a11e2cd09f3bcf31d18a"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "num",
-]
-
-[[package]]
-name = "arrow-select"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ab6613ce65b61d85a3410241744e84e48fbab0fe06e1251b4429d21b3470fd"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-data",
+ "arrow-schema",
  "num",
-]
-
-[[package]]
-name = "arrow-string"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdfbed1b10209f0dc68e6aa4c43dc76079af65880965c7c3b73f641f23d4aba"
-dependencies = [
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-data 36.0.0",
- "arrow-schema 36.0.0",
- "arrow-select 36.0.0",
- "regex",
- "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -635,11 +426,11 @@ version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3008641239e884aefba66d8b8532da6af40d14296349fcc85935de4ba67b89e"
 dependencies = [
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-data 38.0.0",
- "arrow-schema 38.0.0",
- "arrow-select 38.0.0",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "regex",
  "regex-syntax 0.6.29",
 ]
@@ -656,7 +447,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "ahash 0.8.3",
  "arrow 38.0.0",
@@ -673,10 +464,10 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "ahash 0.8.3",
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "chrono",
  "comfy-table",
  "hashbrown 0.13.2",
@@ -890,7 +681,7 @@ dependencies = [
  "futures 0.3.28",
  "log",
  "object_store 1.2.0",
- "parquet 38.0.0",
+ "parquet",
  "parquet_ext",
  "pprof 0.10.1",
  "rand 0.7.3",
@@ -1390,7 +1181,7 @@ dependencies = [
  "reqwest",
  "serde",
  "sqlness",
- "sqlparser 0.33.0",
+ "sqlparser",
  "tokio",
 ]
 
@@ -1614,14 +1405,14 @@ dependencies = [
  "bytes_ext",
  "ceresdbproto",
  "chrono",
- "datafusion 23.0.0",
+ "datafusion",
  "murmur3",
  "paste 1.0.12",
  "prost",
  "serde",
  "serde_json",
  "snafu 0.6.10",
- "sqlparser 0.33.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2040,68 +1831,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "ahash 0.8.3",
- "arrow 36.0.0",
- "async-trait",
- "bytes 1.4.0",
- "chrono",
- "dashmap 5.4.0",
- "datafusion-common 21.1.0",
- "datafusion-execution 21.1.0",
- "datafusion-expr 21.1.0",
- "datafusion-optimizer 21.1.0",
- "datafusion-physical-expr 21.1.0",
- "datafusion-row 21.1.0",
- "datafusion-sql 21.1.0",
- "futures 0.3.28",
- "glob",
- "hashbrown 0.13.2",
- "indexmap",
- "itertools",
- "lazy_static",
- "log",
- "num_cpus",
- "object_store 0.5.6",
- "parking_lot 0.12.1",
- "parquet 36.0.0",
- "percent-encoding",
- "pin-project-lite",
- "rand 0.8.5",
- "smallvec",
- "sqlparser 0.32.0",
- "tempfile",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "url",
- "uuid 1.3.0",
-]
-
-[[package]]
-name = "datafusion"
 version = "23.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
  "ahash 0.8.3",
  "arrow 38.0.0",
- "arrow-array 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-array",
+ "arrow-schema",
  "async-compression",
  "async-trait",
  "bytes 1.4.0",
  "bzip2",
  "chrono",
  "dashmap 5.4.0",
- "datafusion-common 23.0.0",
- "datafusion-execution 23.0.0",
- "datafusion-expr 23.0.0",
- "datafusion-optimizer 23.0.0",
- "datafusion-physical-expr 23.0.0",
- "datafusion-row 23.0.0",
- "datafusion-sql 23.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-row",
+ "datafusion-sql",
  "flate2",
  "futures 0.3.28",
  "glob",
@@ -2113,12 +1862,12 @@ dependencies = [
  "num_cpus",
  "object_store 0.5.6",
  "parking_lot 0.12.1",
- "parquet 38.0.0",
+ "parquet",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
  "smallvec",
- "sqlparser 0.33.0",
+ "sqlparser",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2131,47 +1880,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "arrow 36.0.0",
- "arrow-array 36.0.0",
- "chrono",
- "num_cpus",
- "object_store 0.5.6",
- "parquet 36.0.0",
- "sqlparser 0.32.0",
-]
-
-[[package]]
-name = "datafusion-common"
 version = "23.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
  "arrow 38.0.0",
- "arrow-array 38.0.0",
+ "arrow-array",
  "chrono",
  "num_cpus",
  "object_store 0.5.6",
- "parquet 38.0.0",
- "sqlparser 0.33.0",
-]
-
-[[package]]
-name = "datafusion-execution"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "dashmap 5.4.0",
- "datafusion-common 21.1.0",
- "datafusion-expr 21.1.0",
- "hashbrown 0.13.2",
- "log",
- "object_store 0.5.6",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "tempfile",
- "url",
+ "parquet",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2180,8 +1898,8 @@ version = "23.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
  "dashmap 5.4.0",
- "datafusion-common 23.0.0",
- "datafusion-expr 23.0.0",
+ "datafusion-common",
+ "datafusion-expr",
  "hashbrown 0.13.2",
  "log",
  "object_store 0.5.6",
@@ -2193,41 +1911,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "ahash 0.8.3",
- "arrow 36.0.0",
- "datafusion-common 21.1.0",
- "sqlparser 0.32.0",
-]
-
-[[package]]
-name = "datafusion-expr"
 version = "23.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
  "ahash 0.8.3",
  "arrow 38.0.0",
- "datafusion-common 23.0.0",
- "sqlparser 0.33.0",
-]
-
-[[package]]
-name = "datafusion-optimizer"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "arrow 36.0.0",
- "async-trait",
- "chrono",
- "datafusion-common 21.1.0",
- "datafusion-expr 21.1.0",
- "datafusion-physical-expr 21.1.0",
- "hashbrown 0.13.2",
- "itertools",
- "log",
- "regex-syntax 0.6.29",
+ "datafusion-common",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2238,9 +1928,9 @@ dependencies = [
  "arrow 38.0.0",
  "async-trait",
  "chrono",
- "datafusion-common 23.0.0",
- "datafusion-expr 23.0.0",
- "datafusion-physical-expr 23.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
  "hashbrown 0.13.2",
  "itertools",
  "log",
@@ -2249,45 +1939,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "ahash 0.8.3",
- "arrow 36.0.0",
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-schema 36.0.0",
- "chrono",
- "datafusion-common 21.1.0",
- "datafusion-expr 21.1.0",
- "datafusion-row 21.1.0",
- "half 2.2.1",
- "hashbrown 0.13.2",
- "indexmap",
- "itertools",
- "lazy_static",
- "paste 1.0.12",
- "petgraph",
- "rand 0.8.5",
- "uuid 1.3.0",
-]
-
-[[package]]
-name = "datafusion-physical-expr"
 version = "23.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
  "ahash 0.8.3",
  "arrow 38.0.0",
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-schema 38.0.0",
+ "arrow-schema",
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common 23.0.0",
- "datafusion-expr 23.0.0",
- "datafusion-row 23.0.0",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-row",
  "half 2.2.1",
  "hashbrown 0.13.2",
  "indexmap",
@@ -2311,45 +1976,22 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd
 dependencies = [
  "arrow 38.0.0",
  "chrono",
- "datafusion 23.0.0",
- "datafusion-common 23.0.0",
- "datafusion-expr 23.0.0",
+ "datafusion",
+ "datafusion-common",
+ "datafusion-expr",
  "object_store 0.5.6",
  "prost",
 ]
 
 [[package]]
 name = "datafusion-row"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "arrow 36.0.0",
- "datafusion-common 21.1.0",
- "paste 1.0.12",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "datafusion-row"
 version = "23.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
  "arrow 38.0.0",
- "datafusion-common 23.0.0",
+ "datafusion-common",
  "paste 1.0.12",
  "rand 0.8.5",
-]
-
-[[package]]
-name = "datafusion-sql"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
-dependencies = [
- "arrow-schema 36.0.0",
- "datafusion-common 21.1.0",
- "datafusion-expr 21.1.0",
- "log",
- "sqlparser 0.32.0",
 ]
 
 [[package]]
@@ -2358,22 +2000,22 @@ version = "23.0.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
  "arrow 38.0.0",
- "arrow-schema 38.0.0",
- "datafusion-common 23.0.0",
- "datafusion-expr 23.0.0",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-expr",
  "log",
- "sqlparser 0.33.0",
+ "sqlparser",
 ]
 
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "async-trait",
- "datafusion 23.0.0",
+ "datafusion",
  "futures 0.3.28",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "pin-project",
  "tokio",
  "tokio-stream",
@@ -2382,10 +2024,10 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "async-trait",
- "datafusion 21.1.0",
+ "datafusion",
  "futures 0.3.28",
  "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "pin-project",
@@ -2443,7 +2085,7 @@ dependencies = [
  "chrono",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "hyperloglog",
  "smallvec",
  "snafu 0.6.10",
@@ -2931,7 +2573,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "pbjson",
  "pbjson-build",
@@ -3324,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3359,7 +3001,7 @@ dependencies = [
  "catalog_impls",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "datafusion-proto",
  "df_operator",
  "log",
@@ -3395,23 +3037,23 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "arrow 38.0.0",
- "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "async-trait",
  "chrono",
- "datafusion 23.0.0",
- "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "datafusion",
+ "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "futures 0.3.28",
  "hashbrown 0.13.2",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "once_cell",
  "parking_lot 0.12.1",
- "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "snafu 0.7.4",
- "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "tokio",
  "tokio-stream",
 ]
@@ -3419,13 +3061,13 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "async-trait",
  "chrono",
- "datafusion 21.1.0",
+ "datafusion",
  "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "futures 0.3.28",
  "hashbrown 0.13.2",
@@ -3443,22 +3085,22 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "arrow 38.0.0",
  "chrono",
  "chrono-tz",
- "datafusion 23.0.0",
- "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "datafusion",
+ "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "generated_types",
  "influxdb_influxql_parser",
- "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "once_cell",
- "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "regex",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "serde_json",
 ]
 
@@ -4514,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "tracing",
 ]
@@ -4522,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "tracing",
 ]
@@ -4639,51 +4281,18 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "36.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321a15f8332645759f29875b07f8233d16ed8ec1b3582223de81625a9f8506b7"
-dependencies = [
- "ahash 0.8.3",
- "arrow-array 36.0.0",
- "arrow-buffer 36.0.0",
- "arrow-cast 36.0.0",
- "arrow-data 36.0.0",
- "arrow-ipc 36.0.0",
- "arrow-schema 36.0.0",
- "arrow-select 36.0.0",
- "base64 0.21.0",
- "brotli",
- "bytes 1.4.0",
- "chrono",
- "flate2",
- "futures 0.3.28",
- "hashbrown 0.13.2",
- "lz4",
- "num",
- "num-bigint 0.4.3",
- "paste 1.0.12",
- "seq-macro",
- "snap",
- "thrift",
- "tokio",
- "twox-hash",
- "zstd 0.12.3+zstd.1.5.2",
-]
-
-[[package]]
-name = "parquet"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbd51311f8d9ff3d2697b1522b18a588782e097d313a1a278b0faf2ccf2d3f6"
 dependencies = [
  "ahash 0.8.3",
- "arrow-array 38.0.0",
+ "arrow-array",
  "arrow-buffer 38.0.0",
- "arrow-cast 38.0.0",
- "arrow-data 38.0.0",
- "arrow-ipc 38.0.0",
- "arrow-schema 38.0.0",
- "arrow-select 38.0.0",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
  "base64 0.21.0",
  "brotli",
  "bytes 1.4.0",
@@ -4713,9 +4322,9 @@ dependencies = [
  "async-trait",
  "bytes 1.4.0",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "log",
- "parquet 38.0.0",
+ "parquet",
  "tokio",
 ]
 
@@ -5308,7 +4917,7 @@ dependencies = [
  "cluster",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "df_operator",
  "futures 0.3.28",
  "http",
@@ -5330,7 +4939,7 @@ dependencies = [
  "serde_json",
  "snafu 0.6.10",
  "spin 0.9.8",
- "sqlparser 0.33.0",
+ "sqlparser",
  "system_catalog",
  "table_engine",
  "tokio",
@@ -5396,7 +5005,7 @@ dependencies = [
  "chrono",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "df_operator",
  "futures 0.3.28",
  "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql)",
@@ -5419,7 +5028,7 @@ dependencies = [
  "cluster",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "datafusion-proto",
  "df_operator",
  "hashbrown 0.12.3",
@@ -5432,9 +5041,9 @@ dependencies = [
  "prom-remote-api",
  "regex",
  "regex-syntax 0.6.29",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "snafu 0.6.10",
- "sqlparser 0.33.0",
+ "sqlparser",
  "table_engine",
  "tokio",
 ]
@@ -5442,28 +5051,28 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "arrow 38.0.0",
  "chrono",
- "datafusion 23.0.0",
+ "datafusion",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "once_cell",
  "regex",
  "regex-syntax 0.6.29",
- "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "snafu 0.7.4",
 ]
 
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "chrono",
- "datafusion 21.1.0",
+ "datafusion",
  "itertools",
  "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "once_cell",
@@ -6157,22 +5766,22 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "arrow 38.0.0",
  "hashbrown 0.13.2",
  "indexmap",
  "itertools",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "snafu 0.7.4",
 ]
 
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "hashbrown 0.13.2",
  "indexmap",
  "itertools",
@@ -6330,7 +5939,7 @@ dependencies = [
  "cluster",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "df_operator",
  "futures 0.3.28",
  "http",
@@ -6358,7 +5967,7 @@ dependencies = [
  "serde_json",
  "snafu 0.6.10",
  "spin 0.9.8",
- "sqlparser 0.33.0",
+ "sqlparser",
  "table_engine",
  "tokio",
  "tokio-stream",
@@ -6669,16 +6278,6 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0366f270dbabb5cc2e4c88427dc4c08bba144f81e32fbd459a013f26a4d16aa0"
-dependencies = [
- "log",
- "sqlparser_derive",
-]
-
-[[package]]
-name = "sqlparser"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355dc4d4b6207ca8a3434fc587db0a8016130a574dbcdbfb93d7f7b5bc5b211a"
@@ -6908,7 +6507,7 @@ dependencies = [
  "ceresdbproto",
  "common_types",
  "common_util",
- "datafusion 23.0.0",
+ "datafusion",
  "datafusion-proto",
  "df_operator",
  "env_logger",
@@ -6989,10 +6588,10 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+source = "git+https://github.com/CeresDB/influxql?branch=main#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "dotenvy",
- "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=main)",
  "parking_lot 0.12.1",
  "tempfile",
  "tracing-log",
@@ -7002,7 +6601,7 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql#4cef2d2fb84fc77af1a7a88ad4c978a5b344ad23"
 dependencies = [
  "dotenvy",
  "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
@@ -7364,7 +6963,7 @@ dependencies = [
  "env_logger",
  "futures 0.3.28",
  "object_store 1.2.0",
- "parquet 38.0.0",
+ "parquet",
  "parquet_ext",
  "table_engine",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -80,7 +80,7 @@ version = "1.2.0"
 dependencies = [
  "arc-swap 1.6.0",
  "arena",
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "async-stream",
  "async-trait",
  "base64 0.13.1",
@@ -88,7 +88,7 @@ dependencies = [
  "ceresdbproto",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "env_logger",
  "futures 0.3.28",
  "lazy_static",
@@ -96,7 +96,7 @@ dependencies = [
  "lru",
  "message_queue",
  "object_store 1.2.0",
- "parquet",
+ "parquet 38.0.0",
  "parquet_ext",
  "pin-project-lite",
  "prometheus 0.12.0",
@@ -210,7 +210,7 @@ dependencies = [
  "multiversion",
  "num",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "serde",
  "serde_json",
 ]
@@ -222,19 +222,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990dfa1a9328504aa135820da1c95066537b69ad94c04881b785f64328e0fa6b"
 dependencies = [
  "ahash 0.8.3",
- "arrow-arith",
- "arrow-array",
+ "arrow-arith 36.0.0",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-cast 36.0.0",
+ "arrow-csv 36.0.0",
+ "arrow-data 36.0.0",
+ "arrow-ipc 36.0.0",
+ "arrow-json 36.0.0",
+ "arrow-ord 36.0.0",
+ "arrow-row 36.0.0",
+ "arrow-schema 36.0.0",
+ "arrow-select 36.0.0",
+ "arrow-string 36.0.0",
+]
+
+[[package]]
+name = "arrow"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c107a57b5913d852da9d5a40e280e4695f2258b5b87733c13b770c63a7117287"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow-arith 38.0.0",
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-cast 38.0.0",
+ "arrow-csv 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-ipc 38.0.0",
+ "arrow-json 38.0.0",
+ "arrow-ord 38.0.0",
+ "arrow-row 38.0.0",
+ "arrow-schema 38.0.0",
+ "arrow-select 38.0.0",
+ "arrow-string 38.0.0",
 ]
 
 [[package]]
@@ -243,10 +265,25 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b2e52de0ab54173f9b08232b7184c26af82ee7ab4ac77c83396633c90199fa"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-data",
- "arrow-schema",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "chrono",
+ "half 2.2.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace6aa3d5617c5d03041a05e01c6819428a8ddf49dd0b055df9b40fef9d96094"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
  "chrono",
  "half 2.2.1",
  "num",
@@ -260,8 +297,25 @@ checksum = "e10849b60c17dbabb334be1f4ef7550701aa58082b71335ce1ed586601b2f423"
 dependencies = [
  "ahash 0.8.3",
  "arrow-buffer 36.0.0",
- "arrow-data",
- "arrow-schema",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "chrono",
+ "chrono-tz",
+ "half 2.2.1",
+ "hashbrown 0.13.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104a04520692cc674e6afd7682f213ca41f9b13ff1873f63a5a2857a590b87b3"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow-buffer 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
  "chrono",
  "chrono-tz",
  "half 2.2.1",
@@ -290,16 +344,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c875bcb9530ec403998fb0b2dc6d180a7c64563ca4bc22b90eafb84b113143"
+dependencies = [
+ "half 2.2.1",
+ "num",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88897802515d7b193e38b27ddd9d9e43923d410a9e46307582d756959ee9595"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "arrow-select 36.0.0",
+ "chrono",
+ "comfy-table",
+ "lexical-core 0.8.5",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6d6e18281636c8fc0b93be59834da6bf9a72bb70fd0c98ddfdaf124da466c28"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
+ "arrow-select 38.0.0",
  "chrono",
  "comfy-table",
  "lexical-core 0.8.5",
@@ -312,11 +393,30 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c8220d9741fc37961262710ceebd8451a5b393de57c464f0267ffdda1775c0a"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-cast 36.0.0",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "lazy_static",
+ "lexical-core 0.8.5",
+ "regex",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3197dab0963a236ff8e7c82e2272535745955ac1321eb740c29f2f88b353f54e"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-cast 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
  "chrono",
  "csv",
  "csv-core",
@@ -332,7 +432,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f937efa1aaad9dc86f6a0e382c2fa736a4943e2090c946138079bdf060cef"
 dependencies = [
  "arrow-buffer 36.0.0",
- "arrow-schema",
+ "arrow-schema 36.0.0",
+ "half 2.2.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb68113d6ecdbe8bba48b2c4042c151bf9e1c61244e45072a50250a6fc59bafe"
+dependencies = [
+ "arrow-buffer 38.0.0",
+ "arrow-schema 38.0.0",
  "half 2.2.1",
  "num",
 ]
@@ -343,11 +455,25 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18b75296ff01833f602552dff26a423fc213db8e5049b540ca4a00b1c957e41c"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-cast 36.0.0",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "flatbuffers 23.1.21",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab4bbf2dd3078facb5ce0a9641316a64f42bfd8cf357e6775c8a5e6708e3a8d"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-cast 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
  "flatbuffers 23.1.21",
 ]
 
@@ -357,11 +483,11 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e501d3de4d612c90677594896ca6c0fa075665a7ff980dc4189bb531c17e19f6"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-cast 36.0.0",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
  "chrono",
  "half 2.2.1",
  "indexmap",
@@ -371,16 +497,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-json"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c5b650d23746a494665d914a7fa3d21d939153cff9d53bdebe39bffa88f263"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-cast 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
+ "chrono",
+ "half 2.2.1",
+ "indexmap",
+ "lexical-core 0.8.5",
+ "num",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "arrow-ord"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d2671eb3793f9410230ac3efb0e6d36307be8a2dac5fad58ac9abde8e9f01e"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "arrow-select 36.0.0",
+ "half 2.2.1",
+ "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c6fce28e5011e30acc7466b5efcb8ed0197c396240bd2b10e167f275a3c208"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
+ "arrow-select 38.0.0",
  "half 2.2.1",
  "num",
 ]
@@ -392,10 +553,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc11fa039338cebbf4e29cf709c8ac1d6a65c7540063d4a25f991ab255ca85c8"
 dependencies = [
  "ahash 0.8.3",
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-data",
- "arrow-schema",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "half 2.2.1",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "arrow-row"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f20a421f19799d8b93eb8edde5217e910fa1e2d6ceb3c529f000e57b6db144c0"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
  "half 2.2.1",
  "hashbrown 0.13.2",
 ]
@@ -407,15 +583,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d04f17f7b86ded0b5baf98fe6123391c4343e031acc3ccc5fa604cc180bff220"
 
 [[package]]
+name = "arrow-schema"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc85923d8d6662cc66ac6602c7d1876872e671002d60993dfdf492a6badeae92"
+
+[[package]]
 name = "arrow-select"
 version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "163e35de698098ff5f5f672ada9dc1f82533f10407c7a11e2cd09f3bcf31d18a"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-data",
- "arrow-schema",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ab6613ce65b61d85a3410241744e84e48fbab0fe06e1251b4429d21b3470fd"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
  "num",
 ]
 
@@ -425,22 +620,54 @@ version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdfbed1b10209f0dc68e6aa4c43dc76079af65880965c7c3b73f641f23d4aba"
 dependencies = [
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-data 36.0.0",
+ "arrow-schema 36.0.0",
+ "arrow-select 36.0.0",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "arrow-string"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3008641239e884aefba66d8b8532da6af40d14296349fcc85935de4ba67b89e"
+dependencies = [
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-schema 38.0.0",
+ "arrow-select 38.0.0",
+ "regex",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
 name = "arrow_ext"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "snafu 0.6.10",
  "zstd 0.12.3+zstd.1.5.2",
+]
+
+[[package]]
+name = "arrow_util"
+version = "0.1.0"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow 38.0.0",
+ "chrono",
+ "comfy-table",
+ "hashbrown 0.13.2",
+ "num-traits",
+ "once_cell",
+ "regex",
+ "snafu 0.7.4",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -653,7 +880,7 @@ version = "1.2.0"
 dependencies = [
  "analytic_engine",
  "arena",
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "base64 0.13.1",
  "clap 3.2.23",
  "common_types",
@@ -663,7 +890,7 @@ dependencies = [
  "futures 0.3.28",
  "log",
  "object_store 1.2.0",
- "parquet",
+ "parquet 38.0.0",
  "parquet_ext",
  "pprof 0.10.1",
  "rand 0.7.3",
@@ -1163,7 +1390,7 @@ dependencies = [
  "reqwest",
  "serde",
  "sqlness",
- "sqlparser",
+ "sqlparser 0.33.0",
  "tokio",
 ]
 
@@ -1381,27 +1608,27 @@ dependencies = [
 name = "common_types"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "arrow_ext",
  "byteorder",
  "bytes_ext",
  "ceresdbproto",
  "chrono",
- "datafusion",
+ "datafusion 23.0.0",
  "murmur3",
  "paste 1.0.12",
  "prost",
  "serde",
  "serde_json",
  "snafu 0.6.10",
- "sqlparser",
+ "sqlparser 0.33.0",
 ]
 
 [[package]]
 name = "common_util"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "backtrace",
  "ceresdbproto",
  "chrono",
@@ -1818,19 +2045,63 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce6
 dependencies = [
  "ahash 0.8.3",
  "arrow 36.0.0",
+ "async-trait",
+ "bytes 1.4.0",
+ "chrono",
+ "dashmap 5.4.0",
+ "datafusion-common 21.1.0",
+ "datafusion-execution 21.1.0",
+ "datafusion-expr 21.1.0",
+ "datafusion-optimizer 21.1.0",
+ "datafusion-physical-expr 21.1.0",
+ "datafusion-row 21.1.0",
+ "datafusion-sql 21.1.0",
+ "futures 0.3.28",
+ "glob",
+ "hashbrown 0.13.2",
+ "indexmap",
+ "itertools",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "object_store 0.5.6",
+ "parking_lot 0.12.1",
+ "parquet 36.0.0",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "smallvec",
+ "sqlparser 0.32.0",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "uuid 1.3.0",
+]
+
+[[package]]
+name = "datafusion"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow 38.0.0",
+ "arrow-array 38.0.0",
+ "arrow-schema 38.0.0",
  "async-compression",
  "async-trait",
  "bytes 1.4.0",
  "bzip2",
  "chrono",
  "dashmap 5.4.0",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-optimizer",
- "datafusion-physical-expr",
- "datafusion-row",
- "datafusion-sql",
+ "datafusion-common 23.0.0",
+ "datafusion-execution 23.0.0",
+ "datafusion-expr 23.0.0",
+ "datafusion-optimizer 23.0.0",
+ "datafusion-physical-expr 23.0.0",
+ "datafusion-row 23.0.0",
+ "datafusion-sql 23.0.0",
  "flate2",
  "futures 0.3.28",
  "glob",
@@ -1842,12 +2113,12 @@ dependencies = [
  "num_cpus",
  "object_store 0.5.6",
  "parking_lot 0.12.1",
- "parquet",
+ "parquet 38.0.0",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
  "smallvec",
- "sqlparser",
+ "sqlparser 0.33.0",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -1864,12 +2135,26 @@ version = "21.1.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
 dependencies = [
  "arrow 36.0.0",
- "arrow-array",
+ "arrow-array 36.0.0",
  "chrono",
  "num_cpus",
  "object_store 0.5.6",
- "parquet",
- "sqlparser",
+ "parquet 36.0.0",
+ "sqlparser 0.32.0",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "arrow 38.0.0",
+ "arrow-array 38.0.0",
+ "chrono",
+ "num_cpus",
+ "object_store 0.5.6",
+ "parquet 38.0.0",
+ "sqlparser 0.33.0",
 ]
 
 [[package]]
@@ -1878,8 +2163,25 @@ version = "21.1.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
 dependencies = [
  "dashmap 5.4.0",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 21.1.0",
+ "datafusion-expr 21.1.0",
+ "hashbrown 0.13.2",
+ "log",
+ "object_store 0.5.6",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-execution"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "dashmap 5.4.0",
+ "datafusion-common 23.0.0",
+ "datafusion-expr 23.0.0",
  "hashbrown 0.13.2",
  "log",
  "object_store 0.5.6",
@@ -1896,8 +2198,19 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce6
 dependencies = [
  "ahash 0.8.3",
  "arrow 36.0.0",
- "datafusion-common",
- "sqlparser",
+ "datafusion-common 21.1.0",
+ "sqlparser 0.32.0",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow 38.0.0",
+ "datafusion-common 23.0.0",
+ "sqlparser 0.33.0",
 ]
 
 [[package]]
@@ -1908,13 +2221,30 @@ dependencies = [
  "arrow 36.0.0",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr",
+ "datafusion-common 21.1.0",
+ "datafusion-expr 21.1.0",
+ "datafusion-physical-expr 21.1.0",
  "hashbrown 0.13.2",
  "itertools",
  "log",
- "regex-syntax",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "arrow 38.0.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common 23.0.0",
+ "datafusion-expr 23.0.0",
+ "datafusion-physical-expr 23.0.0",
+ "hashbrown 0.13.2",
+ "itertools",
+ "log",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -1924,20 +2254,46 @@ source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce6
 dependencies = [
  "ahash 0.8.3",
  "arrow 36.0.0",
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-schema",
- "blake2",
- "blake3",
+ "arrow-schema 36.0.0",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-row",
+ "datafusion-common 21.1.0",
+ "datafusion-expr 21.1.0",
+ "datafusion-row 21.1.0",
  "half 2.2.1",
  "hashbrown 0.13.2",
  "indexmap",
  "itertools",
  "lazy_static",
+ "paste 1.0.12",
+ "petgraph",
+ "rand 0.8.5",
+ "uuid 1.3.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow 38.0.0",
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-schema 38.0.0",
+ "blake2",
+ "blake3",
+ "chrono",
+ "datafusion-common 23.0.0",
+ "datafusion-expr 23.0.0",
+ "datafusion-row 23.0.0",
+ "half 2.2.1",
+ "hashbrown 0.13.2",
+ "indexmap",
+ "itertools",
+ "lazy_static",
+ "libc",
  "md-5",
  "paste 1.0.12",
  "petgraph",
@@ -1950,14 +2306,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-version = "21.1.0"
-source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "chrono",
- "datafusion",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion 23.0.0",
+ "datafusion-common 23.0.0",
+ "datafusion-expr 23.0.0",
  "object_store 0.5.6",
  "prost",
 ]
@@ -1968,7 +2324,18 @@ version = "21.1.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
 dependencies = [
  "arrow 36.0.0",
- "datafusion-common",
+ "datafusion-common 21.1.0",
+ "paste 1.0.12",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "datafusion-row"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "arrow 38.0.0",
+ "datafusion-common 23.0.0",
  "paste 1.0.12",
  "rand 0.8.5",
 ]
@@ -1978,11 +2345,38 @@ name = "datafusion-sql"
 version = "21.1.0"
 source = "git+https://github.com/apache/arrow-datafusion.git?rev=b87871fdd1f4ce64201eb1f7c79a0547627f37e9#b87871fdd1f4ce64201eb1f7c79a0547627f37e9"
 dependencies = [
- "arrow-schema",
- "datafusion-common",
- "datafusion-expr",
+ "arrow-schema 36.0.0",
+ "datafusion-common 21.1.0",
+ "datafusion-expr 21.1.0",
  "log",
- "sqlparser",
+ "sqlparser 0.32.0",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "23.0.0"
+source = "git+https://github.com/apache/arrow-datafusion.git?rev=06e9f53637f20dd91bef43b74942ec36c38c22d5#06e9f53637f20dd91bef43b74942ec36c38c22d5"
+dependencies = [
+ "arrow 38.0.0",
+ "arrow-schema 38.0.0",
+ "datafusion-common 23.0.0",
+ "datafusion-expr 23.0.0",
+ "log",
+ "sqlparser 0.33.0",
+]
+
+[[package]]
+name = "datafusion_util"
+version = "0.1.0"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+dependencies = [
+ "async-trait",
+ "datafusion 23.0.0",
+ "futures 0.3.28",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "pin-project",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1991,9 +2385,9 @@ version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
 dependencies = [
  "async-trait",
- "datafusion",
+ "datafusion 21.1.0",
  "futures 0.3.28",
- "observability_deps",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "pin-project",
  "tokio",
  "tokio-stream",
@@ -2043,13 +2437,13 @@ dependencies = [
 name = "df_operator"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "base64 0.13.1",
  "bincode",
  "chrono",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "hyperloglog",
  "smallvec",
  "snafu 0.6.10",
@@ -2537,7 +2931,7 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
 dependencies = [
  "pbjson",
  "pbjson-build",
@@ -2930,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -2959,13 +3353,13 @@ name = "interpreters"
 version = "1.2.0"
 dependencies = [
  "analytic_engine",
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "async-trait",
  "catalog",
  "catalog_impls",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "datafusion-proto",
  "df_operator",
  "log",
@@ -3001,23 +3395,47 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+dependencies = [
+ "arrow 38.0.0",
+ "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "async-trait",
+ "chrono",
+ "datafusion 23.0.0",
+ "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "futures 0.3.28",
+ "hashbrown 0.13.2",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "snafu 0.7.4",
+ "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "iox_query"
+version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
 dependencies = [
  "arrow 36.0.0",
- "arrow_util",
+ "arrow_util 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "async-trait",
  "chrono",
- "datafusion",
- "datafusion_util",
+ "datafusion 21.1.0",
+ "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "futures 0.3.28",
  "hashbrown 0.13.2",
- "observability_deps",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "once_cell",
  "parking_lot 0.12.1",
- "query_functions",
- "schema",
+ "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql)",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "snafu 0.7.4",
- "test_helpers",
+ "test_helpers 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "tokio",
  "tokio-stream",
 ]
@@ -3025,22 +3443,22 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "chrono",
  "chrono-tz",
- "datafusion",
- "datafusion_util",
+ "datafusion 23.0.0",
+ "datafusion_util 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
  "generated_types",
  "influxdb_influxql_parser",
- "iox_query",
+ "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
  "itertools",
- "observability_deps",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
  "once_cell",
- "query_functions",
+ "query_functions 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
  "regex",
- "schema",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
  "serde_json",
 ]
 
@@ -4096,6 +4514,14 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "observability_deps"
+version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
 dependencies = [
  "tracing",
@@ -4218,13 +4644,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321a15f8332645759f29875b07f8233d16ed8ec1b3582223de81625a9f8506b7"
 dependencies = [
  "ahash 0.8.3",
- "arrow-array",
+ "arrow-array 36.0.0",
  "arrow-buffer 36.0.0",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-cast 36.0.0",
+ "arrow-data 36.0.0",
+ "arrow-ipc 36.0.0",
+ "arrow-schema 36.0.0",
+ "arrow-select 36.0.0",
  "base64 0.21.0",
  "brotli",
  "bytes 1.4.0",
@@ -4245,17 +4671,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbd51311f8d9ff3d2697b1522b18a588782e097d313a1a278b0faf2ccf2d3f6"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow-array 38.0.0",
+ "arrow-buffer 38.0.0",
+ "arrow-cast 38.0.0",
+ "arrow-data 38.0.0",
+ "arrow-ipc 38.0.0",
+ "arrow-schema 38.0.0",
+ "arrow-select 38.0.0",
+ "base64 0.21.0",
+ "brotli",
+ "bytes 1.4.0",
+ "chrono",
+ "flate2",
+ "futures 0.3.28",
+ "hashbrown 0.13.2",
+ "lz4",
+ "num",
+ "num-bigint 0.4.3",
+ "object_store 0.5.6",
+ "paste 1.0.12",
+ "seq-macro",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd 0.12.3+zstd.1.5.2",
+]
+
+[[package]]
 name = "parquet_ext"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "arrow_ext",
  "async-trait",
  "bytes 1.4.0",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "log",
- "parquet",
+ "parquet 38.0.0",
  "tokio",
 ]
 
@@ -4838,7 +5298,7 @@ checksum = "9653c3ed92974e34c5a6e0a510864dab979760481714c172e0a34e437cb98804"
 name = "proxy"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "arrow_ext",
  "async-trait",
  "bytes 1.4.0",
@@ -4848,7 +5308,7 @@ dependencies = [
  "cluster",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "df_operator",
  "futures 0.3.28",
  "http",
@@ -4870,7 +5330,7 @@ dependencies = [
  "serde_json",
  "snafu 0.6.10",
  "spin 0.9.8",
- "sqlparser",
+ "sqlparser 0.33.0",
  "system_catalog",
  "table_engine",
  "tokio",
@@ -4931,15 +5391,15 @@ dependencies = [
 name = "query_engine"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "async-trait",
  "chrono",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "df_operator",
  "futures 0.3.28",
- "iox_query",
+ "iox_query 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "log",
  "query_frontend",
  "serde",
@@ -4952,14 +5412,14 @@ dependencies = [
 name = "query_frontend"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "async-trait",
  "catalog",
  "ceresdbproto",
  "cluster",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "datafusion-proto",
  "df_operator",
  "hashbrown 0.12.3",
@@ -4971,12 +5431,29 @@ dependencies = [
  "paste 1.0.12",
  "prom-remote-api",
  "regex",
- "regex-syntax",
- "schema",
+ "regex-syntax 0.6.29",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
  "snafu 0.6.10",
- "sqlparser",
+ "sqlparser 0.33.0",
  "table_engine",
  "tokio",
+]
+
+[[package]]
+name = "query_functions"
+version = "0.1.0"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+dependencies = [
+ "arrow 38.0.0",
+ "chrono",
+ "datafusion 23.0.0",
+ "itertools",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "once_cell",
+ "regex",
+ "regex-syntax 0.6.29",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "snafu 0.7.4",
 ]
 
 [[package]]
@@ -4986,13 +5463,13 @@ source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b84
 dependencies = [
  "arrow 36.0.0",
  "chrono",
- "datafusion",
+ "datafusion 21.1.0",
  "itertools",
- "observability_deps",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "once_cell",
  "regex",
- "regex-syntax",
- "schema",
+ "regex-syntax 0.6.29",
+ "schema 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "snafu 0.7.4",
 ]
 
@@ -5318,13 +5795,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -5333,7 +5810,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5341,6 +5818,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "remote_engine_client"
@@ -5674,13 +6157,26 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+dependencies = [
+ "arrow 38.0.0",
+ "hashbrown 0.13.2",
+ "indexmap",
+ "itertools",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "snafu 0.7.4",
+]
+
+[[package]]
+name = "schema"
+version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
 dependencies = [
  "arrow 36.0.0",
  "hashbrown 0.13.2",
  "indexmap",
  "itertools",
- "observability_deps",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "snafu 0.7.4",
 ]
 
@@ -5824,7 +6320,7 @@ name = "server"
 version = "1.2.0"
 dependencies = [
  "analytic_engine",
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "arrow_ext",
  "async-trait",
  "bytes 1.4.0",
@@ -5834,7 +6330,7 @@ dependencies = [
  "cluster",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "df_operator",
  "futures 0.3.28",
  "http",
@@ -5862,7 +6358,7 @@ dependencies = [
  "serde_json",
  "snafu 0.6.10",
  "spin 0.9.8",
- "sqlparser",
+ "sqlparser 0.33.0",
  "table_engine",
  "tokio",
  "tokio-stream",
@@ -6178,6 +6674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0366f270dbabb5cc2e4c88427dc4c08bba144f81e32fbd459a013f26a4d16aa0"
 dependencies = [
  "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355dc4d4b6207ca8a3434fc587db0a8016130a574dbcdbfb93d7f7b5bc5b211a"
+dependencies = [
+ "log",
  "serde",
  "sqlparser_derive",
 ]
@@ -6377,7 +6883,7 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 name = "system_catalog"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "async-trait",
  "catalog",
  "ceresdbproto",
@@ -6396,13 +6902,13 @@ dependencies = [
 name = "table_engine"
 version = "1.2.0"
 dependencies = [
- "arrow 36.0.0",
+ "arrow 38.0.0",
  "arrow_ext",
  "async-trait",
  "ceresdbproto",
  "common_types",
  "common_util",
- "datafusion",
+ "datafusion 23.0.0",
  "datafusion-proto",
  "df_operator",
  "env_logger",
@@ -6483,10 +6989,23 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
+source = "git+https://github.com/CeresDB/influxql?branch=bump-df#53fab425948c77a7f9b96c7a45994a259232526a"
+dependencies = [
+ "dotenvy",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql?branch=bump-df)",
+ "parking_lot 0.12.1",
+ "tempfile",
+ "tracing-log",
+ "tracing-subscriber 0.3.16",
+]
+
+[[package]]
+name = "test_helpers"
+version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql#6dc964e316a7bd2e0e1232005b9b840fb05e2eda"
 dependencies = [
  "dotenvy",
- "observability_deps",
+ "observability_deps 0.1.0 (git+https://github.com/CeresDB/influxql)",
  "parking_lot 0.12.1",
  "tempfile",
  "tracing-log",
@@ -6845,7 +7364,7 @@ dependencies = [
  "env_logger",
  "futures 0.3.28",
  "object_store 1.2.0",
- "parquet",
+ "parquet 38.0.0",
  "parquet_ext",
  "table_engine",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,10 @@ lazy_static = "1.4.0"
 log = "0.4"
 logger = { path = "components/logger" }
 lru = "0.7.6"
+influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", package = "iox_query_influxql" }
+influxql-parser = { git = "https://github.com/CeresDB/influxql", package = "influxdb_influxql_parser" }
+influxql-query = { git = "https://github.com/CeresDB/influxql", package = "iox_query" }
+influxql-schema = { git = "https://github.com/CeresDB/influxql", package = "schema" }
 interpreters = { path = "interpreters" }
 itertools = "0.10.5"
 meta_client = { path = "meta_client" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ name = "ceresdb-server"
 path = "src/bin/ceresdb-server.rs"
 
 [workspace.dependencies]
-arrow = { version = "36.0.0", features = ["prettyprint"] }
-arrow_ipc = { version = "36.0.0" }
+arrow = { version = "38.0.0", features = ["prettyprint"] }
+arrow_ipc = { version = "38.0.0" }
 arrow_ext = { path = "components/arrow_ext" }
 analytic_engine = { path = "analytic_engine" }
 arena = { path = "components/arena" }
@@ -76,8 +76,8 @@ cluster = { path = "cluster" }
 criterion = "0.3"
 common_types = { path = "common_types" }
 common_util = { path = "common_util" }
-datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "b87871fdd1f4ce64201eb1f7c79a0547627f37e9" }
-datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "b87871fdd1f4ce64201eb1f7c79a0547627f37e9" }
+datafusion = { git = "https://github.com/apache/arrow-datafusion.git", rev = "06e9f53637f20dd91bef43b74942ec36c38c22d5" }
+datafusion-proto = { git = "https://github.com/apache/arrow-datafusion.git", rev = "06e9f53637f20dd91bef43b74942ec36c38c22d5" }
 df_operator = { path = "df_operator" }
 etcd-client = "0.10.3"
 env_logger = "0.6"
@@ -95,7 +95,7 @@ meta_client = { path = "meta_client" }
 object_store = { path = "components/object_store" }
 partition_table_engine = { path = "partition_table_engine" }
 parquet_ext = { path = "components/parquet_ext" }
-parquet = { version = "36.0.0" }
+parquet = { version = "38.0.0" }
 paste = "1.0"
 pin-project-lite = "0.2.8"
 profile = { path = "components/profile" }
@@ -117,7 +117,7 @@ smallvec = "1.6"
 slog = "2.7"
 spin = "0.9.6"
 query_frontend = { path = "query_frontend" }
-sqlparser = { version = "0.32", features = ["serde"] }
+sqlparser = { version = "0.33", features = ["serde"] }
 system_catalog = { path = "system_catalog" }
 table_engine = { path = "table_engine" }
 table_kv = { path = "components/table_kv" }

--- a/analytic_engine/src/sst/parquet/hybrid.rs
+++ b/analytic_engine/src/sst/parquet/hybrid.rs
@@ -74,12 +74,13 @@ impl ArrayHandle {
     }
 
     // Note: this require primitive array
+
     fn data_slice(&self) -> &[u8] {
-        self.array.data().buffers()[0].as_slice()
+        unimplemented!()
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {
-        self.array.data().nulls()
+        self.array.nulls()
     }
 }
 
@@ -122,12 +123,12 @@ pub fn build_hybrid_arrow_schema(schema: &Schema) -> ArrowSchemaRef {
         .enumerate()
         .map(|(idx, field)| {
             if schema.is_collapsible_column(idx) {
-                let field_type = DataType::List(Box::new(Field::new(
+                let field_type = DataType::List(Arc::new(Field::new(
                     LIST_ITEM_NAME,
                     field.data_type().clone(),
                     true,
                 )));
-                Field::new(field.name(), field_type, true)
+                Arc::new(Field::new(field.name(), field_type, true))
             } else {
                 field.clone()
             }
@@ -418,7 +419,7 @@ impl ListArrayBuilder {
         let array_len = self.multi_row_arrays.len();
         let mut offsets = MutableBuffer::new(array_len * std::mem::size_of::<i32>());
         let child_data = self.build_child_data(&mut offsets)?;
-        let field = Box::new(Field::new(
+        let field = Arc::new(Field::new(
             LIST_ITEM_NAME,
             self.datum_kind.to_arrow_data_type(),
             true,

--- a/analytic_engine/src/sst/parquet/hybrid.rs
+++ b/analytic_engine/src/sst/parquet/hybrid.rs
@@ -732,14 +732,14 @@ mod tests {
         let string_data =
             string_array(vec![Some("bb"), None, Some("ccc"), Some("eeee"), Some("a")]);
         let offsets: [i32; 3] = [0, 4, 5];
-        let array_data = ArrayData::builder(DataType::List(Box::new(Field::new(
+        let array_data = ArrayData::builder(DataType::List(Arc::new(Field::new(
             LIST_ITEM_NAME,
             DataType::Utf8,
             true,
         ))))
         .len(2)
         .add_buffer(Buffer::from_slice_ref(offsets))
-        .add_child_data(string_data.data().to_owned())
+        .add_child_data(string_data.to_data())
         .build()
         .unwrap();
         let expected = ListArray::from(array_data);

--- a/analytic_engine/src/sst/parquet/hybrid.rs
+++ b/analytic_engine/src/sst/parquet/hybrid.rs
@@ -74,9 +74,8 @@ impl ArrayHandle {
     }
 
     // Note: this require primitive array
-
-    fn data_slice(&self) -> &[u8] {
-        unimplemented!()
+    fn data_slice(&self) -> Vec<u8> {
+        self.array.to_data().buffers()[0].as_slice().to_vec()
     }
 
     fn nulls(&self) -> Option<&NullBuffer> {

--- a/common_types/src/column.rs
+++ b/common_types/src/column.rs
@@ -346,7 +346,7 @@ macro_rules! impl_from_array_and_slice {
                 // the underlying vector of [arrow::buffer::Buffer] and Bitmap (also
                 // holds a Buffer), thus require some allocation. However, the Buffer is
                 // managed by Arc, so cloning the buffer is not too expensive.
-                let array_data = array_ref.data().clone();
+                let array_data = array_ref.into_data();
                 let array = $ArrayType::from(array_data);
 
                 Self(array)
@@ -356,7 +356,7 @@ macro_rules! impl_from_array_and_slice {
         impl $Column {
             fn to_arrow_array(&self) -> $ArrayType {
                 // Clone the array data.
-                let array_data = self.0.data().clone();
+                let array_data = self.0.clone().into_data();
                 $ArrayType::from(array_data)
             }
 
@@ -367,7 +367,7 @@ macro_rules! impl_from_array_and_slice {
             fn slice(&self, offset: usize, length: usize) -> Self {
                 let array_slice = self.0.slice(offset, length);
                 // Clone the slice data.
-                let array_data = array_slice.data().clone();
+                let array_data = array_slice.into_data();
                 let array = $ArrayType::from(array_data);
 
                 Self(array)

--- a/common_types/src/column_schema.rs
+++ b/common_types/src/column_schema.rs
@@ -2,7 +2,7 @@
 
 //! Schema of column
 
-use std::{collections::HashMap, convert::TryFrom, str::FromStr};
+use std::{collections::HashMap, convert::TryFrom, str::FromStr, sync::Arc};
 
 use arrow::datatypes::{DataType, Field};
 use ceresdbproto::schema as schema_pb;
@@ -280,10 +280,10 @@ impl TryFrom<schema_pb::ColumnSchema> for ColumnSchema {
     }
 }
 
-impl TryFrom<&Field> for ColumnSchema {
+impl TryFrom<&Arc<Field>> for ColumnSchema {
     type Error = Error;
 
-    fn try_from(field: &Field) -> Result<Self> {
+    fn try_from(field: &Arc<Field>) -> Result<Self> {
         let ArrowFieldMeta {
             id,
             is_tag,

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -977,7 +977,7 @@ pub mod arrow_convert {
                 | DataType::LargeBinary
                 | DataType::FixedSizeBinary(_)
                 | DataType::Struct(_)
-                | DataType::Union(_, _, _)
+                | DataType::Union(_, _)
                 | DataType::List(_)
                 | DataType::LargeList(_)
                 | DataType::FixedSizeList(_, _)

--- a/common_types/src/record_batch.rs
+++ b/common_types/src/record_batch.rs
@@ -7,7 +7,7 @@ use std::{cmp, convert::TryFrom, mem, sync::Arc};
 use arrow::{
     array::BooleanArray,
     compute,
-    datatypes::{DataType, Field, Schema, SchemaRef as ArrowSchemaRef, TimeUnit},
+    datatypes::{DataType, Field, Fields, Schema, SchemaRef as ArrowSchemaRef, TimeUnit},
     error::ArrowError,
     record_batch::RecordBatch as ArrowRecordBatch,
 };
@@ -325,7 +325,7 @@ fn cast_arrow_record_batch(source: ArrowRecordBatch) -> Result<ArrowRecordBatch>
         })
         .collect::<Vec<_>>();
     let mills_schema = Schema {
-        fields: mills_fileds,
+        fields: mills_fileds.into(),
         metadata: schema.metadata().clone(),
     };
     let result =

--- a/common_types/src/record_batch.rs
+++ b/common_types/src/record_batch.rs
@@ -7,7 +7,7 @@ use std::{cmp, convert::TryFrom, mem, sync::Arc};
 use arrow::{
     array::BooleanArray,
     compute,
-    datatypes::{DataType, Field, Fields, Schema, SchemaRef as ArrowSchemaRef, TimeUnit},
+    datatypes::{DataType, Field, Schema, SchemaRef as ArrowSchemaRef, TimeUnit},
     error::ArrowError,
     record_batch::RecordBatch as ArrowRecordBatch,
 };

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -434,7 +434,7 @@ impl RecordSchema {
             .columns
             .iter()
             .map(|col| col.to_arrow_field())
-            .collect();
+            .collect::<Vec<_>>();
         // Build arrow schema.
         let arrow_schema = Arc::new(ArrowSchema::new_with_metadata(
             fields,
@@ -1222,7 +1222,11 @@ impl Builder {
             );
         }
 
-        let fields = self.columns.iter().map(|c| c.to_arrow_field()).collect();
+        let fields = self
+            .columns
+            .iter()
+            .map(|c| c.to_arrow_field())
+            .collect::<Vec<_>>();
         let meta = self.build_arrow_schema_meta();
 
         Ok(Schema {

--- a/components/parquet_ext/src/prune/min_max.rs
+++ b/components/parquet_ext/src/prune/min_max.rs
@@ -210,7 +210,7 @@ mod test {
         let fields = fields
             .into_iter()
             .map(|(name, data_type)| ArrowField::new(name, data_type, false))
-            .collect();
+            .collect::<Vec<_>>();
         Arc::new(ArrowSchema::new(fields))
     }
 

--- a/integration_tests/build_meta.sh
+++ b/integration_tests/build_meta.sh
@@ -2,11 +2,14 @@
 
 set -exo
 
-if [ -d ceresmeta ]; then
+SRC=/tmp/ceresmeta-src
+TARGET=$(pwd)/ceresmeta
+
+if [ -d $SRC ]; then
   echo "Remove old meta..."
-  rm -r ceresmeta
+  rm -rf $SRC
 fi
 
-git clone --depth 1 https://github.com/ceresdb/ceresmeta.git
-cd ceresmeta
-go build -o ceresmeta ./cmd/meta/...
+git clone --depth 1 https://github.com/ceresdb/ceresmeta.git ${SRC}
+cd ${SRC}
+go build -o ${TARGET}/ceresmeta ./cmd/meta/...

--- a/integration_tests/cases/common/dummy/select_1.result
+++ b/integration_tests/cases/common/dummy/select_1.result
@@ -6,7 +6,7 @@ Int64(1),
 
 SELECT x;
 
-Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: SELECT x;. Caused by: Failed to create plan, err:Failed to generate datafusion plan, err:Schema error: No field named \"x\"." })
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: SELECT x;. Caused by: Failed to create plan, err:Failed to generate datafusion plan, err:Schema error: No field named x." })
 
 SELECT 'a';
 
@@ -22,7 +22,9 @@ Boolean(false),
 
 SELECT NOT(1);
 
-Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to execute interpreter, sql: SELECT NOT(1);. Caused by: Failed to execute select, err:Failed to execute logical plan, err:Failed to collect record batch stream, err:Stream error, msg:convert from arrow record batch, err:Internal error: NOT 'Literal { value: Int64(1) }' can't be evaluated because the expression's type is Int64, not boolean or NULL. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker" })
+NOT Int64(1),
+Int64(-2),
+
 
 SELECT TRUE;
 

--- a/proxy/src/influxdb/types.rs
+++ b/proxy/src/influxdb/types.rs
@@ -602,7 +602,7 @@ pub(crate) fn convert_influxql_output(output: Output) -> Result<InfluxqlResponse
 mod tests {
     use std::sync::Arc;
 
-    use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
+    use arrow::datatypes::{Field as ArrowField, Fields, Schema as ArrowSchema};
     use common_types::{
         column::{ColumnBlock, ColumnBlockBuilder},
         column_schema,
@@ -796,14 +796,14 @@ mod tests {
             false,
         );
         let project_fields = vec![
-            measurement_field,
+            Arc::new(measurement_field),
             fields[1].clone(),
             fields[0].clone(),
             fields[2].clone(),
             fields[3].clone(),
         ];
         let project_arrow_schema = Arc::new(ArrowSchema::new_with_metadata(
-            project_fields,
+            Fields::from(project_fields),
             arrow_schema.metadata().clone(),
         ));
 

--- a/query_engine/Cargo.toml
+++ b/query_engine/Cargo.toml
@@ -20,7 +20,7 @@ common_util = { workspace = true }
 datafusion = { workspace = true }
 df_operator = { workspace = true }
 futures = { workspace = true }
-iox_query = { git = "https://github.com/CeresDB/influxql" }
+influxql-query = { workspace = true }
 log = { workspace = true }
 query_frontend = { workspace = true }
 serde = { workspace = true }

--- a/query_engine/src/context.rs
+++ b/query_engine/src/context.rs
@@ -88,7 +88,6 @@ impl Context {
 
     fn logical_optimize_rules() -> Vec<Arc<dyn OptimizerRule + Send + Sync>> {
         let mut optimizers: Vec<Arc<dyn OptimizerRule + Send + Sync>> = vec![
-            Arc::new(TypeConversion),
             // These rules are the default settings of the datafusion.
             Arc::new(SimplifyExpressions::new()),
             Arc::new(CommonSubexprEliminate::new()),
@@ -108,8 +107,9 @@ impl Context {
     }
 
     fn analyzer_rules() -> Vec<Arc<dyn AnalyzerRule + Send + Sync>> {
-        vec![Arc::new(
-            datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new(),
-        )]
+        vec![
+            Arc::new(TypeConversion),
+            Arc::new(datafusion::optimizer::analyzer::type_coercion::TypeCoercion::new()),
+        ]
     }
 }

--- a/query_engine/src/context.rs
+++ b/query_engine/src/context.rs
@@ -69,7 +69,7 @@ impl Context {
                 .with_query_planner(Arc::new(QueryPlannerAdapter))
                 .with_analyzer_rules(Self::analyzer_rules())
                 .with_optimizer_rules(logical_optimize_rules);
-        let state = iox_query::logical_optimizer::register_iox_logical_optimizers(state);
+        let state = influxql_query::logical_optimizer::register_iox_logical_optimizers(state);
         let physical_optimizer =
             Self::apply_adapters_for_physical_optimize_rules(state.physical_optimizers());
         SessionContext::with_state(state.with_physical_optimizer_rules(physical_optimizer))

--- a/query_engine/src/df_planner_extension/mod.rs
+++ b/query_engine/src/df_planner_extension/mod.rs
@@ -30,7 +30,7 @@ impl QueryPlanner for QueryPlannerAdapter {
         let extension_planners: Vec<Arc<dyn ExtensionPlanner + Send + Sync>> = vec![
             Arc::new(table_scan_by_primary_key::Planner),
             Arc::new(prom_align::PromAlignPlanner),
-            Arc::new(iox_query::exec::context::IOxExtensionPlanner {}),
+            Arc::new(influxql_query::exec::context::IOxExtensionPlanner {}),
         ];
 
         let physical_planner = DefaultPhysicalPlanner::with_extension_planners(extension_planners);

--- a/query_engine/src/logical_optimizer/type_conversion.rs
+++ b/query_engine/src/logical_optimizer/type_conversion.rs
@@ -44,7 +44,7 @@ impl AnalyzerRule for TypeConversion {
             LogicalPlan::Filter(Filter {
                 predicate, input, ..
             }) => {
-                let input: &LogicalPlan = &input;
+                let input: &LogicalPlan = input;
                 let predicate = predicate.clone().rewrite(&mut rewriter)?;
                 let input = self.analyze(input.clone(), config)?;
                 Ok(LogicalPlan::Filter(Filter::try_new(

--- a/query_engine/src/logical_optimizer/type_conversion.rs
+++ b/query_engine/src/logical_optimizer/type_conversion.rs
@@ -82,7 +82,6 @@ impl OptimizerRule for TypeConversion {
             | LogicalPlan::Window { .. }
             | LogicalPlan::Aggregate { .. }
             | LogicalPlan::Repartition { .. }
-            | LogicalPlan::CreateExternalTable { .. }
             | LogicalPlan::Extension { .. }
             | LogicalPlan::Sort { .. }
             | LogicalPlan::Explain { .. }
@@ -90,14 +89,12 @@ impl OptimizerRule for TypeConversion {
             | LogicalPlan::Union { .. }
             | LogicalPlan::Join { .. }
             | LogicalPlan::CrossJoin { .. }
-            | LogicalPlan::CreateMemoryTable { .. }
-            | LogicalPlan::DropTable { .. }
-            | LogicalPlan::DropView { .. }
             | LogicalPlan::Values { .. }
             | LogicalPlan::Analyze { .. }
             | LogicalPlan::Distinct { .. }
             | LogicalPlan::Prepare { .. }
             | LogicalPlan::DescribeTable { .. }
+            | LogicalPlan::Ddl { .. }
             | LogicalPlan::Dml { .. } => {
                 let inputs = plan.inputs();
                 let new_inputs = inputs
@@ -119,9 +116,6 @@ impl OptimizerRule for TypeConversion {
             LogicalPlan::Subquery(_)
             | LogicalPlan::Statement { .. }
             | LogicalPlan::SubqueryAlias(_)
-            | LogicalPlan::CreateView(_)
-            | LogicalPlan::CreateCatalogSchema(_)
-            | LogicalPlan::CreateCatalog(_)
             | LogicalPlan::Unnest(_)
             | LogicalPlan::EmptyRelation { .. } => Ok(Some(plan.clone())),
         }

--- a/query_frontend/Cargo.toml
+++ b/query_frontend/Cargo.toml
@@ -26,9 +26,9 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 df_operator = { workspace = true }
 hashbrown = { version = "0.12", features = ["raw"] }
-influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", package = "iox_query_influxql" }
-influxql-parser = { git = "https://github.com/CeresDB/influxql", package = "influxdb_influxql_parser" }
-influxql-schema = { git = "https://github.com/CeresDB/influxql", package = "schema" }
+influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", package = "iox_query_influxql", branch = "bump-df" }
+influxql-parser = { git = "https://github.com/CeresDB/influxql", package = "influxdb_influxql_parser", branch = "bump-df" }
+influxql-schema = { git = "https://github.com/CeresDB/influxql", package = "schema", branch = "bump-df" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/query_frontend/Cargo.toml
+++ b/query_frontend/Cargo.toml
@@ -26,9 +26,9 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 df_operator = { workspace = true }
 hashbrown = { version = "0.12", features = ["raw"] }
-influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", branch = "chore-log", package = "iox_query_influxql" }
-influxql-parser = { git = "https://github.com/CeresDB/influxql", branch = "chore-log", package = "influxdb_influxql_parser" }
-influxql-schema = { git = "https://github.com/CeresDB/influxql", branch = "chore-log", package = "schema" }
+influxql-logical-planner = { workspace = true }
+influxql-parser = { workspace = true }
+influxql-schema = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/query_frontend/Cargo.toml
+++ b/query_frontend/Cargo.toml
@@ -26,9 +26,9 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 df_operator = { workspace = true }
 hashbrown = { version = "0.12", features = ["raw"] }
-influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", branch = "main", package = "iox_query_influxql" }
-influxql-parser = { git = "https://github.com/CeresDB/influxql", branch = "main", package = "influxdb_influxql_parser" }
-influxql-schema = { git = "https://github.com/CeresDB/influxql", branch = "main", package = "schema" }
+influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", branch = "chore-log", package = "iox_query_influxql" }
+influxql-parser = { git = "https://github.com/CeresDB/influxql", branch = "chore-log", package = "influxdb_influxql_parser" }
+influxql-schema = { git = "https://github.com/CeresDB/influxql", branch = "chore-log", package = "schema" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/query_frontend/Cargo.toml
+++ b/query_frontend/Cargo.toml
@@ -26,9 +26,9 @@ datafusion = { workspace = true }
 datafusion-proto = { workspace = true }
 df_operator = { workspace = true }
 hashbrown = { version = "0.12", features = ["raw"] }
-influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", package = "iox_query_influxql", branch = "bump-df" }
-influxql-parser = { git = "https://github.com/CeresDB/influxql", package = "influxdb_influxql_parser", branch = "bump-df" }
-influxql-schema = { git = "https://github.com/CeresDB/influxql", package = "schema", branch = "bump-df" }
+influxql-logical-planner = { git = "https://github.com/CeresDB/influxql", branch = "main", package = "iox_query_influxql" }
+influxql-parser = { git = "https://github.com/CeresDB/influxql", branch = "main", package = "influxdb_influxql_parser" }
+influxql-schema = { git = "https://github.com/CeresDB/influxql", branch = "main", package = "schema" }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -1022,13 +1022,12 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
 // `enable_ident_normalization` is `true`, but we want to
 // function case-insensitive, so add this normalization.
 fn normalize_func_name(sql_stmt: &mut SqlStatement) {
-    let normalize_expr = |expr: &mut SqlExpr| match expr {
-        SqlExpr::Function(ref mut func) => {
+    let normalize_expr = |expr: &mut SqlExpr| {
+        if let SqlExpr::Function(ref mut func) = expr {
             for ident in &mut func.name.0 {
                 ident.value = ident.value.to_lowercase();
             }
         }
-        _ => {}
     };
 
     visit_statements_mut(sql_stmt, |stmt| {

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -1037,7 +1037,7 @@ fn normalize_func_name(sql_stmt: &mut SqlStatement) {
                     match projection {
                         SelectItem::UnnamedExpr(ref mut expr) => normalize_expr(expr),
                         SelectItem::ExprWithAlias { ref mut expr, .. } => normalize_expr(expr),
-                        _ => (),
+                        SelectItem::QualifiedWildcard(_, _) | SelectItem::Wildcard(_) => {}
                     }
                 }
             }

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     convert::TryFrom,
     mem,
+    ops::ControlFlow,
     sync::Arc,
 };
 
@@ -41,8 +42,8 @@ use log::{debug, trace};
 use prom_remote_api::types::Query as PromRemoteQuery;
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use sqlparser::ast::{
-    ColumnDef, ColumnOption, Expr, Ident, Query, SetExpr, SqlOption, Statement as SqlStatement,
-    TableConstraint, UnaryOperator, Value, Values,
+    visit_statements_mut, ColumnDef, ColumnOption, Expr, Expr as SqlExpr, Ident, Query, SelectItem,
+    SetExpr, SqlOption, Statement as SqlStatement, TableConstraint, UnaryOperator, Value, Values,
 };
 use table_engine::table::TableRef;
 
@@ -565,10 +566,11 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
         Self { meta_provider }
     }
 
-    pub(crate) fn sql_statement_to_plan(self, sql_stmt: SqlStatement) -> Result<Plan> {
+    pub(crate) fn sql_statement_to_plan(self, mut sql_stmt: SqlStatement) -> Result<Plan> {
         match sql_stmt {
             // Query statement use datafusion planner
             SqlStatement::Explain { .. } | SqlStatement::Query(_) => {
+                normalize_func_name(&mut sql_stmt);
                 self.sql_statement_to_datafusion_plan(sql_stmt)
             }
             SqlStatement::Insert { .. } => self.insert_to_plan(sql_stmt),
@@ -1014,6 +1016,35 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
             .table(table_ref)
             .context(MetaProviderFindTable)
     }
+}
+
+// Datafusion only support lower-case function name when
+// `enable_ident_normalization` is `true`, but we want to
+// function case-insensitive, so add this normalization.
+fn normalize_func_name(sql_stmt: &mut SqlStatement) {
+    let normalize_expr = |expr: &mut SqlExpr| match expr {
+        SqlExpr::Function(ref mut func) => {
+            for ident in &mut func.name.0 {
+                ident.value = ident.value.to_lowercase();
+            }
+        }
+        _ => {}
+    };
+
+    visit_statements_mut(sql_stmt, |stmt| {
+        if let SqlStatement::Query(q) = stmt {
+            if let SetExpr::Select(select) = q.body.as_mut() {
+                for projection in &mut select.projection {
+                    match projection {
+                        SelectItem::UnnamedExpr(ref mut expr) => normalize_expr(expr),
+                        SelectItem::ExprWithAlias { ref mut expr, .. } => normalize_expr(expr),
+                        _ => (),
+                    }
+                }
+            }
+        }
+        ControlFlow::<()>::Continue(())
+    });
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Which issue does this PR close?


Related with #867

## Rationale for this change


## What changes are included in this PR?
- Bump datafusion to 24
- Bump Arrow/Parquet to 38
- Bump sqlparser to 0.33
## Are there any user-facing changes?
No

## How does this change test
CI

