### PR TITLE
chore: adjust log level

### DIFF
--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -196,7 +196,7 @@ impl Flusher {
         table_data: &TableDataRef,
         opts: TableFlushOptions,
     ) -> Result<()> {
-        info!(
+        debug!(
             "Instance flush table, table_data:{:?}, flush_opts:{:?}",
             table_data, opts
         );

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -271,7 +271,7 @@ impl Instance {
 
         let last_sequence = log_entries.back().unwrap().sequence;
 
-        info!(
+        debug!(
             "Instance replay table log entries begin, table:{}, table_id:{:?}, sequence:{}",
             table_data.name, table_data.id, last_sequence
         );
@@ -350,7 +350,7 @@ impl Instance {
             }
         }
 
-        info!(
+        debug!(
             "Instance replay table log entries end, table:{}, table_id:{:?}, last_sequence:{}",
             table_data.name, table_data.id, last_sequence
         );


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
When restart server, there are too many logs about replay
```
2023-05-17 08:17:58.267 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6103359                                            2023-05-17 08:17:58.268 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6103359                                         2023-05-17 08:17:58.277 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6103859                                           
2023-05-17 08:17:58.278 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6103859                                        
2023-05-17 08:17:58.288 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6104359                                           
2023-05-17 08:17:58.289 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6104359                                         2023-05-17 08:17:58.297 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6104859                                           
2023-05-17 08:17:58.299 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6104859                                         2023-05-17 08:17:58.308 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6105359                                            2023-05-17 08:17:58.309 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6105359                                         2023-05-17 08:17:58.318 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6105859                                           
2023-05-17 08:17:58.320 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6105859                                        
2023-05-17 08:17:58.328 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6106359                                           
2023-05-17 08:17:58.329 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6106359                                         2023-05-17 08:17:58.338 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6106859                                           
2023-05-17 08:17:58.340 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6106859                                         2023-05-17 08:17:58.349 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6107359                                            2023-05-17 08:17:58.351 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6107359                                         2023-05-17 08:17:58.359 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6107859                                            
2023-05-17 08:17:58.360 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6107859                                         
2023-05-17 08:17:58.369 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6108359                                           
2023-05-17 08:17:58.371 INFO [analytic_engine/src/instance/open.rs:350] Instance replay table log entries end, table:meta_peers_refresh_counter, table_id:TableId(314), last_sequence:6108359                                         2023-05-17 08:17:58.380 INFO [analytic_engine/src/instance/open.rs:272] Instance replay table log entries begin, table:meta_peers_refresh_counter, table_id:TableId(314), sequence:6108859      
```
## What changes are included in this PR?
Change to debug level
## Are there any user-facing changes?
No
## How does this change test

No need

