### PR TITLE
chore: remove parse table name in integration-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,11 +1160,9 @@ dependencies = [
  "async-trait",
  "ceresdb-client",
  "local-ip-address",
- "query_frontend",
  "reqwest",
  "serde",
  "sqlness",
- "sqlparser",
  "tokio",
 ]
 

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -10,9 +10,7 @@ anyhow = "1.0.58"
 async-trait = "0.1"
 ceresdb-client = "1.0"
 local-ip-address = "0.5"
-query_frontend = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 sqlness = "0.4.3"
-sqlparser = { workspace = true }
 tokio = { workspace = true }

--- a/integration_tests/src/database.rs
+++ b/integration_tests/src/database.rs
@@ -16,7 +16,6 @@ use ceresdb_client::{
     model::sql_query::{display::CsvFormatter, Request},
     RpcContext,
 };
-use query_frontend::{frontend, parser::Parser};
 use reqwest::{ClientBuilder, Url};
 use sqlness::{Database, QueryContext};
 
@@ -271,18 +270,10 @@ impl<T> CeresDB<T> {
             database: Some("public".to_string()),
             timeout: None,
         };
-        let statements = Parser::parse_sql(&query).unwrap();
-        let table_name = frontend::parse_table_name(&statements);
 
-        let query_req = match table_name {
-            Some(table_name) => Request {
-                tables: vec![table_name],
-                sql: query,
-            },
-            None => Request {
-                tables: vec![],
-                sql: query,
-            },
+        let query_req = Request {
+            tables: vec![],
+            sql: query,
         };
 
         let result = client.sql_query(&query_ctx, &query_req).await;


### PR DESCRIPTION
## Which issue does this PR close?

Closes #

## Rationale for this change
Proxy module already supports query without passing `table_name`.

## What changes are included in this PR?
* Remove table_name `parser` in integration-test.

## Are there any user-facing changes?

## How does this change test
