### PR TITLE
fix: remove shard from cluster topology after shard closed

### DIFF
--- a/analytic_engine/src/engine.rs
+++ b/analytic_engine/src/engine.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_util::error::BoxError;
-use log::{error, info};
+use log::{error, info, warn};
 use snafu::ResultExt;
 use table_engine::{
     engine::{
@@ -63,6 +63,10 @@ impl TableEngineImpl {
                     }
                     table_opt
                 });
+
+            if let Ok(None) = result {
+                warn!("Try to open a missing table, open request:{request:?}");
+            }
 
             open_results.push(result);
         }

--- a/catalog/src/table_operator.rs
+++ b/catalog/src/table_operator.rs
@@ -55,8 +55,8 @@ impl TableOperator {
 
         // Check and register successful opened table into schema.
         let mut success_count = 0_u32;
-        let mut no_table_count = 0_u32;
-        let mut open_err_count = 0_u32;
+        let mut missing_table_count = 0_u32;
+        let mut open_table_errs = Vec::new();
 
         for (schema, open_result) in schemas.into_iter().zip(open_results.into_iter()) {
             match open_result {
@@ -65,31 +65,31 @@ impl TableOperator {
                     success_count += 1;
                 }
                 Ok(None) => {
-                    no_table_count += 1;
+                    missing_table_count += 1;
                 }
                 // Has printed error log for it.
-                Err(_) => {
-                    open_err_count += 1;
+                Err(e) => {
+                    open_table_errs.push(e);
                 }
             }
         }
 
         info!(
-            "Open shard finish, shard id:{}, cost:{}ms, successful count:{}, no table is opened count:{}, open error count:{}",
-            shard_id,
+            "Open shard finish, shard id:{shard_id}, cost:{}ms, success_count:{success_count}, missing_table_count:{missing_table_count}, open_table_errs:{open_table_errs:?}",
             instant.saturating_elapsed().as_millis(),
-            success_count,
-            no_table_count,
-            open_err_count
         );
 
-        if no_table_count == 0 && open_err_count == 0 {
+        if missing_table_count == 0 && open_table_errs.is_empty() {
             Ok(())
         } else {
-            TableOperatorNoCause {
-                msg:  format!(
-                            "Failed to open shard, some tables open failed, shard id:{shard_id}, no table is opened count:{no_table_count}, open error count:{open_err_count}"),
-            }.fail()
+            let msg = format!(
+                "Failed to open shard, some tables open failed, shard id:{shard_id}, \
+                missing_table_count:{missing_table_count}, \
+                open_err_count:{}",
+                open_table_errs.len()
+            );
+
+            TableOperatorNoCause { msg }.fail()
         }
     }
 
@@ -131,11 +131,8 @@ impl TableOperator {
         }
 
         info!(
-            "Close shard finished, shard id:{}, cost:{}ms, success_count:{}, close_table_errs:{:?}",
-            shard_id,
+            "Close shard finished, shard id:{shard_id}, cost:{}ms, success_count:{success_count}, close_table_errs:{close_table_errs:?}",
             instant.saturating_elapsed().as_millis(),
-            success_count,
-            close_table_errs,
         );
 
         if close_table_errs.is_empty() {

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -105,7 +105,7 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Update on a frozen shard, shard_id:{shard_id}\nBacktrace:\n{backtrace}",))]
+    #[snafu(display("Update on a frozen shard, shard_id:{shard_id}.\nBacktrace:\n{backtrace}",))]
     UpdateFrozenShard {
         shard_id: ShardId,
         backtrace: Backtrace,

--- a/cluster/src/lib.rs
+++ b/cluster/src/lib.rs
@@ -105,6 +105,12 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
+    #[snafu(display("Update on a frozen shard, shard_id:{shard_id}\nBacktrace:\n{backtrace}",))]
+    UpdateFrozenShard {
+        shard_id: ShardId,
+        backtrace: Backtrace,
+    },
+
     #[snafu(display(
         "Cluster nodes are not found in the topology, version:{version}.\nBacktrace:\n{backtrace}",
     ))]
@@ -127,7 +133,14 @@ pub trait Cluster {
     async fn start(&self) -> Result<()>;
     async fn stop(&self) -> Result<()>;
     async fn open_shard(&self, shard_info: &ShardInfo) -> Result<TablesOfShard>;
+    /// Close the shard.
+    ///
+    /// Return error if the shard is not found.
     async fn close_shard(&self, req: ShardId) -> Result<TablesOfShard>;
+    /// Freeze the shard to reject create/drop table on the shard.
+    ///
+    /// Return error if the shard is not found.
+    async fn freeze_shard(&self, req: ShardId) -> Result<TablesOfShard>;
     async fn create_table_on_shard(&self, req: &CreateTableOnShardRequest) -> Result<()>;
     async fn drop_table_on_shard(&self, req: &DropTableOnShardRequest) -> Result<()>;
     async fn open_table_on_shard(&self, req: &OpenTableOnShardRequest) -> Result<()>;

--- a/cluster/src/shard_lock_manager.rs
+++ b/cluster/src/shard_lock_manager.rs
@@ -669,7 +669,7 @@ impl ShardLockManager {
         OnExpired: FnOnce(ShardId) -> Fut + Send + 'static,
         Fut: Future<Output = ()> + Send + 'static,
     {
-        info!("Try to grant lock for shard:{shard_id}");
+        info!("Try to grant lock for shard, shard_id:{shard_id}");
 
         let mut shard_locks = self.shard_locks.write().await;
         if let Some(shard_lock) = shard_locks.get_mut(&shard_id) {
@@ -698,7 +698,7 @@ impl ShardLockManager {
             shard_locks.insert(shard_id, shard_lock);
         }
 
-        info!("Finish granting lock for shard:{shard_id}");
+        info!("Finish granting lock for shard, shard_id:{shard_id}");
         Ok(true)
     }
 
@@ -707,7 +707,7 @@ impl ShardLockManager {
     /// If the lock is not exist, return false. And the `on_lock_expired` won't
     /// be triggered.
     pub async fn revoke_lock(&self, shard_id: u32) -> Result<bool> {
-        info!("Try to revoke lock for shard:{shard_id}");
+        info!("Try to revoke lock for shard, shard_id:{shard_id}");
 
         let mut shard_locks = self.shard_locks.write().await;
         let shard_lock = shard_locks.remove(&shard_id);
@@ -716,7 +716,7 @@ impl ShardLockManager {
                 let mut etcd_client = self.etcd_client.clone();
                 v.revoke(&mut etcd_client).await?;
 
-                info!("Finish revoking lock for shard:{shard_id}");
+                info!("Finish revoking lock for shard, shard_id:{shard_id}");
                 Ok(true)
             }
             None => {

--- a/cluster/src/shard_tables_cache.rs
+++ b/cluster/src/shard_tables_cache.rs
@@ -54,14 +54,14 @@ impl ShardTablesCache {
         self.inner.write().unwrap().remove(shard_id)
     }
 
-    /// Insert or update the tables of one shard.
+    /// Insert the tables of one shard.
     pub fn insert(&self, tables_of_shard: TablesOfShard) {
         self.inner.write().unwrap().insert(tables_of_shard)
     }
 
     /// Freeze the shard.
     pub fn freeze(&self, shard_id: ShardId) -> Option<TablesOfShard> {
-        self.inner.write().unwrap().freeze_shard(shard_id)
+        self.inner.write().unwrap().freeze(shard_id)
     }
 
     /// Try to insert a new table to the shard with a newer version.
@@ -164,7 +164,7 @@ impl Inner {
         self.tables_by_shard.remove(&shard_id).map(|v| v.entry)
     }
 
-    fn freeze_shard(&mut self, shard_id: ShardId) -> Option<TablesOfShard> {
+    fn freeze(&mut self, shard_id: ShardId) -> Option<TablesOfShard> {
         let tables_of_shard = self.tables_by_shard.get_mut(&shard_id)?;
         tables_of_shard.frozen = true;
 

--- a/cluster/src/shard_tables_cache.rs
+++ b/cluster/src/shard_tables_cache.rs
@@ -111,13 +111,6 @@ struct TablesOfShardCacheEntry {
     frozen: bool,
 }
 
-impl TablesOfShardCacheEntry {
-    #[inline]
-    fn is_frozen(&self) -> bool {
-        self.frozen
-    }
-}
-
 #[derive(Debug, Default)]
 struct Inner {
     // Tables organized by shard.
@@ -204,7 +197,7 @@ impl Inner {
             })?;
 
         ensure!(
-            !tables_of_shard.is_frozen(),
+            !tables_of_shard.frozen,
             UpdateFrozenShard {
                 shard_id: curr_shard.id,
             }
@@ -254,7 +247,7 @@ impl Inner {
             })?;
 
         ensure!(
-            !tables_of_shard.is_frozen(),
+            !tables_of_shard.frozen,
             UpdateFrozenShard {
                 shard_id: curr_shard.id,
             }

--- a/router/src/cluster_based.rs
+++ b/router/src/cluster_based.rs
@@ -199,6 +199,10 @@ mod tests {
             unimplemented!();
         }
 
+        async fn freeze_shard(&self, _: ShardId) -> cluster::Result<TablesOfShard> {
+            unimplemented!();
+        }
+
         async fn create_table_on_shard(
             &self,
             _req: &CreateTableOnShardRequest,

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -306,7 +306,7 @@ async fn handle_open_shard(ctx: HandlerContext, request: OpenShardRequest) -> Re
 }
 
 async fn do_close_shard(ctx: &HandlerContext, shard_id: ShardId) -> Result<()> {
-    info!("Do close shard begins, shard_id:{shard_id:?}");
+    info!("Do close shard begins, shard_id:{shard_id}");
     let tables_of_shard =
         ctx.cluster
             .freeze_shard(shard_id)
@@ -316,6 +316,7 @@ async fn do_close_shard(ctx: &HandlerContext, shard_id: ShardId) -> Result<()> {
                 code: StatusCode::Internal,
                 msg: "fail to freeze shard before close it in cluster",
             })?;
+    info!("Freeze shard before closing, shard_id:{shard_id}");
 
     let catalog_name = &ctx.default_catalog.clone();
     let shard_info = tables_of_shard.shard_info;

--- a/server/src/grpc/meta_event_service/shard_operation.rs
+++ b/server/src/grpc/meta_event_service/shard_operation.rs
@@ -1,6 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
-
-// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Implementation of operations on shards.
 


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
- Remove the shard from the cluster topology only after it is closed successfully.
- Freeze the shard to avoid any updates on it before close the shard, and do shard close with the tables of the frozen shard.
- Add some logs for open/close shards.
## Test Plan 
Test with CeresMeta, and trigger closing shard.
