### PR TITLE
feat: shard based manifest recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build-arm64:
 build-with-console:
 	ls -alh
 	cd $(DIR); RUSTFLAGS="--cfg tokio_unstable" cargo build --release
+
 test:
 	cd $(DIR); cargo test --workspace -- --test-threads=4
 

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -11,7 +11,7 @@ use crate::{
         engine::{DoManifestSnapshot, FlushTable, Result},
         flush_compaction::{Flusher, TableFlushOptions},
     },
-    manifest::{ManifestRef, SnapshotRequest},
+    manifest::{ManifestRef, DoSnapshotRequest},
     space::SpaceRef,
 };
 
@@ -50,7 +50,7 @@ impl Closer {
             })?;
 
         // Force manifest to do snapshot.
-        let snapshot_request = SnapshotRequest {
+        let snapshot_request = DoSnapshotRequest {
             space_id: self.space.id,
             table_id: table_data.id,
             shard_id: table_data.shard_info.shard_id,

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -11,7 +11,7 @@ use crate::{
         engine::{DoManifestSnapshot, FlushTable, Result},
         flush_compaction::{Flusher, TableFlushOptions},
     },
-    manifest::{ManifestRef, DoSnapshotRequest},
+    manifest::{DoSnapshotRequest, ManifestRef},
     space::SpaceRef,
 };
 

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -208,7 +208,7 @@ pub enum Error {
 
     #[snafu(display("Failed to open manifest, err:{}", source))]
     OpenManifest {
-        source: crate::manifest::details::Error,
+        source: crate::manifest::error::Error,
     },
 
     #[snafu(display("Failed to find table, msg:{}.\nBacktrace:\n{}", msg, backtrace))]

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -213,6 +213,12 @@ pub enum Error {
 
     #[snafu(display("Failed to find table, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
     TableNotExist { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to recover manifest, err:{}", source))]
+    RecoverManifest {
+        source: GenericError,
+    },
+
 }
 
 define_result!(Error);
@@ -244,7 +250,8 @@ impl From<Error> for table_engine::engine::Error {
             | Error::CreateOpenFailedTable { .. }
             | Error::DoManifestSnapshot { .. }
             | Error::OpenManifest { .. }
-            | Error::TableNotExist { .. } => Self::Unexpected {
+            | Error::TableNotExist { .. }
+            | Error::RecoverManifest { .. } => Self::Unexpected {
                 source: Box::new(err),
             },
         }

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -30,7 +30,7 @@ use crate::{
         write::MemTableWriter,
         Instance, SpaceStore,
     },
-    manifest::{details::ManifestImpl, LoadRequest},
+    manifest::{details::ManifestImpl, DoSnapshotRequest, RecoverRequest, TableInSpace},
     payload::{ReadPayload, WalDecoder},
     row_iter::IterOptions,
     space::{SpaceRef, Spaces},
@@ -180,14 +180,13 @@ impl Instance {
         // Load manifest, also create a new snapshot at startup.
         let table_id = request.table_id;
         let space_id = engine::build_space_id(request.schema_id);
-        let load_req = LoadRequest {
-            space_id,
-            table_id,
+        let recover_req = RecoverRequest {
             shard_id: request.shard_id,
+            tables: vec![TableInSpace { table_id, space_id }],
         };
         self.space_store
             .manifest
-            .recover(&load_req)
+            .recover(&recover_req)
             .await
             .context(ReadMetaUpdate {
                 table_id: request.table_id,

--- a/analytic_engine/src/manifest/error.rs
+++ b/analytic_engine/src/manifest/error.rs
@@ -92,6 +92,16 @@ pub enum Error {
 
     #[snafu(display("Failed to load snapshot, err:{}", source))]
     LoadSnapshot { source: GenericError },
+
+    #[snafu(display("Failed to recover from storage, msg:{}, err:{}", msg, source))]
+    RecoverFromStorageWithCause { msg: String, source: GenericError },
+
+    #[snafu(display(
+        "Failed to recover from storage, msg:{}.\nBacktrace:\n{}",
+        msg,
+        backtrace
+    ))]
+    RecoverFromStorageNoCause { msg: String, backtrace: Backtrace },
 }
 
 define_result!(Error);

--- a/analytic_engine/src/manifest/error.rs
+++ b/analytic_engine/src/manifest/error.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use common_util::{define_result, error::GenericError};
-use snafu::{Snafu, Backtrace};
+use snafu::{Backtrace, Snafu};
 use wal::manager::WalLocation;
 
 #[derive(Debug, Snafu)]

--- a/analytic_engine/src/manifest/error.rs
+++ b/analytic_engine/src/manifest/error.rs
@@ -1,0 +1,97 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use common_util::{define_result, error::GenericError};
+use snafu::{Snafu, Backtrace};
+use wal::manager::WalLocation;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum Error {
+    #[snafu(display(
+        "Failed to encode payloads, wal_location:{:?}, err:{}",
+        wal_location,
+        source
+    ))]
+    EncodePayloads {
+        wal_location: WalLocation,
+        source: wal::manager::Error,
+    },
+
+    #[snafu(display("Failed to write update to wal, err:{}", source))]
+    WriteWal { source: wal::manager::Error },
+
+    #[snafu(display("Failed to read wal, err:{}", source))]
+    ReadWal { source: wal::manager::Error },
+
+    #[snafu(display("Failed to read log entry, err:{}", source))]
+    ReadEntry { source: wal::manager::Error },
+
+    #[snafu(display("Failed to apply table meta update, err:{}", source))]
+    ApplyUpdate {
+        source: crate::manifest::meta_snapshot::Error,
+    },
+
+    #[snafu(display("Failed to clean wal, err:{}", source))]
+    CleanWal { source: wal::manager::Error },
+
+    #[snafu(display(
+        "Failed to store snapshot, err:{}.\nBacktrace:\n{:?}",
+        source,
+        backtrace
+    ))]
+    StoreSnapshot {
+        source: object_store::ObjectStoreError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "Failed to fetch snapshot, err:{}.\nBacktrace:\n{:?}",
+        source,
+        backtrace
+    ))]
+    FetchSnapshot {
+        source: object_store::ObjectStoreError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
+        "Failed to decode snapshot, err:{}.\nBacktrace:\n{:?}",
+        source,
+        backtrace
+    ))]
+    DecodeSnapshot {
+        source: prost::DecodeError,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display("Failed to build snapshot, msg:{}.\nBacktrace:\n{:?}", msg, backtrace))]
+    BuildSnapshotNoCause { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to build snapshot, msg:{}, err:{}", msg, source))]
+    BuildSnapshotWithCause { msg: String, source: GenericError },
+
+    #[snafu(display(
+        "Failed to apply edit to table, msg:{}.\nBacktrace:\n{:?}",
+        msg,
+        backtrace
+    ))]
+    ApplyUpdateToTableNoCause { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to apply edit to table, msg:{}, err:{}", msg, source))]
+    ApplyUpdateToTableWithCause { msg: String, source: GenericError },
+
+    #[snafu(display(
+        "Failed to apply snapshot to table, msg:{}.\nBacktrace:\n{:?}",
+        msg,
+        backtrace
+    ))]
+    ApplySnapshotToTableNoCause { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to apply snapshot to table, msg:{}, err:{}", msg, source))]
+    ApplySnapshotToTableWithCause { msg: String, source: GenericError },
+
+    #[snafu(display("Failed to load snapshot, err:{}", source))]
+    LoadSnapshot { source: GenericError },
+}
+
+define_result!(Error);

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -3,10 +3,10 @@
 //! Manage meta data of the engine
 
 pub mod details;
+pub mod error;
 pub mod meta_edit;
 pub mod meta_snapshot;
 mod storage;
-pub mod error;
 
 use std::{fmt, sync::Arc};
 
@@ -30,13 +30,11 @@ pub struct TableInSpace {
 }
 
 #[derive(Debug)]
-pub struct LoadRequest {
+pub struct DoSnapshotRequest {
     pub space_id: SpaceId,
     pub table_id: TableId,
     pub shard_id: ShardId,
 }
-
-pub type SnapshotRequest = LoadRequest;
 
 /// Manifest holds meta data of all tables.
 #[async_trait]
@@ -47,16 +45,14 @@ pub trait Manifest: Send + Sync + fmt::Debug {
     /// Recover table metas from storage.
     async fn recover(&self, load_req: &RecoverRequest) -> GenericResult<Vec<RecoverResult>>;
 
-    async fn do_snapshot(&self, request: SnapshotRequest) -> GenericResult<()>;
+    async fn do_snapshot(&self, request: DoSnapshotRequest) -> GenericResult<()>;
 }
 
 pub type ManifestRef = Arc<dyn Manifest>;
 
-struct TableResult<T> {
+pub struct TableResult<T> {
     pub table_id: TableId,
     pub result: GenericResult<T>,
 }
 
 pub type RecoverResult = TableResult<()>;
-
-

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -5,6 +5,8 @@
 pub mod details;
 pub mod meta_edit;
 pub mod meta_snapshot;
+mod storage;
+pub mod error;
 
 use std::{fmt, sync::Arc};
 
@@ -56,3 +58,5 @@ struct TableResult<T> {
 }
 
 pub type RecoverResult = TableResult<()>;
+
+

--- a/analytic_engine/src/manifest/mod.rs
+++ b/analytic_engine/src/manifest/mod.rs
@@ -15,6 +15,18 @@ use table_engine::table::TableId;
 
 use crate::{manifest::meta_edit::MetaEditRequest, space::SpaceId};
 
+#[derive(Debug, Clone)]
+pub struct RecoverRequest {
+    pub tables: Vec<TableInSpace>,
+    pub shard_id: ShardId,
+}
+
+#[derive(Debug, Clone)]
+pub struct TableInSpace {
+    pub table_id: TableId,
+    pub space_id: SpaceId,
+}
+
 #[derive(Debug)]
 pub struct LoadRequest {
     pub space_id: SpaceId,
@@ -23,6 +35,7 @@ pub struct LoadRequest {
 }
 
 pub type SnapshotRequest = LoadRequest;
+
 /// Manifest holds meta data of all tables.
 #[async_trait]
 pub trait Manifest: Send + Sync + fmt::Debug {
@@ -30,9 +43,16 @@ pub trait Manifest: Send + Sync + fmt::Debug {
     async fn apply_edit(&self, request: MetaEditRequest) -> GenericResult<()>;
 
     /// Recover table metas from storage.
-    async fn recover(&self, load_request: &LoadRequest) -> GenericResult<()>;
+    async fn recover(&self, load_req: &RecoverRequest) -> GenericResult<Vec<RecoverResult>>;
 
     async fn do_snapshot(&self, request: SnapshotRequest) -> GenericResult<()>;
 }
 
 pub type ManifestRef = Arc<dyn Manifest>;
+
+struct TableResult<T> {
+    pub table_id: TableId,
+    pub result: GenericResult<T>,
+}
+
+pub type RecoverResult = TableResult<()>;

--- a/analytic_engine/src/manifest/storage.rs
+++ b/analytic_engine/src/manifest/storage.rs
@@ -58,6 +58,7 @@ pub trait MetaUpdateLogStore: std::fmt::Debug + Clone {
 
 pub enum ScanLogRequest {
     Table(ScanTableRequest),
+    #[allow(dead_code)]
     Region(ScanRegionRequest),
 }
 
@@ -93,10 +94,6 @@ pub struct ObjectStoreBasedSnapshotStore {
 impl ObjectStoreBasedSnapshotStore {
     const CURRENT_SNAPSHOT_NAME: &str = "current";
     const SNAPSHOT_PATH_PREFIX: &str = "manifest/snapshot";
-
-    pub fn new(store: ObjectStoreRef) -> Self {
-        Self { store }
-    }
 
     pub fn snapshot_path(space_id: SpaceId, table_id: TableId) -> Path {
         format!(

--- a/analytic_engine/src/manifest/storage.rs
+++ b/analytic_engine/src/manifest/storage.rs
@@ -1,0 +1,302 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::collections::VecDeque;
+
+use common_types::SequenceNumber;
+use common_util::error::BoxError;
+use log::warn;
+use object_store::{Path, ObjectStoreRef};
+use parquet::data_type::AsBytes;
+use prost::Message;
+use snafu::ResultExt;
+use table_engine::table::TableId;
+use wal::{manager::{ReadBoundary, WalLocation, RegionId, WalManagerRef, BatchLogIteratorAdapter, ScanContext, WriteContext, ReadContext, ReadRequest}, kv_encoder::LogBatchEncoder, log_batch::LogEntry};
+
+use super::{details::Options, meta_edit::{MetaUpdatePayload, MetaUpdate, Snapshot, MetaUpdateDecoder}};
+use async_trait::async_trait;
+use crate::{manifest::error::*, space::SpaceId}; 
+use ceresdbproto::manifest as manifest_pb;
+
+/// Manifest Snapshot store
+#[async_trait]
+pub trait MetaUpdateSnapshotStore: std::fmt::Debug + Clone {
+    async fn store(&self, request: StoreSnapshotRequest) -> Result<()>;
+
+    async fn load(&self, request: LoadSnapshotRequest) -> Result<Option<Snapshot>>;
+}
+
+pub struct StoreSnapshotRequest {
+    pub snapshot: Snapshot,
+    pub snapshot_path: Path,    
+}
+
+pub struct LoadSnapshotRequest {
+    pub snapshot_path: Path,    
+}
+
+/// Manifest Log store
+#[async_trait]
+pub trait MetaUpdateLogStore: std::fmt::Debug + Clone {
+    type Iter: MetaUpdateLogEntryIterator + Send;
+
+    async fn scan(&self, request: ScanRequest) -> Result<Self::Iter>;    
+
+    async fn append(&self, request: AppendRequest) -> Result<SequenceNumber>;
+
+    async fn delete_up_to(&self, request: DeleteRequest) -> Result<()>;
+}
+
+pub enum ScanRequest {
+    Table(ScanTableRequest),
+    Region(ScanRegionRequest)
+}
+
+pub struct ScanTableRequest {
+    pub opts: Options,
+    pub location: WalLocation,
+    pub start: ReadBoundary,    
+}
+
+pub struct ScanRegionRequest {
+    pub opts: Options,
+    pub region_id: RegionId,
+}
+
+pub struct AppendRequest {
+    opts: Options,
+    location: WalLocation,
+    meta_update: MetaUpdate,
+}
+
+pub struct DeleteRequest {
+    pub opts: Options,
+    pub location: WalLocation,
+    pub inclusive_end: SequenceNumber        
+}
+
+/// Object store impl for manifest snapshot store
+#[derive(Debug, Clone)]
+pub struct ObjectStoreBasedSnapshotStore {
+    pub store: ObjectStoreRef,
+}
+
+impl ObjectStoreBasedSnapshotStore {
+    const CURRENT_SNAPSHOT_NAME: &str = "current";
+    const SNAPSHOT_PATH_PREFIX: &str = "manifest/snapshot";
+
+    pub fn new(store: ObjectStoreRef) -> Self {
+        Self {
+            store,
+        }
+    }
+
+    pub fn snapshot_path(space_id: SpaceId, table_id: TableId) -> Path {
+        format!(
+            "{}/{}/{}/{}",
+            Self::SNAPSHOT_PATH_PREFIX,
+            space_id,
+            table_id,
+            Self::CURRENT_SNAPSHOT_NAME,
+        )
+        .into()
+    }
+}
+
+#[async_trait]
+impl MetaUpdateSnapshotStore for ObjectStoreBasedSnapshotStore {
+    /// Store the latest snapshot to the underlying store by overwriting the old
+    /// snapshot.
+    async fn store(&self, request: StoreSnapshotRequest) -> Result<()> {
+        let snapshot_pb = manifest_pb::Snapshot::from(request.snapshot);
+        let payload = snapshot_pb.encode_to_vec();
+        
+        // The atomic write is ensured by the [`ObjectStore`] implementation.
+        self.store
+            .put(&request.snapshot_path, payload.into())
+            .await
+            .context(StoreSnapshot)?;
+
+        Ok(())
+    }
+
+    /// Load the `current_snapshot` file from the underlying store, and with the
+    /// mapping info in it load the latest snapshot file then.
+    async fn load(&self, request: LoadSnapshotRequest) -> Result<Option<Snapshot>> {
+        let get_res = self.store.get(&request.snapshot_path).await;
+        if let Err(object_store::ObjectStoreError::NotFound { path, source }) = &get_res {
+            warn!(
+                "Current snapshot file doesn't exist, path:{}, err:{}",
+                path, source
+            );
+            return Ok(None);
+        };
+
+        // TODO: currently, this is just a workaround to handle the case where the error
+        // is not thrown as [object_store::ObjectStoreError::NotFound].
+        if let Err(err) = &get_res {
+            let err_msg = err.to_string().to_lowercase();
+            if err_msg.contains("404") || err_msg.contains("not found") {
+                warn!("Current snapshot file doesn't exist, err:{}", err);
+                return Ok(None);
+            }
+        }
+
+        let payload = get_res
+            .context(FetchSnapshot)?
+            .bytes()
+            .await
+            .context(FetchSnapshot)?;
+        let snapshot_pb =
+            manifest_pb::Snapshot::decode(payload.as_bytes()).context(DecodeSnapshot)?;
+        let snapshot = Snapshot::try_from(snapshot_pb)
+            .box_err()
+            .context(LoadSnapshot)?;
+
+        Ok(Some(snapshot))
+    }
+}
+
+/// Wal impl for manifest log store
+#[derive(Debug, Clone)]
+pub struct WalBasedLogStore {
+    pub wal_manager: WalManagerRef,
+}
+
+impl WalBasedLogStore {
+    async fn scan_logs_of_table(&self, request: ScanTableRequest) -> Result<MetaUpdateReaderImpl> {
+        let ctx = ReadContext {
+            timeout: request.opts.scan_timeout.0,
+            batch_size: request.opts.scan_batch_size,
+        };
+
+        let read_req = ReadRequest {
+            location: request.location,
+            start: request.start,
+            end: ReadBoundary::Max,
+        };
+
+        let iter = self
+            .wal_manager
+            .read_batch(&ctx, &read_req)
+            .await
+            .context(ReadWal)?;
+
+        Ok(MetaUpdateReaderImpl {
+            iter,
+            has_next: true,
+            buffer: VecDeque::with_capacity(ctx.batch_size),
+        })
+    }
+
+    async fn scan_logs_of_region(&self, request: ScanRegionRequest) -> Result<MetaUpdateReaderImpl> {
+        let ctx = ScanContext {
+            timeout: request.opts.scan_timeout.0,
+            batch_size: request.opts.scan_batch_size,
+        };
+
+        let scan_req = wal::manager::ScanRequest {
+            region_id: request.region_id,
+        };
+
+        let iter = self
+            .wal_manager
+            .scan(&ctx, &scan_req)
+            .await
+            .context(ReadWal)?;
+
+        Ok(MetaUpdateReaderImpl {
+            iter,
+            has_next: true,
+            buffer: VecDeque::with_capacity(ctx.batch_size),
+        })
+    }
+}   
+
+#[async_trait]
+impl MetaUpdateLogStore for WalBasedLogStore {
+    type Iter = MetaUpdateReaderImpl;
+
+    async fn scan(&self, request: ScanRequest) -> Result<Self::Iter> {
+        match request {
+            ScanRequest::Table(req) => self.scan_logs_of_table(req).await,
+            ScanRequest::Region(req) => self.scan_logs_of_region(req).await,
+        }
+    }    
+
+    async fn append(&self, request: AppendRequest) -> Result<SequenceNumber> {
+        let payload = MetaUpdatePayload::from(request.meta_update);
+        let log_batch_encoder = LogBatchEncoder::create(request.location);
+        let log_batch = log_batch_encoder.encode(&payload).context(EncodePayloads {
+            wal_location: request.location
+        })?;
+
+        let write_ctx = WriteContext {
+            timeout: request.opts.store_timeout.0,
+        };
+
+        self.wal_manager
+            .write(&write_ctx, &log_batch)
+            .await
+            .context(WriteWal)
+    }
+
+    async fn delete_up_to(&self, request: DeleteRequest) -> Result<()> {
+        self.wal_manager
+            .mark_delete_entries_up_to(request.location, request.inclusive_end)
+            .await
+            .context(CleanWal)
+    }
+}
+
+#[async_trait]
+trait MetaUpdateLogEntryIterator {
+    async fn next_update(&mut self) -> Result<Option<MetaUpdateLogEntry>>;
+}
+
+pub struct MetaUpdateLogEntry {
+    pub sequence: SequenceNumber,
+    pub table_id: TableId,
+    pub meta_update: MetaUpdate,
+}
+
+/// Implementation of [`MetaUpdateLogEntryIterator`].
+#[derive(Debug)]
+pub struct MetaUpdateReaderImpl {
+    iter: BatchLogIteratorAdapter,
+    has_next: bool,
+    buffer: VecDeque<LogEntry<MetaUpdate>>,
+}
+
+#[async_trait]
+impl MetaUpdateLogEntryIterator for MetaUpdateReaderImpl {
+    async fn next_update(&mut self) -> Result<Option<MetaUpdateLogEntry>> {
+        if !self.has_next {
+            return Ok(None);
+        }
+
+        if self.buffer.is_empty() {
+            let decoder = MetaUpdateDecoder;
+            let buffer = std::mem::take(&mut self.buffer);
+            self.buffer = self
+                .iter
+                .next_log_entries(decoder, buffer)
+                .await
+                .context(ReadEntry)?;
+        }
+
+        match self.buffer.pop_front() {
+            Some(entry) => {
+                let log_entry = MetaUpdateLogEntry {
+                    sequence: entry.sequence,
+                    table_id: TableId::new(entry.table_id),
+                    meta_update: entry.payload,
+                };
+                Ok(Some(log_entry))
+            }
+            None => {
+                self.has_next = false;
+                Ok(None)
+            }
+        }
+    }
+}

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -60,7 +60,7 @@ pub enum Error {
 
     #[snafu(display("Failed to open manifest, err:{}", source))]
     OpenManifest {
-        source: crate::manifest::details::Error,
+        source: crate::manifest::error::Error,
     },
 
     #[snafu(display("Failed to open obkv, err:{}", source))]

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -11,10 +11,8 @@ use table_engine::table::TableId;
 
 use crate::{
     manifest::{
-        details::{
-            ApplySnapshotToTableWithCause, ApplyUpdateToTableNoCause, ApplyUpdateToTableWithCause,
-            BuildSnapshotNoCause, TableMetaSet,
-        },
+        error::*,
+        details::TableMetaSet,
         meta_edit::{
             self, AddTableMeta, AlterOptionsMeta, AlterSchemaMeta, DropTableMeta, MetaEditRequest,
             MetaUpdate, VersionEditMeta,
@@ -49,9 +47,9 @@ impl TableMetaSetImpl {
         &self,
         space_id: SpaceId,
         apply_edit: F,
-    ) -> crate::manifest::details::Result<()>
+    ) -> Result<()>
     where
-        F: FnOnce(Arc<Space>) -> crate::manifest::details::Result<()>,
+        F: FnOnce(Arc<Space>) -> Result<()>,
     {
         let spaces = self.spaces.read().unwrap();
         let space = spaces
@@ -66,7 +64,7 @@ impl TableMetaSetImpl {
         &self,
         meta_update: MetaUpdate,
         shard_info: TableShardInfo,
-    ) -> crate::manifest::details::Result<()> {
+    ) -> Result<()> {
         match meta_update {
             MetaUpdate::AddTable(AddTableMeta {
                 space_id,
@@ -199,7 +197,7 @@ impl TableMetaSetImpl {
         &self,
         meta_snapshot: MetaSnapshot,
         shard_info: TableShardInfo,
-    ) -> crate::manifest::details::Result<()> {
+    ) -> Result<()> {
         debug!("TableMetaSet apply snapshot, snapshot :{:?}", meta_snapshot);
 
         let MetaSnapshot {
@@ -264,7 +262,7 @@ impl TableMetaSet for TableMetaSetImpl {
         &self,
         space_id: SpaceId,
         table_id: TableId,
-    ) -> crate::manifest::details::Result<Option<MetaSnapshot>> {
+    ) -> Result<Option<MetaSnapshot>> {
         let spaces = self.spaces.read().unwrap();
         let table_data = spaces
             .get_by_id(space_id)
@@ -311,7 +309,7 @@ impl TableMetaSet for TableMetaSetImpl {
     fn apply_edit_to_table(
         &self,
         request: crate::manifest::meta_edit::MetaEditRequest,
-    ) -> crate::manifest::details::Result<()> {
+    ) -> Result<()> {
         let MetaEditRequest {
             shard_info,
             meta_edit,

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -11,8 +11,8 @@ use table_engine::table::TableId;
 
 use crate::{
     manifest::{
-        error::*,
         details::TableMetaSet,
+        error::*,
         meta_edit::{
             self, AddTableMeta, AlterOptionsMeta, AlterSchemaMeta, DropTableMeta, MetaEditRequest,
             MetaUpdate, VersionEditMeta,
@@ -20,7 +20,7 @@ use crate::{
         meta_snapshot::MetaSnapshot,
     },
     space::{Space, SpaceId, SpacesRef},
-    sst::file::FilePurgerRef,
+    sst::file::{FilePurgerRef},
     table::{
         data::{TableData, TableShardInfo},
         version::{TableVersionMeta, TableVersionSnapshot},
@@ -43,11 +43,7 @@ impl fmt::Debug for TableMetaSetImpl {
 }
 
 impl TableMetaSetImpl {
-    fn find_space_and_apply_edit<F>(
-        &self,
-        space_id: SpaceId,
-        apply_edit: F,
-    ) -> Result<()>
+    fn find_space_and_apply_edit<F>(&self, space_id: SpaceId, apply_edit: F) -> Result<()>
     where
         F: FnOnce(Arc<Space>) -> Result<()>,
     {
@@ -60,11 +56,7 @@ impl TableMetaSetImpl {
         apply_edit(space.clone())
     }
 
-    fn apply_update(
-        &self,
-        meta_update: MetaUpdate,
-        shard_info: TableShardInfo,
-    ) -> Result<()> {
+    fn apply_update(&self, meta_update: MetaUpdate, shard_info: TableShardInfo) -> Result<()> {
         match meta_update {
             MetaUpdate::AddTable(AddTableMeta {
                 space_id,


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
+ Modify the `Manifest` and related trait to support shard based recovery.
+ Concurrently pull tables' snapshots from oss and apply.
+ Load all entries from the shard and apply them to related table.

## Test Plan 
+ Pass the exist ut.
+ Add test about multiple tables recovery on shard based mode.
+ Pass the exist integration test.
