### PR TITLE
feat: add sst-metadata tool to query sst metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6929,6 +6929,7 @@ dependencies = [
  "common_util",
  "env_logger",
  "futures 0.3.28",
+ "num_cpus",
  "object_store 1.2.0",
  "parquet",
  "parquet_ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "crossbeam-utils 0.8.15",
  "env_logger",
  "gag",
+ "hex",
  "lazy_static",
  "libc",
  "log",
@@ -2794,6 +2795,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ build-arm64:
 build-with-console:
 	ls -alh
 	cd $(DIR); RUSTFLAGS="--cfg tokio_unstable" cargo build --release
+
 test:
 	cd $(DIR); cargo test --workspace -- --test-threads=4
 
@@ -125,3 +126,7 @@ dev-setup:
 	echo "Error: Unsupported OS. Exiting..."
 	exit 1
 endif
+
+fix:
+	cargo fmt
+	cargo sort --workspace

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -294,10 +294,7 @@ impl<'a> Reader<'a> {
 
     async fn load_meta_data_from_storage(&self) -> Result<parquet_ext::ParquetMetaDataRef> {
         let file_size = self.load_file_size().await?;
-        let chunk_reader_adapter = ChunkReaderAdapter {
-            path: self.path,
-            store: self.store,
-        };
+        let chunk_reader_adapter = ChunkReaderAdapter::new(self.path, self.store);
 
         let meta_data =
             parquet_ext::meta_data::fetch_parquet_metadata(file_size, &chunk_reader_adapter)
@@ -440,9 +437,15 @@ impl AsyncFileReader for ObjectStoreReader {
     }
 }
 
-struct ChunkReaderAdapter<'a> {
+pub struct ChunkReaderAdapter<'a> {
     path: &'a Path,
     store: &'a ObjectStoreRef,
+}
+
+impl<'a> ChunkReaderAdapter<'a> {
+    pub fn new(path: &'a Path, store: &'a ObjectStoreRef) -> Self {
+        Self { path, store }
+    }
 }
 
 #[async_trait]

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -296,7 +296,7 @@ impl<'a> Reader<'a> {
         let file_size = self.load_file_size().await?;
         let chunk_reader_adapter = ChunkReaderAdapter::new(self.path, self.store);
 
-        let meta_data =
+        let (meta_data, _) =
             parquet_ext::meta_data::fetch_parquet_metadata(file_size, &chunk_reader_adapter)
                 .await
                 .with_context(|| FetchAndDecodeSstMeta {

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -64,6 +64,11 @@ trait Filter: fmt::Debug {
     /// Serialize the bitmap index to binary array.
     fn to_bytes(&self) -> Vec<u8>;
 
+    /// Serialized size
+    fn size(&self) -> usize {
+        self.to_bytes().len()
+    }
+
     /// Deserialize the binary array to bitmap index.
     fn from_bytes(buf: Vec<u8>) -> Result<Self>
     where
@@ -189,6 +194,13 @@ impl RowGroupFilter {
             .as_ref()
             .map(|v| v.contains(data))
     }
+
+    fn size(&self) -> usize {
+        self.column_filters
+            .iter()
+            .map(|cf| cf.as_ref().map(|cf| cf.size()).unwrap_or(0))
+            .sum()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Default)]
@@ -208,6 +220,10 @@ impl ParquetFilter {
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn size(&self) -> usize {
+        self.row_group_filters.iter().map(|f| f.size()).sum()
     }
 }
 
@@ -324,14 +340,22 @@ impl From<ParquetMetaData> for MetaData {
 
 impl fmt::Debug for ParquetMetaData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use common_util::byte::encode;
+
         f.debug_struct("ParquetMetaData")
-            .field("min_key", &self.min_key)
-            .field("max_key", &self.max_key)
+            .field("min_key", &encode(&self.min_key))
+            .field("max_key", &encode(&self.max_key))
             .field("time_range", &self.time_range)
             .field("max_sequence", &self.max_sequence)
             .field("schema", &self.schema)
-            // Avoid the messy output from filter.
-            .field("has_filter", &self.parquet_filter.is_some())
+            .field(
+                "filter_size",
+                &self
+                    .parquet_filter
+                    .as_ref()
+                    .map(|filter| filter.size())
+                    .unwrap_or(0),
+            )
             .field("collapsible_cols_idx", &self.collapsible_cols_idx)
             .finish()
     }

--- a/common_util/Cargo.toml
+++ b/common_util/Cargo.toml
@@ -22,11 +22,11 @@ chrono = { workspace = true }
 common_types = { workspace = true, features = ["test"] }
 crossbeam-utils = "0.8.7"
 env_logger = { workspace = true, optional = true }
+hex = "0.4.3"
 lazy_static = { workspace = true }
 libc = "0.2"
 log = { workspace = true }
 logger = { workspace = true }
-hex = "0.4.3"
 pin-project-lite = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true }

--- a/common_util/Cargo.toml
+++ b/common_util/Cargo.toml
@@ -26,6 +26,7 @@ lazy_static = { workspace = true }
 libc = "0.2"
 log = { workspace = true }
 logger = { workspace = true }
+hex = "0.4.3"
 pin-project-lite = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true }

--- a/common_util/src/byte.rs
+++ b/common_util/src/byte.rs
@@ -1,0 +1,3 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+pub use hex::encode;

--- a/common_util/src/lib.rs
+++ b/common_util/src/lib.rs
@@ -9,6 +9,7 @@ pub mod macros;
 
 // TODO(yingwen): Move some mod into components as a crate
 pub mod alloc_tracker;
+pub mod byte;
 pub mod codec;
 pub mod config;
 pub mod error;

--- a/common_util/src/time.rs
+++ b/common_util/src/time.rs
@@ -6,10 +6,10 @@
 
 use std::{
     convert::TryInto,
-    time::{Duration, Instant},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 
 pub trait DurationExt {
     /// Convert into u64.
@@ -47,7 +47,7 @@ impl InstantExt for Instant {
 
 #[inline]
 pub fn secs_to_nanos(s: u64) -> u64 {
-    s * 1000000000
+    s * 1_000_000_000
 }
 
 #[inline]
@@ -58,6 +58,12 @@ pub fn current_time_millis() -> u64 {
 #[inline]
 pub fn current_as_rfc3339() -> String {
     Utc::now().to_rfc3339()
+}
+
+#[inline]
+pub fn format_as_ymdhms(unix_timestamp: i64) -> String {
+    let dt = DateTime::<Utc>::from(UNIX_EPOCH + Duration::from_millis(unix_timestamp as u64));
+    dt.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
 #[cfg(test)]

--- a/components/parquet_ext/src/meta_data.rs
+++ b/components/parquet_ext/src/meta_data.rs
@@ -21,7 +21,7 @@ pub trait ChunkReader: Sync + Send {
 pub async fn fetch_parquet_metadata(
     file_size: usize,
     file_reader: &dyn ChunkReader,
-) -> Result<ParquetMetaData> {
+) -> Result<(ParquetMetaData, usize)> {
     const FOOTER_LEN: usize = 8;
 
     if file_size < FOOTER_LEN {
@@ -63,5 +63,5 @@ pub async fn fetch_parquet_metadata(
             ParquetError::General(err_msg)
         })?;
 
-    footer::decode_metadata(&metadata_bytes)
+    footer::decode_metadata(&metadata_bytes).map(|v| (v, metadata_len))
 }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -18,6 +18,7 @@ common_types = { workspace = true }
 common_util = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
+num_cpus = "1.15.0"
 object_store = { workspace = true }
 parquet = { workspace = true }
 parquet_ext = { workspace = true }

--- a/tools/src/bin/sst-metadata.rs
+++ b/tools/src/bin/sst-metadata.rs
@@ -115,14 +115,20 @@ async fn run(args: Args) -> Result<()> {
         if args.verbose {
             println!("object_meta:{object_meta:?}, parquet_meta:{parquet_meta:?}");
         } else {
-            let size_mb = *size as f64 / 1024.0 / 1024.0;
+            let size_mb = as_mb(*size);
+            let metadata_mb = as_mb(metadata_size);
+            let filter_mb = as_mb(filter_size);
             println!(
-                "Location:{location}, time_range:[{start}, {end}), size:{size_mb:.3}M, max_seq:{seq}, filter:{filter_size}, metadata:{metadata_size}, row_num:{row_num}"
+                "Location:{location}, time_range:[{start}, {end}), max_seq:{seq}, size:{size_mb:.3}M, filter:{filter_mb:.3}M, metadata:{metadata_mb:.3}M, row_num:{row_num}"
             );
         }
     }
 
     Ok(())
+}
+
+fn as_mb(v: usize) -> f64 {
+    v as f64 / 1024.0 / 1024.0
 }
 
 async fn parse_metadata(

--- a/tools/src/bin/sst-metadata.rs
+++ b/tools/src/bin/sst-metadata.rs
@@ -1,0 +1,76 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! A cli to query sst meta data
+
+use std::sync::Arc;
+
+use analytic_engine::sst::{
+    meta_data::cache::MetaData,
+    parquet::{async_reader::ChunkReaderAdapter, meta_data::ParquetMetaDataRef},
+};
+use anyhow::Result;
+use clap::Parser;
+use common_util::runtime::{self, Runtime};
+use futures::StreamExt;
+use object_store::{LocalFileSystem, ObjectMeta, ObjectStoreRef, Path};
+use parquet_ext::meta_data::fetch_parquet_metadata;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Root dir of storage
+    #[clap(short, long, required(true))]
+    store_path: String,
+
+    /// Sst directory(relative to store_path)
+    #[clap(short, long, required(true))]
+    dir: String,
+}
+
+fn new_runtime(thread_num: usize) -> Runtime {
+    runtime::Builder::default()
+        .thread_name("tools")
+        .worker_threads(thread_num)
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+fn main() {
+    let args = Args::parse();
+    let rt = Arc::new(new_runtime(2));
+    rt.block_on(async move {
+        if let Err(e) = run(args).await {
+            eprintln!("Run failed, err:{e}");
+        }
+    });
+}
+
+async fn run(args: Args) -> Result<()> {
+    let storage = LocalFileSystem::new_with_prefix(args.store_path)?;
+    let storage: ObjectStoreRef = Arc::new(storage);
+    let prefix_path = Path::parse(args.dir)?;
+    let mut ssts = storage.list(Some(&prefix_path)).await?;
+    while let Some(object_meta) = ssts.next().await {
+        let ObjectMeta { location, size, .. } = object_meta?;
+        let md = parse_metadata(&storage, &location, size).await?;
+        let time_range = md.time_range;
+        let seq = md.max_sequence;
+        println!("Location:{location}, time_range:{time_range:?}, size:{size}, max_seq:{seq}");
+    }
+
+    Ok(())
+}
+
+async fn parse_metadata(
+    storage: &ObjectStoreRef,
+    path: &Path,
+    size: usize,
+) -> Result<ParquetMetaDataRef> {
+    let reader = ChunkReaderAdapter::new(path, storage);
+    let parquet_meta_data = fetch_parquet_metadata(size, &reader).await?;
+
+    let md = MetaData::try_new(&parquet_meta_data, true)?;
+    let custom_meta = md.custom();
+    Ok(custom_meta.clone())
+}

--- a/tools/src/bin/sst-metadata.rs
+++ b/tools/src/bin/sst-metadata.rs
@@ -10,7 +10,10 @@ use analytic_engine::sst::{
 };
 use anyhow::Result;
 use clap::Parser;
-use common_util::runtime::{self, Runtime};
+use common_util::{
+    runtime::{self, Runtime},
+    time::format_as_ymdhms,
+};
 use futures::StreamExt;
 use object_store::{LocalFileSystem, ObjectMeta, ObjectStoreRef, Path};
 use parquet_ext::meta_data::fetch_parquet_metadata;
@@ -55,8 +58,10 @@ async fn run(args: Args) -> Result<()> {
         let ObjectMeta { location, size, .. } = object_meta?;
         let md = parse_metadata(&storage, &location, size).await?;
         let time_range = md.time_range;
+        let start = format_as_ymdhms(time_range.inclusive_start().as_i64());
+        let end = format_as_ymdhms(time_range.exclusive_end().as_i64());
         let seq = md.max_sequence;
-        println!("Location:{location}, time_range:{time_range:?}, size:{size}, max_seq:{seq}");
+        println!("Location:{location}, time_range:[{start}, {end}), size:{size}, max_seq:{seq}");
     }
 
     Ok(())

--- a/tools/src/bin/sst-metadata.rs
+++ b/tools/src/bin/sst-metadata.rs
@@ -19,11 +19,7 @@ use tokio::{runtime::Handle, task::JoinSet};
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// Root dir of storage
-    #[clap(short, long, required(true))]
-    store_path: String,
-
-    /// SST directory(relative to store_path)
+    /// SST directory
     #[clap(short, long, required(true))]
     dir: String,
 
@@ -62,12 +58,11 @@ fn main() {
 
 async fn run(args: Args) -> Result<()> {
     let handle = Handle::current();
-    let storage = LocalFileSystem::new_with_prefix(args.store_path)?;
+    let storage = LocalFileSystem::new_with_prefix(&args.dir)?;
     let storage: ObjectStoreRef = Arc::new(storage);
-    let prefix_path = Path::parse(args.dir)?;
 
     let mut join_set = JoinSet::new();
-    let mut ssts = storage.list(Some(&prefix_path)).await?;
+    let mut ssts = storage.list(None).await?;
     while let Some(object_meta) = ssts.next().await {
         let object_meta = object_meta?;
         let storage = storage.clone();


### PR DESCRIPTION
## Related Issues
Closes #

When debug compaction related issue, it's helpful to check sst metadata.

## Detailed Changes
- Add new cli tool `sst-metadata`.

## Test Plan 
Manually
```
$ ./target/release/sst-metadata --dir ~/bench/data/store/2/2199023255817/

Location:2/2199023255817/51491.sst, time_range:[2022-09-05 10:00:00, 2022-09-05 12:00:00), max_seq:305309, size:440.000M, metadata:55.219M, kv:51.565M, filter:38.470M, row_num:14480000
Location:2/2199023255817/53873.sst, time_range:[2022-09-05 10:00:00, 2022-09-05 12:00:00), max_seq:319320, size:666.969M, metadata:83.759M, kv:78.198M, filter:58.342M, row_num:21960000
Location:2/2199023255817/51538.sst, time_range:[2022-09-05 10:00:00, 2022-09-05 12:00:00), max_seq:305001, size:1161.511M, metadata:145.723M, kv:136.025M, filter:101.489M, row_num:38200000
Location:2/2199023255817/53269.sst, time_range:[2022-09-05 10:00:00, 2022-09-05 12:00:00), max_seq:315057, size:1176.751M, metadata:147.631M, kv:137.805M, filter:102.817M, row_num:38700000
Location:2/2199023255817/53973.sst, time_range:[2022-09-05 10:00:00, 2022-09-05 12:00:00), max_seq:320198, size:1183.643M, metadata:148.508M, kv:138.623M, filter:103.428M, row_num:38930000


```

