### PR TITLE
chore: replace DefaultHash with AHasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,7 @@ dependencies = [
 name = "common_types"
 version = "1.2.0"
 dependencies = [
+ "ahash 0.8.3",
  "arrow 38.0.0",
  "arrow_ext",
  "byteorder",

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -30,3 +30,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
+ahash = "0.8.3"

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -15,8 +15,8 @@ default = ["arrow", "datafusion"]
 test = []
 
 [dependencies]
-ahash = "0.8.3"
 # In alphabetical order
+ahash = "0.8.3"
 arrow = { workspace = true, optional = true }
 arrow_ext = { workspace = true }
 byteorder = "1.2"

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -15,6 +15,7 @@ default = ["arrow", "datafusion"]
 test = []
 
 [dependencies]
+ahash = "0.8.3"
 # In alphabetical order
 arrow = { workspace = true, optional = true }
 arrow_ext = { workspace = true }
@@ -30,4 +31,3 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
-ahash = "0.8.3"

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -1,11 +1,17 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 // custom hash mod
+
+/* We compared the speed difference between murmur3 and ahash for a string of
+    length 10, and the results show that ahash has a clear advantage.
+    Average time to DefaultHash a string of length 10: 33.6364 nanoseconds
+    Average time to ahash a string of length 10: 19.0412 nanoseconds
+    Average time to murmur3 a string of length 10: 33.0394 nanoseconds
+*/
 pub use ahash::AHasher;
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
-// We compared the speed difference between murmur3 and ahash for a string of
-// length 10, and the results show that ahash has a clear advantage.
+
 pub fn hash64(mut bytes: &[u8]) -> u64 {
     let mut out = [0; 16];
     murmur3_x64_128(&mut bytes, 0, &mut out);

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -1,9 +1,11 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
 // custom hash mod
+pub use ahash::AHasher;
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
-
+// We compared the speed difference between murmur3 and ahash for a string of
+// length 10, and the results show that ahash has a clear advantage.
 pub fn hash64(mut bytes: &[u8]) -> u64 {
     let mut out = [0; 16];
     murmur3_x64_128(&mut bytes, 0, &mut out);

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -3,11 +3,11 @@
 //! Partitioned locks
 
 use std::{
-    collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
+use common_types::hash::AHasher;
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {
     partitions: Vec<RwLock<T>>,
@@ -42,7 +42,7 @@ where
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &RwLock<T> {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
         key.hash(&mut hasher);
 
         &self.partitions[(hasher.finish() as usize) & self.partition_mask]
@@ -77,7 +77,7 @@ where
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &Mutex<T> {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
         key.hash(&mut hasher);
 
         &self.partitions[(hasher.finish() as usize) & self.partition_mask]


### PR DESCRIPTION
## Related Issues
Closes #921 

## Detailed Changes
Replace the hash algorithm from `DefaultHasher` to `ahash` for better performance in partition lock.

## Test Plan
Time cost to compute hash on a 10-char string:
- DefaultHash: 10: 33.6364 ns
- ahash: 10: 19.0412 ns
- murmur3: 10: 33.0394 ns
