### PR TITLE
chore: add hint about `ahash` usage

### DIFF
--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -16,7 +16,7 @@ test = []
 
 [dependencies]
 # In alphabetical order
-ahash = "0.8.3"
+ahash = { version = "0.8.2",  default-features = false, features = ["runtime-rng"] }
 arrow = { workspace = true, optional = true }
 arrow_ext = { workspace = true }
 byteorder = "1.2"

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -16,7 +16,7 @@ test = []
 
 [dependencies]
 # In alphabetical order
-ahash = { version = "0.8.2",  default-features = false, features = ["runtime-rng"] }
+ahash = { version = "0.8.2", default-features = false, features = ["runtime-rng"] }
 arrow = { workspace = true, optional = true }
 arrow_ext = { workspace = true }
 byteorder = "1.2"

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -7,6 +7,9 @@
     Average time to DefaultHash a string of length 10: 33.6364 nanoseconds
     Average time to ahash a string of length 10: 19.0412 nanoseconds
     Average time to murmur3 a string of length 10: 33.0394 nanoseconds
+    Warning: Do not use this hash in non-memory scenarios,
+    One of the reasons is as follows:
+    https://github.com/tkaitchuck/aHash/blob/master/README.md#goals-and-non-goals
 */
 pub use ahash::AHasher;
 use byteorder::{ByteOrder, LittleEndian};

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -7,7 +7,6 @@ use std::{
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-/// Warning, do not use this hash in non-memory scenarios.
 use common_types::hash::AHasher;
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -6,6 +6,7 @@ use std::{
     hash::{Hash, Hasher},
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
+
 /// Warning, do not use this hash in non-memory scenarios.
 use common_types::hash::AHasher;
 /// Simple partitioned `RwLock`
@@ -49,7 +50,7 @@ where
     }
 
     #[cfg(test)]
-    fn get_partition_by_index(&self, index: usize) -> &RwLock<T>{
+    fn get_partition_by_index(&self, index: usize) -> &RwLock<T> {
         &self.partitions[index]
     }
 }
@@ -88,7 +89,7 @@ where
     }
 
     #[cfg(test)]
-    fn get_partition_by_index(&self, index: usize) -> &Mutex<T>{
+    fn get_partition_by_index(&self, index: usize) -> &Mutex<T> {
         &self.partitions[index]
     }
 }


### PR DESCRIPTION
## Related Issues
Closes #921 

## Detailed Changes
Be careful not to use `ahash` for non-memory scenarios.
Note that when an upstream dependency also references the same library, their `FEATURES` are merged.
Reference: 
[1] https://github.com/tkaitchuck/aHash/blob/master/README.md?plain=1#L22
## Test Plan 

