### PR TITLE
fix: http query support querying partitioned sub-table

### DIFF
--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -61,6 +61,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
         let ctx = ProxyContext {
             runtime: self.engine_runtimes.write_runtime.clone(),
             timeout: ctx.timeout,
+            enable_partition_table_access: false,
         };
 
         let result = self.handle_write_internal(ctx, table_request).await?;

--- a/proxy/src/http/sql.rs
+++ b/proxy/src/http/sql.rs
@@ -36,6 +36,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
         let context = Context {
             timeout: ctx.timeout,
             runtime: self.engine_runtimes.read_runtime.clone(),
+            enable_partition_table_access: true,
         };
 
         match self.handle_sql(context, &ctx.schema, &req.query).await? {

--- a/proxy/src/influxdb/mod.rs
+++ b/proxy/src/influxdb/mod.rs
@@ -57,6 +57,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
         let proxy_context = Context {
             timeout: ctx.timeout,
             runtime: self.engine_runtimes.write_runtime.clone(),
+            enable_partition_table_access: false,
         };
         let result = self
             .handle_write_internal(proxy_context, table_request)

--- a/server/src/grpc/storage_service/mod.rs
+++ b/server/src/grpc/storage_service/mod.rs
@@ -137,6 +137,7 @@ impl<Q: QueryExecutor + 'static> StorageService for StorageServiceImpl<Q> {
         let ctx = Context {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
+            enable_partition_table_access: false,
         };
         let stream = Self::stream_sql_query_internal(ctx, proxy, req).await;
 
@@ -159,6 +160,7 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
         let ctx = Context {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
+            enable_partition_table_access: false,
         };
 
         let join_handle = self
@@ -189,6 +191,7 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
         let ctx = Context {
             runtime: self.runtimes.write_runtime.clone(),
             timeout: self.timeout,
+            enable_partition_table_access: false,
         };
 
         let join_handle = self.runtimes.write_runtime.spawn(async move {
@@ -228,6 +231,7 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
         let ctx = Context {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
+            enable_partition_table_access: false,
         };
         let join_handle = self
             .runtimes
@@ -290,6 +294,7 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
         let ctx = Context {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
+            enable_partition_table_access: false,
         };
         let join_handle = self.runtimes.read_runtime.spawn(async move {
             if req.context.is_none() {
@@ -329,6 +334,7 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
         let ctx = Context {
             runtime: self.runtimes.write_runtime.clone(),
             timeout: self.timeout,
+            enable_partition_table_access: false,
         };
 
         let join_handle = self.runtimes.write_runtime.spawn(async move {


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
The http api supports querying sub-tables of partition table.

## Test Plan 
Manual test.
