### PR TITLE
refactor: use partition lock for memory cache

### DIFF
--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -2,6 +2,8 @@
 
 // custom hash mod
 
+use std::hash::BuildHasher;
+
 /* We compared the speed difference between murmur3 and ahash for a string of
     length 10, and the results show that ahash has a clear advantage.
     Average time to DefaultHash a string of length 10: 33.6364 nanoseconds
@@ -14,7 +16,6 @@
 pub use ahash::AHasher;
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
-
 pub fn hash64(mut bytes: &[u8]) -> u64 {
     let mut out = [0; 16];
     murmur3_x64_128(&mut bytes, 0, &mut out);
@@ -22,6 +23,10 @@ pub fn hash64(mut bytes: &[u8]) -> u64 {
     LittleEndian::read_u64(&out[0..8])
 }
 
+pub fn build_fixed_seed_ahasher() -> AHasher {
+    ahash::AHasher::default();
+    ahash::RandomState::with_seeds(0, 0, 0, 0).build_hasher()
+}
 #[cfg(test)]
 mod test {
     use super::*;

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -13,7 +13,7 @@ use std::hash::BuildHasher;
     One of the reasons is as follows:
     https://github.com/tkaitchuck/aHash/blob/master/README.md#goals-and-non-goals
 */
-pub use ahash::AHasher;
+use ahash::AHasher;
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
 pub fn hash64(mut bytes: &[u8]) -> u64 {
@@ -26,6 +26,7 @@ pub fn hash64(mut bytes: &[u8]) -> u64 {
 pub fn build_fixed_seed_ahasher() -> AHasher {
     ahash::RandomState::with_seeds(0, 0, 0, 0).build_hasher()
 }
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -24,7 +24,6 @@ pub fn hash64(mut bytes: &[u8]) -> u64 {
 }
 
 pub fn build_fixed_seed_ahasher() -> AHasher {
-    ahash::AHasher::default();
     ahash::RandomState::with_seeds(0, 0, 0, 0).build_hasher()
 }
 #[cfg(test)]

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-use common_types::hash::AHasher;
+use common_types::hash::{build_fixed_seed_ahasher, AHasher};
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {
     partitions: Vec<RwLock<T>>,
@@ -42,7 +42,8 @@ where
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &RwLock<T> {
-        let mut hasher = AHasher::default();
+        let mut hasher = build_fixed_seed_ahasher();
+
         key.hash(&mut hasher);
 
         &self.partitions[(hasher.finish() as usize) & self.partition_mask]
@@ -81,7 +82,7 @@ impl<T> PartitionedMutex<T> {
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &Mutex<T> {
-        let mut hasher = AHasher::default();
+        let mut hasher = build_fixed_seed_ahasher();
         key.hash(&mut hasher);
         &self.partitions[(hasher.finish() as usize) & self.partition_mask]
     }

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_partitioned_rwlock() {
-        let init_hmap = || HashMap::new();
+        let init_hmap = HashMap::new;
         let test_locked_map = PartitionedRwLock::new(init_hmap, 4);
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_partitioned_mutex() {
-        let init_hmap = || HashMap::new();
+        let init_hmap = HashMap::new;
         let test_locked_map = PartitionedMutex::new(init_hmap, 4);
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_partitioned_mutex_vis_different_partition() {
-        let init_vec = || Vec::<i32>::new();
+        let init_vec = Vec::<i32>::new;
         let test_locked_map = PartitionedMutex::new(init_vec, 4);
         let mutex_first = test_locked_map.get_partition_by_index(0);
 
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_partitioned_rwmutex_vis_different_partition() {
-        let init_vec = || Vec::<i32>::new();
+        let init_vec = Vec::<i32>::new;
         let test_locked_map = PartitionedRwLock::new(init_vec, 4);
         let mutex_first = test_locked_map.get_partition_by_index(0);
         let mut _tmp = mutex_first.write().unwrap();

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -93,7 +93,9 @@ impl<T> PartitionedMutex<T> {
     fn get_partition_by_index(&self, index: usize) -> &Mutex<T> {
         &self.partitions[index]
     }
-
+    /// This method is for testing purposes only.
+    /// Can not be accessed across create #[cfg(test)] method
+    /// https://github.com/rust-lang/cargo/issues/8379
     pub fn get_all_partition(&self) -> &Vec<Mutex<T>> {
         &self.partitions
     }

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-use common_types::hash::{build_fixed_seed_ahasher, AHasher};
+use common_types::hash::{build_fixed_seed_ahasher};
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {
     partitions: Vec<RwLock<T>>,
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_partitioned_mutex() {
-        let hmap: Vec<_> = (0..(1 << 4)).into_iter().map(|_| HashMap::new()).collect();
+        let hmap: Vec<_> = (0..(1 << 4)).map(|_| HashMap::new()).collect();
         let test_locked_map = PartitionedMutex::new(hmap, 4);
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -61,12 +61,11 @@ pub struct PartitionedMutex<T> {
     partition_mask: usize,
 }
 
-impl<T> PartitionedMutex<T>
-where
-{
+impl<T> PartitionedMutex<T> {
     pub fn new(t: Vec<T>, partition_bit: usize) -> Self {
         let partition_num = 1 << partition_bit;
-        let partitions = t.into_iter()
+        let partitions = t
+            .into_iter()
             .map(|i| Mutex::new(i))
             .collect::<Vec<Mutex<T>>>();
         Self {
@@ -90,6 +89,10 @@ where
     #[cfg(test)]
     fn get_partition_by_index(&self, index: usize) -> &Mutex<T> {
         &self.partitions[index]
+    }
+
+    pub fn get_all_partition(&self) -> &Vec<Mutex<T>> {
+        &self.partitions
     }
 }
 
@@ -118,7 +121,7 @@ mod tests {
 
     #[test]
     fn test_partitioned_mutex() {
-        let hmap :  Vec<_>= (0..(1<<4)).into_iter().map(|_|HashMap::new()).collect();
+        let hmap: Vec<_> = (0..(1 << 4)).into_iter().map(|_| HashMap::new()).collect();
         let test_locked_map = PartitionedMutex::new(hmap, 4);
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -55,6 +55,7 @@ where
 }
 
 /// Simple partitioned `Mutex`
+#[derive(Debug)]
 pub struct PartitionedMutex<T> {
     partitions: Vec<Mutex<T>>,
     partition_mask: usize,
@@ -62,13 +63,12 @@ pub struct PartitionedMutex<T> {
 
 impl<T> PartitionedMutex<T>
 where
-    T: Clone,
 {
-    pub fn new(t: T, partition_bit: usize) -> Self {
+    pub fn new(t: Vec<T>, partition_bit: usize) -> Self {
         let partition_num = 1 << partition_bit;
-        let partitions = (0..partition_num)
-            .map(|_| Mutex::new(t.clone()))
-            .collect::<Vec<_>>();
+        let partitions = t.into_iter()
+            .map(|i| Mutex::new(i))
+            .collect::<Vec<Mutex<T>>>();
         Self {
             partitions,
             partition_mask: partition_num - 1,
@@ -118,7 +118,8 @@ mod tests {
 
     #[test]
     fn test_partitioned_mutex() {
-        let test_locked_map = PartitionedMutex::new(HashMap::new(), 4);
+        let hmap :  Vec<_>= (0..(1<<4)).into_iter().map(|_|HashMap::new()).collect();
+        let test_locked_map = PartitionedMutex::new(hmap, 4);
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -93,9 +93,8 @@ impl<T> PartitionedMutex<T> {
     fn get_partition_by_index(&self, index: usize) -> &Mutex<T> {
         &self.partitions[index]
     }
-    /// This method is for testing purposes only.
-    /// Can not be accessed across create #[cfg(test)] method
-    /// https://github.com/rust-lang/cargo/issues/8379
+
+    /// This function should be marked with `#[cfg(test)]`, but there is [an issue](https://github.com/rust-lang/cargo/issues/8379) in cargo, so public this function now.
     pub fn get_all_partition(&self) -> &Vec<Mutex<T>> {
         &self.partitions
     }

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -54,12 +54,9 @@ impl MemCache {
         let cap_per_part = mem_cap
             .checked_mul(NonZeroUsize::new(partition_num).unwrap())
             .context(InvalidCapacity)?;
-        let inner_vec = (0..partition_num)
-            .map(|_| {
-                CLruCache::with_config(CLruCacheConfig::new(cap_per_part).with_scale(CustomScale))
-            })
-            .collect::<Vec<_>>();
-        let inner = PartitionedMutex::new(inner_vec, partition_bits);
+        let inin_lru =
+            || CLruCache::with_config(CLruCacheConfig::new(cap_per_part).with_scale(CustomScale));
+        let inner = PartitionedMutex::new(inin_lru, partition_bits);
         Ok(Self { mem_cap, inner })
     }
 

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -69,7 +69,8 @@ impl MemCache {
     }
 
     fn insert(&self, key: String, value: Bytes) {
-        self.inner.lock(&key).put_with_weight(key, value).unwrap();
+        // don't care error now.
+        _  = self.inner.lock(&key).put_with_weight(key, value);
     }
 
     /// Give a description of the cache state.

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -108,7 +108,7 @@ impl MemCache {
     }
 
     fn peek(&self, key: &str) -> Option<Bytes> {
-        self.partitions.lock(&key).peek(&key)
+        self.partitions.lock(&key).peek(key)
     }
 
     fn insert(&self, key: String, value: Bytes) {

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -5,11 +5,11 @@
 //! 2. Builtin Partition to reduce lock contention
 
 use std::{
-    collections::hash_map::{RandomState},
+    collections::hash_map::RandomState,
     fmt::{self, Display},
     num::NonZeroUsize,
     ops::Range,
-    sync::{Arc},
+    sync::Arc,
 };
 
 use async_trait::async_trait;
@@ -45,9 +45,7 @@ impl Partition {
     fn new(mem_cap: NonZeroUsize) -> Self {
         let cache = CLruCache::with_config(CLruCacheConfig::new(mem_cap).with_scale(CustomScale));
 
-        Self {
-            inner: cache,
-        }
+        Self { inner: cache }
     }
 }
 
@@ -76,12 +74,10 @@ impl Partition {
     }
 }
 
-
-
 pub struct MemCache {
     /// Max memory this store can use
     mem_cap: NonZeroUsize,
-    partitions_tmp: PartitionedMutex<Partition>, 
+    partitions_tmp: PartitionedMutex<Partition>,
     partition_mask: usize,
 }
 
@@ -124,7 +120,8 @@ impl MemCache {
 
     #[cfg(test)]
     fn state_desc(&self) -> String {
-        self.partitions_tmp.get_all_partition()
+        self.partitions_tmp
+            .get_all_partition()
             .iter()
             .map(|part| part.lock().unwrap().keys().join(","))
             .enumerate()

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -70,7 +70,7 @@ impl MemCache {
 
     fn insert(&self, key: String, value: Bytes) {
         // don't care error now.
-        _  = self.inner.lock(&key).put_with_weight(key, value);
+        _ = self.inner.lock(&key).put_with_weight(key, value);
     }
 
     /// Give a description of the cache state.


### PR DESCRIPTION
## Related Issues
Ralated #914 

## Detailed Changes
Add `build_fixed_seed_ahasher` to build fixed  seeds ahasher.
Use PartitionedMutex in `MemCache`.
## Test Plan 
UT.
