### PR TITLE
chore: add `cargo clippy --fix` to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,3 +130,4 @@ endif
 fix:
 	cargo fmt
 	cargo sort --workspace
+	cargo clippy --fix --all-targets --all-features --workspace -- -D warnings


### PR DESCRIPTION
## Related Issues


## Detailed Changes
add `cargo clippy --fix` to Makefile

## Test Plan 

