### PR TITLE
fix: write cancel when flush pending write queue

### DIFF
--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -353,7 +353,7 @@ impl<'a> MemTableWriter<'a> {
 
 impl<'a> Writer<'a> {
     pub(crate) async fn write(&mut self, request: WriteRequest) -> Result<usize> {
-        let _timer = self.table_data.metrics.start_table_write_timer();
+        let _timer = self.table_data.metrics.start_table_write_execute_timer();
         self.table_data.metrics.on_write_request_begin();
 
         self.validate_before_write(&request)?;

--- a/analytic_engine/src/table/metrics.rs
+++ b/analytic_engine/src/table/metrics.rs
@@ -144,6 +144,7 @@ pub struct Metrics {
     table_write_space_flush_wait_duration: Histogram,
     table_write_instance_flush_wait_duration: Histogram,
     table_write_flush_wait_duration: Histogram,
+    table_write_execute_duration: Histogram,
     table_write_total_duration: Histogram,
 }
 
@@ -175,6 +176,8 @@ impl Default for Metrics {
                 .with_label_values(&["wait_instance_flush"]),
             table_write_flush_wait_duration: TABLE_WRITE_DURATION_HISTOGRAM
                 .with_label_values(&["wait_flush"]),
+            table_write_execute_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["execute"]),
             table_write_total_duration: TABLE_WRITE_DURATION_HISTOGRAM
                 .with_label_values(&["total"]),
         }
@@ -210,8 +213,13 @@ impl Metrics {
     }
 
     #[inline]
-    pub fn start_table_write_timer(&self) -> HistogramTimer {
+    pub fn start_table_total_timer(&self) -> HistogramTimer {
         self.table_write_total_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_execute_timer(&self) -> HistogramTimer {
+        self.table_write_execute_duration.start_timer()
     }
 
     #[inline]

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -379,6 +379,12 @@ impl Table for TableImpl {
     }
 
     async fn write(&self, request: WriteRequest) -> Result<usize> {
+        let _timer = self
+            .space_table
+            .table_data()
+            .metrics
+            .start_table_total_timer();
+
         if self.should_queue_write_request(&request) {
             return self.write_with_pending_queue(request).await;
         }

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -178,6 +178,8 @@ impl<Q: QueryExecutor + 'static> RemoteEngineServiceImpl<Q> {
                 code: StatusCode::Internal,
                 msg: "fail to run the join task",
             });
+            // The underlying write can't be cancelled, so just ignore the left write
+            // handles (don't abort them) if any error is encountered.
             match write_result {
                 Ok(res) => match res {
                     Ok(resp) => batch_resp.affected_rows += resp.affected_rows,


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
Currently, the writer for the first request in the pending write queue is responsible for flushing all the writes in the queue, but it can't be ensured to always trigger flush because it may be cancelled when await for the serial exec lock. And this change set replaces the `try_join_all` in the rpc services to avoid such cancellation.

## Test Plan 
Test it manually.
