### PR TITLE
fix: deadlock when stop keepalive bg task

### DIFF
--- a/common_util/src/runtime/mod.rs
+++ b/common_util/src/runtime/mod.rs
@@ -101,6 +101,12 @@ pin_project! {
     }
 }
 
+impl<T> JoinHandle<T> {
+    pub fn abort(&self) {
+        self.inner.abort();
+    }
+}
+
 impl<T> Future for JoinHandle<T> {
     type Output = Result<T>;
 


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
When shard lock is expired, the `on_expired` callback will be executed in the shard lock lease keepalive background task, and the callback will stop the background task and wait for its finish, leading to a deadlock. This change set fixes it by avoid waiting for the background task to finish.

## Test Plan 
Test it by these steps:
- Start ceresmeta and ceresdb;
- Wait all the shards to open on the ceresdb;
- Stop ceresmeta to let the shard lock lease be expired;
- Observe whether the shard lock can be revoked successfully.

