### PR TITLE
fix: the problem of inconsistent error message returned when auto_create_table fails

### DIFF
--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -43,14 +43,13 @@ impl Error {
     /// Get the error message returned to the user.
     pub fn error_message(&self) -> String {
         match self {
-            Error::ErrNoCause { msg, .. } => msg.clone(),
+            Error::ErrNoCause { msg, .. } | Error::InternalNoCause { msg, .. } => msg.clone(),
 
-            Error::ErrWithCause { msg, source, .. } => {
+            Error::ErrWithCause { msg, source, .. } | Error::Internal { msg, source, .. } => {
                 let err_string = source.to_string();
                 let first_line = error_util::remove_backtrace_from_err(&err_string);
                 format!("{msg}. Caused by: {first_line}")
             }
-            Error::Internal { msg, .. } | Error::InternalNoCause { msg, .. } => msg.clone(),
         }
     }
 }

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -279,10 +279,10 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
 
         let output = self
             .execute_plan(request_id, catalog, schema, plan, deadline)
-            .await;
+            .await?;
 
         ensure!(
-            matches!(output, Ok(Output::AffectedRows(_))),
+            matches!(output, Output::AffectedRows(_)),
             ErrNoCause {
                 code: StatusCode::INTERNAL_SERVER_ERROR,
                 msg: "Invalid output type, expect AffectedRows, found Records",


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
* Fix the problem of inconsistent error message returned when auto_create_table fails.
* Grpc returns more detailed error info.

## Test Plan 
Manual test and CI.
