### PR TITLE
feat: ignore column filter when there are too few values

### DIFF
--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -289,7 +289,7 @@ impl SchedulerImpl {
         runtime: Arc<Runtime>,
         config: SchedulerConfig,
         write_sst_max_buffer_size: usize,
-        min_rows_when_build_filter: usize,
+        min_value_num_when_build_filter: usize,
         scan_options: ScanOptions,
     ) -> Self {
         let (tx, rx) = mpsc::channel(config.schedule_channel_len);
@@ -305,7 +305,7 @@ impl SchedulerImpl {
             max_ongoing_tasks: config.max_ongoing_tasks,
             max_unflushed_duration: config.max_unflushed_duration.0,
             write_sst_max_buffer_size,
-            min_rows_when_build_filter,
+            min_value_num_when_build_filter,
             scan_options,
             limit: Arc::new(OngoingTaskLimit {
                 ongoing_tasks: AtomicUsize::new(0),
@@ -384,7 +384,7 @@ struct ScheduleWorker {
     picker_manager: PickerManager,
     max_ongoing_tasks: usize,
     write_sst_max_buffer_size: usize,
-    min_rows_when_build_filter: usize,
+    min_value_num_when_build_filter: usize,
     scan_options: ScanOptions,
     limit: Arc<OngoingTaskLimit>,
     running: Arc<AtomicBool>,
@@ -486,7 +486,7 @@ impl ScheduleWorker {
             num_rows_per_row_group: table_data.table_options().num_rows_per_row_group,
             compression: table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
-            min_rows_when_build_filter: self.min_rows_when_build_filter,
+            min_value_num_when_build_filter: self.min_value_num_when_build_filter,
         };
         let scan_options = self.scan_options.clone();
 
@@ -647,7 +647,7 @@ impl ScheduleWorker {
             space_store: self.space_store.clone(),
             runtime: self.runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
-            min_rows_when_build_filter: self.min_rows_when_build_filter,
+            min_value_num_when_build_filter: self.min_value_num_when_build_filter,
         };
 
         for table_data in &tables_buf {

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -289,6 +289,7 @@ impl SchedulerImpl {
         runtime: Arc<Runtime>,
         config: SchedulerConfig,
         write_sst_max_buffer_size: usize,
+        min_rows_when_build_filter: usize,
         scan_options: ScanOptions,
     ) -> Self {
         let (tx, rx) = mpsc::channel(config.schedule_channel_len);
@@ -304,6 +305,7 @@ impl SchedulerImpl {
             max_ongoing_tasks: config.max_ongoing_tasks,
             max_unflushed_duration: config.max_unflushed_duration.0,
             write_sst_max_buffer_size,
+            min_rows_when_build_filter,
             scan_options,
             limit: Arc::new(OngoingTaskLimit {
                 ongoing_tasks: AtomicUsize::new(0),
@@ -382,6 +384,7 @@ struct ScheduleWorker {
     picker_manager: PickerManager,
     max_ongoing_tasks: usize,
     write_sst_max_buffer_size: usize,
+    min_rows_when_build_filter: usize,
     scan_options: ScanOptions,
     limit: Arc<OngoingTaskLimit>,
     running: Arc<AtomicBool>,
@@ -483,6 +486,7 @@ impl ScheduleWorker {
             num_rows_per_row_group: table_data.table_options().num_rows_per_row_group,
             compression: table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
+            min_rows_when_build_filter: self.min_rows_when_build_filter,
         };
         let scan_options = self.scan_options.clone();
 
@@ -643,6 +647,7 @@ impl ScheduleWorker {
             space_store: self.space_store.clone(),
             runtime: self.runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
+            min_rows_when_build_filter: self.min_rows_when_build_filter,
         };
 
         for table_data in &tables_buf {

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -169,6 +169,7 @@ pub struct Flusher {
 
     pub runtime: RuntimeRef,
     pub write_sst_max_buffer_size: usize,
+    pub min_rows_when_build_filter: usize,
 }
 
 struct FlushTask {
@@ -178,6 +179,7 @@ struct FlushTask {
 
     runtime: RuntimeRef,
     write_sst_max_buffer_size: usize,
+    min_rows_when_build_filter: usize,
 }
 
 impl Flusher {
@@ -282,6 +284,7 @@ impl Flusher {
             space_store: self.space_store.clone(),
             runtime: self.runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
+            min_rows_when_build_filter: self.min_rows_when_build_filter,
         };
         let flush_job = async move { flush_task.run().await };
 
@@ -460,6 +463,7 @@ impl FlushTask {
             num_rows_per_row_group: self.table_data.table_options().num_rows_per_row_group,
             compression: self.table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
+            min_rows_when_build_filter: self.min_rows_when_build_filter,
         };
 
         for time_range in &time_ranges {
@@ -594,6 +598,7 @@ impl FlushTask {
             num_rows_per_row_group: self.table_data.table_options().num_rows_per_row_group,
             compression: self.table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
+            min_rows_when_build_filter: self.min_rows_when_build_filter,
         };
         let mut writer = self
             .space_store

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -169,7 +169,7 @@ pub struct Flusher {
 
     pub runtime: RuntimeRef,
     pub write_sst_max_buffer_size: usize,
-    pub min_rows_when_build_filter: usize,
+    pub min_value_num_when_build_filter: usize,
 }
 
 struct FlushTask {
@@ -179,7 +179,7 @@ struct FlushTask {
 
     runtime: RuntimeRef,
     write_sst_max_buffer_size: usize,
-    min_rows_when_build_filter: usize,
+    min_value_num_when_build_filter: usize,
 }
 
 impl Flusher {
@@ -284,7 +284,7 @@ impl Flusher {
             space_store: self.space_store.clone(),
             runtime: self.runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
-            min_rows_when_build_filter: self.min_rows_when_build_filter,
+            min_value_num_when_build_filter: self.min_value_num_when_build_filter,
         };
         let flush_job = async move { flush_task.run().await };
 
@@ -463,7 +463,7 @@ impl FlushTask {
             num_rows_per_row_group: self.table_data.table_options().num_rows_per_row_group,
             compression: self.table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
-            min_rows_when_build_filter: self.min_rows_when_build_filter,
+            min_value_num_when_build_filter: self.min_value_num_when_build_filter,
         };
 
         for time_range in &time_ranges {
@@ -598,7 +598,7 @@ impl FlushTask {
             num_rows_per_row_group: self.table_data.table_options().num_rows_per_row_group,
             compression: self.table_data.table_options().compression,
             max_buffer_size: self.write_sst_max_buffer_size,
-            min_rows_when_build_filter: self.min_rows_when_build_filter,
+            min_value_num_when_build_filter: self.min_value_num_when_build_filter,
         };
         let mut writer = self
             .space_store

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -153,7 +153,7 @@ pub struct Instance {
     /// Write sst max buffer size
     pub(crate) write_sst_max_buffer_size: usize,
     /// Min rows required when build sst filter
-    pub(crate) min_rows_when_build_filter: usize,
+    pub(crate) min_value_num_when_build_filter: usize,
     /// Max retry limit to flush memtables
     pub(crate) max_retry_flush_limit: usize,
     /// Max bytes per write batch
@@ -273,7 +273,7 @@ impl Instance {
             // Do flush in write runtime
             runtime: self.runtimes.write_runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
-            min_rows_when_build_filter: self.min_rows_when_build_filter,
+            min_value_num_when_build_filter: self.min_value_num_when_build_filter,
         }
     }
 

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -152,6 +152,8 @@ pub struct Instance {
     pub(crate) replay_batch_size: usize,
     /// Write sst max buffer size
     pub(crate) write_sst_max_buffer_size: usize,
+    /// Min rows required when build sst filter
+    pub(crate) min_rows_when_build_filter: usize,
     /// Max retry limit to flush memtables
     pub(crate) max_retry_flush_limit: usize,
     /// Max bytes per write batch
@@ -271,6 +273,7 @@ impl Instance {
             // Do flush in write runtime
             runtime: self.runtimes.write_runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
+            min_rows_when_build_filter: self.min_rows_when_build_filter,
         }
     }
 

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -99,7 +99,7 @@ impl Instance {
             compaction_runtime,
             scheduler_config,
             ctx.config.write_sst_max_buffer_size.as_byte() as usize,
-            ctx.config.min_rows_when_build_filter,
+            ctx.config.min_value_num_when_build_filter,
             scan_options_for_compaction,
         ));
 
@@ -126,7 +126,7 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_byte() as usize,
-            min_rows_when_build_filter: ctx.config.min_rows_when_build_filter,
+            min_value_num_when_build_filter: ctx.config.min_value_num_when_build_filter,
             max_retry_flush_limit: ctx.config.max_retry_flush_limit,
             max_bytes_per_write_batch: ctx
                 .config

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -99,6 +99,7 @@ impl Instance {
             compaction_runtime,
             scheduler_config,
             ctx.config.write_sst_max_buffer_size.as_byte() as usize,
+            ctx.config.min_rows_when_build_filter,
             scan_options_for_compaction,
         ));
 
@@ -125,6 +126,7 @@ impl Instance {
             space_write_buffer_size: ctx.config.space_write_buffer_size,
             replay_batch_size: ctx.config.replay_batch_size,
             write_sst_max_buffer_size: ctx.config.write_sst_max_buffer_size.as_byte() as usize,
+            min_rows_when_build_filter: ctx.config.min_rows_when_build_filter,
             max_retry_flush_limit: ctx.config.max_retry_flush_limit,
             max_bytes_per_write_batch: ctx
                 .config

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -82,7 +82,7 @@ pub struct Config {
     /// Sst background reading parallelism
     pub sst_background_read_parallelism: usize,
     /// Min rows required when build sst filter
-    pub min_rows_when_build_filter: usize,
+    pub min_value_num_when_build_filter: usize,
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
     /// Max retry limit After flush failed
@@ -126,7 +126,7 @@ impl Default for Config {
             sst_background_read_parallelism: 8,
             scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),
-            min_rows_when_build_filter: 20,
+            min_value_num_when_build_filter: 20,
             max_retry_flush_limit: 0,
             max_bytes_per_write_batch: None,
             wal: WalStorageConfig::RocksDB(Box::default()),

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -81,6 +81,8 @@ pub struct Config {
     pub scan_max_record_batches_in_flight: usize,
     /// Sst background reading parallelism
     pub sst_background_read_parallelism: usize,
+    /// Min rows required when build sst filter
+    pub min_rows_when_build_filter: usize,
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
     /// Max retry limit After flush failed
@@ -124,6 +126,7 @@ impl Default for Config {
             sst_background_read_parallelism: 8,
             scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),
+            min_rows_when_build_filter: 20,
             max_retry_flush_limit: 0,
             max_bytes_per_write_batch: None,
             wal: WalStorageConfig::RocksDB(Box::default()),

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -132,6 +132,7 @@ pub struct SstWriteOptions {
     pub num_rows_per_row_group: usize,
     pub compression: Compression,
     pub max_buffer_size: usize,
+    pub min_rows_when_build_filter: usize,
 }
 
 #[derive(Debug, Default)]

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -132,7 +132,7 @@ pub struct SstWriteOptions {
     pub num_rows_per_row_group: usize,
     pub compression: Compression,
     pub max_buffer_size: usize,
-    pub min_rows_when_build_filter: usize,
+    pub min_value_num_when_build_filter: usize,
 }
 
 #[derive(Debug, Default)]

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -118,15 +118,15 @@ impl Filter for Xor8Filter {
 pub struct RowGroupFilterBuilder {
     builders: Vec<Option<Xor8Builder>>,
     column_values: Vec<HashSet<Vec<u8>>>,
-    min_rows_when_build_filter: usize,
+    min_value_num_when_build_filter: usize,
 }
 
 impl RowGroupFilterBuilder {
-    pub(crate) fn with_num_columns(num_col: usize, min_rows_when_build_filter: usize) -> Self {
+    pub(crate) fn with_num_columns(num_col: usize, min_value_num_when_build_filter: usize) -> Self {
         Self {
             builders: vec![None; num_col],
             column_values: vec![HashSet::new(); num_col],
-            min_rows_when_build_filter,
+            min_value_num_when_build_filter,
         }
     }
 
@@ -142,7 +142,7 @@ impl RowGroupFilterBuilder {
             .zip(self.column_values.iter())
             .map(|(b, values)| {
                 // ignore build when distinct column values are less than threshold.
-                if values.len() < self.min_rows_when_build_filter {
+                if values.len() < self.min_value_num_when_build_filter {
                     return Ok(None);
                 }
 

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -457,7 +457,7 @@ mod tests {
     }
 
     #[test]
-    fn test_row_group_filter_builder() {
+    fn test_row_group_filter_builder_normal_case() {
         let mut builders = RowGroupFilterBuilder::with_num_columns(1, 0);
         for key in ["host-123", "host-456", "host-789"] {
             builders.add_key(0, key.as_bytes());
@@ -472,5 +472,17 @@ mod tests {
 
             assert_eq!(expected, actual);
         }
+    }
+
+    #[test]
+    fn test_row_group_filter_builder_none_case() {
+        // Require 10 values to build filter, but only given 3.
+        let mut builders = RowGroupFilterBuilder::with_num_columns(1, 10);
+        for key in ["host-123", "host-456", "host-789"] {
+            builders.add_key(0, key.as_bytes());
+        }
+        let row_group_filter = builders.build().unwrap();
+        assert_eq!(1, row_group_filter.column_filters.len());
+        assert!(row_group_filter.column_filters[0].is_none());
     }
 }

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -139,8 +139,9 @@ impl RowGroupFilterBuilder {
     pub(crate) fn build(self) -> Result<RowGroupFilter> {
         self.builders
             .into_iter()
-            .zip(self.column_values.into_iter())
+            .zip(self.column_values.iter())
             .map(|(b, values)| {
+                // ignore build when distinct column values are less than threshold.
                 if values.len() < self.min_rows_when_build_filter {
                     return Ok(None);
                 }

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -40,6 +40,7 @@ pub struct ParquetSstWriter<'a> {
     store: &'a ObjectStoreRef,
     /// Max row group size.
     num_rows_per_row_group: usize,
+    min_rows_when_build_filter: usize,
     max_buffer_size: usize,
     compression: Compression,
 }
@@ -59,6 +60,7 @@ impl<'a> ParquetSstWriter<'a> {
             hybrid_encoding,
             store,
             num_rows_per_row_group: options.num_rows_per_row_group,
+            min_rows_when_build_filter: options.min_rows_when_build_filter,
             compression: options.compression.into(),
             max_buffer_size: options.max_buffer_size,
         }
@@ -74,6 +76,7 @@ struct RecordBatchGroupWriter {
     input_exhausted: bool,
     meta_data: MetaData,
     num_rows_per_row_group: usize,
+    min_rows_when_build_filter: usize,
     max_buffer_size: usize,
     compression: Compression,
     level: Level,
@@ -147,7 +150,10 @@ impl RecordBatchGroupWriter {
         &self,
         row_group_batch: &[RecordBatchWithKey],
     ) -> Result<RowGroupFilter> {
-        let mut builder = RowGroupFilterBuilder::with_num_columns(row_group_batch[0].num_columns());
+        let mut builder = RowGroupFilterBuilder::with_num_columns(
+            row_group_batch[0].num_columns(),
+            self.min_rows_when_build_filter,
+        );
 
         for partial_batch in row_group_batch {
             for (col_idx, column) in partial_batch.columns().iter().enumerate() {
@@ -287,6 +293,7 @@ impl<'a> SstWriter for ParquetSstWriter<'a> {
             input,
             input_exhausted: false,
             num_rows_per_row_group: self.num_rows_per_row_group,
+            min_rows_when_build_filter: self.min_rows_when_build_filter,
             max_buffer_size: self.max_buffer_size,
             compression: self.compression,
             meta_data: meta.clone(),
@@ -379,6 +386,7 @@ mod tests {
             let sst_write_options = SstWriteOptions {
                 storage_format_hint: StorageFormatHint::Auto,
                 num_rows_per_row_group,
+                min_rows_when_build_filter: 0,
                 compression: table_options::Compression::Uncompressed,
                 max_buffer_size: 0,
             };
@@ -543,6 +551,7 @@ mod tests {
             input: record_batch_stream,
             input_exhausted: false,
             num_rows_per_row_group,
+            min_rows_when_build_filter: 100,
             compression: Compression::UNCOMPRESSED,
             meta_data: MetaData {
                 min_key: Default::default(),

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -40,7 +40,7 @@ pub struct ParquetSstWriter<'a> {
     store: &'a ObjectStoreRef,
     /// Max row group size.
     num_rows_per_row_group: usize,
-    min_rows_when_build_filter: usize,
+    min_value_num_when_build_filter: usize,
     max_buffer_size: usize,
     compression: Compression,
 }
@@ -60,7 +60,7 @@ impl<'a> ParquetSstWriter<'a> {
             hybrid_encoding,
             store,
             num_rows_per_row_group: options.num_rows_per_row_group,
-            min_rows_when_build_filter: options.min_rows_when_build_filter,
+            min_value_num_when_build_filter: options.min_value_num_when_build_filter,
             compression: options.compression.into(),
             max_buffer_size: options.max_buffer_size,
         }
@@ -76,7 +76,7 @@ struct RecordBatchGroupWriter {
     input_exhausted: bool,
     meta_data: MetaData,
     num_rows_per_row_group: usize,
-    min_rows_when_build_filter: usize,
+    min_value_num_when_build_filter: usize,
     max_buffer_size: usize,
     compression: Compression,
     level: Level,
@@ -152,7 +152,7 @@ impl RecordBatchGroupWriter {
     ) -> Result<RowGroupFilter> {
         let mut builder = RowGroupFilterBuilder::with_num_columns(
             row_group_batch[0].num_columns(),
-            self.min_rows_when_build_filter,
+            self.min_value_num_when_build_filter,
         );
 
         for partial_batch in row_group_batch {
@@ -293,7 +293,7 @@ impl<'a> SstWriter for ParquetSstWriter<'a> {
             input,
             input_exhausted: false,
             num_rows_per_row_group: self.num_rows_per_row_group,
-            min_rows_when_build_filter: self.min_rows_when_build_filter,
+            min_value_num_when_build_filter: self.min_value_num_when_build_filter,
             max_buffer_size: self.max_buffer_size,
             compression: self.compression,
             meta_data: meta.clone(),
@@ -386,7 +386,7 @@ mod tests {
             let sst_write_options = SstWriteOptions {
                 storage_format_hint: StorageFormatHint::Auto,
                 num_rows_per_row_group,
-                min_rows_when_build_filter: 0,
+                min_value_num_when_build_filter: 0,
                 compression: table_options::Compression::Uncompressed,
                 max_buffer_size: 0,
             };
@@ -551,7 +551,7 @@ mod tests {
             input: record_batch_stream,
             input_exhausted: false,
             num_rows_per_row_group,
-            min_rows_when_build_filter: 0,
+            min_value_num_when_build_filter: 0,
             compression: Compression::UNCOMPRESSED,
             meta_data: MetaData {
                 min_key: Default::default(),

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -551,7 +551,7 @@ mod tests {
             input: record_batch_stream,
             input_exhausted: false,
             num_rows_per_row_group,
-            min_rows_when_build_filter: 100,
+            min_rows_when_build_filter: 0,
             compression: Compression::UNCOMPRESSED,
             meta_data: MetaData {
                 min_key: Default::default(),

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -52,7 +52,7 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
         num_rows_per_row_group: config.num_rows_per_row_group,
         compression: config.compression,
         max_buffer_size: 1024 * 1024 * 10,
-        min_rows_when_build_filter: 20,
+        min_value_num_when_build_filter: 20,
     };
 
     info!(

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -52,6 +52,7 @@ async fn create_sst_from_stream(config: SstConfig, record_batch_stream: RecordBa
         num_rows_per_row_group: config.num_rows_per_row_group,
         compression: config.compression,
         max_buffer_size: 1024 * 1024 * 10,
+        min_rows_when_build_filter: 20,
     };
 
     info!(

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -108,6 +108,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         compression: Compression::parse_from(&args.compression)
             .with_context(|| format!("invalid compression:{}", args.compression))?,
         max_buffer_size: 10 * 1024 * 1024,
+        min_rows_when_build_filter: 20,
     };
     let output = Path::from(args.output);
     let mut writer = factory

--- a/tools/src/bin/sst-convert.rs
+++ b/tools/src/bin/sst-convert.rs
@@ -108,7 +108,7 @@ async fn run(args: Args, runtime: Arc<Runtime>) -> Result<()> {
         compression: Compression::parse_from(&args.compression)
             .with_context(|| format!("invalid compression:{}", args.compression))?,
         max_buffer_size: 10 * 1024 * 1024,
-        min_rows_when_build_filter: 20,
+        min_value_num_when_build_filter: 20,
     };
     let output = Path::from(args.output);
     let mut writer = factory


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
Introduce a new options `min_value_num_when_build_filter`(default 20), which control column filter build.

Ignore build current column filter when distinct column values are less than it.

## Test Plan 
New UT `test_row_group_filter_builder_none_case`