### PR TITLE
feat: remove duplicated schema covert from arrow schema

### DIFF
--- a/interpreters/src/describe.rs
+++ b/interpreters/src/describe.rs
@@ -1,6 +1,6 @@
 // Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use std::{convert::TryInto, sync::Arc};
+use std::sync::Arc;
 
 use arrow::{
     array::{BooleanArray, StringArray},
@@ -8,6 +8,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use async_trait::async_trait;
+use common_types::record_batch::convert_single_arrow_record_batch;
 use query_engine::executor::RecordBatchVec;
 use query_frontend::plan::DescribeTablePlan;
 use snafu::{ResultExt, Snafu};
@@ -74,7 +75,7 @@ impl DescribeInterpreter {
         )
         .unwrap();
 
-        let record_batch = arrow_record_batch.try_into().unwrap();
+        let record_batch = convert_single_arrow_record_batch(arrow_record_batch).unwrap();
 
         Ok(vec![record_batch])
     }

--- a/interpreters/src/describe.rs
+++ b/interpreters/src/describe.rs
@@ -8,7 +8,6 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use async_trait::async_trait;
-use common_types::record_batch::convert_single_arrow_record_batch;
 use query_engine::executor::RecordBatchVec;
 use query_frontend::plan::DescribeTablePlan;
 use snafu::{ResultExt, Snafu};
@@ -75,7 +74,7 @@ impl DescribeInterpreter {
         )
         .unwrap();
 
-        let record_batch = convert_single_arrow_record_batch(arrow_record_batch).unwrap();
+        let record_batch = arrow_record_batch.try_into().unwrap();
 
         Ok(vec![record_batch])
     }

--- a/interpreters/src/exists.rs
+++ b/interpreters/src/exists.rs
@@ -1,6 +1,6 @@
 // Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use std::{convert::TryInto, sync::Arc};
+use std::sync::Arc;
 
 use arrow::{
     array::UInt8Array,
@@ -8,6 +8,7 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use async_trait::async_trait;
+use common_types::record_batch::convert_single_arrow_record_batch;
 use query_engine::executor::RecordBatchVec;
 use query_frontend::plan::ExistsTablePlan;
 use snafu::{ResultExt, Snafu};
@@ -49,7 +50,7 @@ fn exists_table_result(exists: bool) -> Result<RecordBatchVec> {
     )
     .unwrap();
 
-    let record_batch = arrow_record_batch.try_into().unwrap();
+    let record_batch = convert_single_arrow_record_batch(arrow_record_batch).unwrap();
 
     Ok(vec![record_batch])
 }

--- a/interpreters/src/exists.rs
+++ b/interpreters/src/exists.rs
@@ -8,7 +8,6 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use async_trait::async_trait;
-use common_types::record_batch::convert_single_arrow_record_batch;
 use query_engine::executor::RecordBatchVec;
 use query_frontend::plan::ExistsTablePlan;
 use snafu::{ResultExt, Snafu};
@@ -50,7 +49,7 @@ fn exists_table_result(exists: bool) -> Result<RecordBatchVec> {
     )
     .unwrap();
 
-    let record_batch = convert_single_arrow_record_batch(arrow_record_batch).unwrap();
+    let record_batch = arrow_record_batch.try_into().unwrap();
 
     Ok(vec![record_batch])
 }

--- a/interpreters/src/show.rs
+++ b/interpreters/src/show.rs
@@ -9,7 +9,6 @@ use arrow::{
 };
 use async_trait::async_trait;
 use catalog::{manager::ManagerRef, schema::Schema, Catalog};
-use common_types::record_batch::convert_single_arrow_record_batch;
 use query_frontend::{
     ast::ShowCreateObject,
     plan::{QueryType, ShowCreatePlan, ShowPlan, ShowTablesPlan},
@@ -159,8 +158,7 @@ impl ShowInterpreter {
                 .context(CreateRecordBatch)?
             }
         };
-        let record_batch =
-            convert_single_arrow_record_batch(arrow_record_batch).context(ToCommonRecordType)?;
+        let record_batch = arrow_record_batch.try_into().context(ToCommonRecordType)?;
 
         Ok(Output::Records(vec![record_batch]))
     }
@@ -185,8 +183,7 @@ impl ShowInterpreter {
         )
         .context(CreateRecordBatch)?;
 
-        let record_batch =
-            convert_single_arrow_record_batch(arrow_record_batch).context(ToCommonRecordType)?;
+        let record_batch = arrow_record_batch.try_into().context(ToCommonRecordType)?;
 
         Ok(Output::Records(vec![record_batch]))
     }

--- a/interpreters/src/show_create.rs
+++ b/interpreters/src/show_create.rs
@@ -7,7 +7,6 @@ use arrow::{
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
-use common_types::record_batch::convert_single_arrow_record_batch;
 use datafusion::logical_expr::Expr;
 use datafusion_proto::bytes::Serializeable;
 use log::error;
@@ -59,7 +58,7 @@ impl ShowCreateInterpreter {
         )
         .unwrap();
 
-        let record_batch = convert_single_arrow_record_batch(arrow_record_batch).unwrap();
+        let record_batch = arrow_record_batch.try_into().unwrap();
 
         Ok(vec![record_batch])
     }

--- a/interpreters/src/show_create.rs
+++ b/interpreters/src/show_create.rs
@@ -1,12 +1,13 @@
 // Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
-use std::{collections::HashMap, convert::TryInto, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use arrow::{
     array::StringArray,
     datatypes::{DataType, Field, Schema},
     record_batch::RecordBatch,
 };
+use common_types::record_batch::convert_single_arrow_record_batch;
 use datafusion::logical_expr::Expr;
 use datafusion_proto::bytes::Serializeable;
 use log::error;
@@ -58,7 +59,7 @@ impl ShowCreateInterpreter {
         )
         .unwrap();
 
-        let record_batch = arrow_record_batch.try_into().unwrap();
+        let record_batch = convert_single_arrow_record_batch(arrow_record_batch).unwrap();
 
         Ok(vec![record_batch])
     }

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -473,7 +473,7 @@ mod tests {
     };
     use common_types::{
         column_schema,
-        record_batch::RecordBatch,
+        record_batch::convert_single_arrow_record_batch,
         schema::{self, TIMESTAMP_COLUMN},
     };
     use prom_remote_api::types::Label;
@@ -574,7 +574,7 @@ mod tests {
         )
         .unwrap();
 
-        vec![RecordBatch::try_from(batch).unwrap()]
+        vec![convert_single_arrow_record_batch(batch).unwrap()]
     }
 
     #[test]

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -473,7 +473,6 @@ mod tests {
     };
     use common_types::{
         column_schema,
-        record_batch::convert_single_arrow_record_batch,
         schema::{self, TIMESTAMP_COLUMN},
     };
     use prom_remote_api::types::Label;
@@ -574,7 +573,7 @@ mod tests {
         )
         .unwrap();
 
-        vec![convert_single_arrow_record_batch(batch).unwrap()]
+        vec![batch.try_into().unwrap()]
     }
 
     #[test]

--- a/remote_engine_client/src/client.rs
+++ b/remote_engine_client/src/client.rs
@@ -15,7 +15,9 @@ use ceresdbproto::{
     storage::arrow_payload,
 };
 use common_types::{
-    projected_schema::ProjectedSchema, record_batch::RecordBatch, schema::RecordSchema,
+    projected_schema::ProjectedSchema,
+    record_batch::{RecordBatch, RecordBatchBuilder},
+    schema::RecordSchema,
 };
 use common_util::{error::BoxError, runtime::Runtime};
 use futures::{future::join_all, Stream, StreamExt};
@@ -328,6 +330,7 @@ pub struct ClientReadRecordBatchStream {
     pub response_stream: Streaming<remote_engine::ReadResponse>,
     pub projected_schema: ProjectedSchema,
     pub projected_record_schema: RecordSchema,
+    pub record_batch_builder: RecordBatchBuilder,
 }
 
 impl ClientReadRecordBatchStream {
@@ -342,6 +345,7 @@ impl ClientReadRecordBatchStream {
             response_stream,
             projected_schema,
             projected_record_schema,
+            record_batch_builder: RecordBatchBuilder::default(),
         }
     }
 }
@@ -397,9 +401,10 @@ impl Stream for ClientReadRecordBatchStream {
                                                 batch_num: record_batch_vec.len()
                                             }
                                         );
-                                        record_batch_vec
-                                            .swap_remove(0)
-                                            .try_into()
+
+                                        let arrow_record_batch = record_batch_vec.swap_remove(0);
+                                        this.record_batch_builder
+                                            .build(arrow_record_batch)
                                             .map_err(|e| Box::new(e) as _)
                                             .context(Convert {
                                                 msg: "convert read record batch",

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -14,7 +14,7 @@ use ceresdbproto::{
     storage::{arrow_payload, ArrowPayload},
 };
 use common_types::{
-    record_batch::{RecordBatchBuilder, RecordBatchWithKeyBuilder},
+    record_batch::{CachedRecordBatchesConverter, RecordBatchWithKeyBuilder},
     row::{RowGroup, RowGroupBuilder},
     schema::Schema,
 };
@@ -336,10 +336,10 @@ fn build_row_group_from_record_batch(
             .context(ConvertRowGroup)?,
     );
 
-    let mut record_batch_builder = RecordBatchBuilder::default();
+    let mut record_batches_converter = CachedRecordBatchesConverter::default();
     for arrow_record_batch in arrow_record_batches {
-        let record_batch = record_batch_builder
-            .build(arrow_record_batch)
+        let record_batch = record_batches_converter
+            .convert(arrow_record_batch)
             .map_err(|e| Box::new(e) as _)
             .context(ConvertRowGroup)?;
 


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
+ Add a `RecordBatchBuilder` which will cache the schema coverted from arrow's.
+ Build inner `RecordBatch` using `RecordBatchBuilder`.

## Test Plan 
Test by exist tests.
