### PR TITLE
refactor: replace *join_all with forloop in flush

### DIFF
--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -19,7 +19,7 @@ use common_types::{
     SequenceNumber,
 };
 use common_util::{define_result, error::GenericError};
-use futures::StreamExt;
+use futures::{stream::FuturesUnordered, StreamExt};
 use log::{debug, trace};
 use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use table_engine::{predicate::PredicateRef, table::TableId};
@@ -675,7 +675,7 @@ impl MergeIterator {
         let init_start = Instant::now();
 
         // Initialize buffered streams concurrently.
-        let mut init_buffered_streams = Vec::with_capacity(self.origin_streams.len());
+        let mut init_buffered_streams = FuturesUnordered::new();
         for origin_stream in mem::take(&mut self.origin_streams) {
             let schema = self.schema.clone();
             init_buffered_streams
@@ -688,8 +688,8 @@ impl MergeIterator {
 
         // Push streams to heap.
         let current_schema = &self.schema;
-        for buffered_stream in init_buffered_streams {
-            let buffered_stream = buffered_stream.await?;
+        while let Some(buffered_stream) = init_buffered_streams.next().await {
+            let buffered_stream = buffered_stream?;
             let stream_schema = buffered_stream.schema();
             ensure!(
                 current_schema == stream_schema,

--- a/analytic_engine/src/row_iter/merge.rs
+++ b/analytic_engine/src/row_iter/merge.rs
@@ -678,8 +678,7 @@ impl MergeIterator {
         let mut init_buffered_streams = FuturesUnordered::new();
         for origin_stream in mem::take(&mut self.origin_streams) {
             let schema = self.schema.clone();
-            init_buffered_streams
-                .push(async move { BufferedStream::build(schema, origin_stream).await });
+            init_buffered_streams.push(BufferedStream::build(schema, origin_stream));
         }
 
         let pull_start = Instant::now();

--- a/wal/src/tests/read_write.rs
+++ b/wal/src/tests/read_write.rs
@@ -404,12 +404,10 @@ async fn write_multiple_regions_parallelly<B: WalBuilder + 'static>(env: Arc<Tes
         handles.push(read_write_0);
         handles.push(read_write_1);
     }
-    futures::future::join_all(handles)
-        .await
-        .into_iter()
-        .for_each(|res| {
-            res.expect("should succeed to join the write");
-        });
+
+    for handle in handles {
+        handle.await.expect("should succeed to join the write")
+    }
 
     wal.close_gracefully().await.unwrap();
 }


### PR DESCRIPTION
## Related Issues
Close #945 

## Detailed Changes
Avoid using *join_all.

## Test Plan 
Existing tests.
