### PR TITLE
chore: check compact_files is empty

### DIFF
--- a/analytic_engine/src/compaction/mod.rs
+++ b/analytic_engine/src/compaction/mod.rs
@@ -347,8 +347,12 @@ impl CompactionTask {
         total_input_size as usize
     }
 
-    pub fn num_input_files(&self) -> usize {
+    pub fn num_compact_files(&self) -> usize {
         self.compaction_inputs.iter().map(|v| v.files.len()).sum()
+    }
+
+    pub fn num_expired_files(&self) -> usize {
+        self.expired.iter().map(|v| v.files.len()).sum()
     }
 }
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -659,7 +659,7 @@ impl SpaceStore {
             mems_to_remove: vec![],
         };
 
-        if task.expired.is_empty() && task.compaction_inputs.is_empty() {
+        if task.num_expired_files() == 0 && task.num_compact_files() == 0 {
             // Nothing to compact.
             return Ok(());
         }
@@ -673,7 +673,7 @@ impl SpaceStore {
             table_data.name,
             table_data.id,
             task.estimated_total_input_file_size(),
-            task.num_input_files(),
+            task.num_compact_files(),
         );
 
         for input in &task.compaction_inputs {


### PR DESCRIPTION
## Related Issues
Closes #

## Detailed Changes
Since there are multiple levels now, the original logic of checking that the compact_file is empty fails. 
Fix check logic.

## Test Plan 
CI.
