### PR TITLE
feat: upgrade vergen and remove dep libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2149,26 +2149,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-iterator"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,35 +2589,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error 1.0.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
-
-[[package]]
-name = "git2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
 
 [[package]]
 name = "glob"
@@ -3282,18 +3237,6 @@ name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.14.2+1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
 
 [[package]]
 name = "libloading"
@@ -7134,18 +7077,13 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "7.5.1"
+version = "8.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21b881cd6636ece9735721cf03c1fe1e774fe258683d084bb2812ab67435749"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "enum-iterator",
- "getset",
- "git2",
  "rustc_version 0.4.0",
  "rustversion",
- "thiserror",
  "time 0.3.20",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ toml = { workspace = true }
 tracing_util = { workspace = true }
 
 [build-dependencies]
-vergen = { version = "7", default-features = false, features = ["build", "git", "rustc"] }
+vergen = { version = "8", default-features = false, features = ["build", "cargo", "git", "gitcl", "rustc"] }
 
 # This profile optimizes for good runtime performance.
 [profile.release]

--- a/build.rs
+++ b/build.rs
@@ -1,26 +1,16 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Build script
 
-use std::env;
-
-use vergen::{vergen, Config, ShaKind};
+use vergen::EmitBuilder;
 
 fn main() {
-    // Generate the default 'cargo:' instruction output
-    let mut config = Config::default();
-    // Change the SHA output to the short variant
-    *config.git_mut().sha_kind_mut() = ShaKind::Short;
-    // Override git branch by env if provided.
-    if let Some(branch) = env::var_os("GITBRANCH") {
-        let branch = branch
-            .into_string()
-            .expect("Convert git branch env to string");
-        if !branch.is_empty() {
-            *config.git_mut().branch_mut() = false;
-            println!("cargo:rustc-env=VERGEN_GIT_BRANCH={branch}");
-        }
-    }
-
-    let _ = vergen(config);
+    EmitBuilder::builder()
+        .all_cargo()
+        .all_build()
+        .all_rustc()
+        .git_branch()
+        .git_sha(true)
+        .emit()
+        .expect("Should succeed emit version message");
 }

--- a/src/bin/ceresdb-server.rs
+++ b/src/bin/ceresdb-server.rs
@@ -19,19 +19,25 @@ const NODE_ADDR: &str = "CERESDB_SERVER_ADDR";
 /// overridden.
 const CLUSTER_NAME: &str = "CLUSTER_NAME";
 
+const UNKNOWN: &str = "Unknown";
+
 fn fetch_version() -> String {
-    let build_version = option_env!("VERGEN_BUILD_SEMVER").unwrap_or("NONE");
-    let git_branch = option_env!("VERGEN_GIT_BRANCH").unwrap_or("NONE");
-    let git_commit_id = option_env!("VERGEN_GIT_SHA_SHORT").unwrap_or("NONE");
-    let build_time = option_env!("VERGEN_BUILD_TIMESTAMP").unwrap_or("NONE");
-    let rustc_version = option_env!("VERGEN_RUSTC_SEMVER").unwrap_or("NONE");
+    let version = option_env!("CARGO_PKG_VERSION").unwrap_or(UNKNOWN);
+    let git_branch = option_env!("VERGEN_GIT_BRANCH").unwrap_or(UNKNOWN);
+    let git_commit_id = option_env!("VERGEN_GIT_SHA").unwrap_or(UNKNOWN);
+    let build_time = option_env!("VERGEN_BUILD_TIMESTAMP").unwrap_or(UNKNOWN);
+    let rustc_version = option_env!("VERGEN_RUSTC_SEMVER").unwrap_or(UNKNOWN);
+    let opt_level = option_env!("VERGEN_CARGO_OPT_LEVEL").unwrap_or(UNKNOWN);
+    let target = option_env!("VERGEN_CARGO_TARGET_TRIPLE").unwrap_or(UNKNOWN);
 
     [
-        ("\nCeresDB version", build_version),
-        ("Git branch", git_branch),
+        ("\nVersion", version),
         ("Git commit", git_commit_id),
-        ("Build time", build_time),
+        ("Git branch", git_branch),
+        ("Optimize Level", opt_level),
         ("Rustc version", rustc_version),
+        ("Target", target),
+        ("Build date", build_time),
     ]
     .iter()
     .map(|(label, value)| format!("{label}: {value}"))

--- a/src/bin/ceresdb-server.rs
+++ b/src/bin/ceresdb-server.rs
@@ -19,6 +19,7 @@ const NODE_ADDR: &str = "CERESDB_SERVER_ADDR";
 /// overridden.
 const CLUSTER_NAME: &str = "CLUSTER_NAME";
 
+/// Default value for version information is not found from environment
 const UNKNOWN: &str = "Unknown";
 
 fn fetch_version() -> String {
@@ -34,7 +35,7 @@ fn fetch_version() -> String {
         ("\nVersion", version),
         ("Git commit", git_commit_id),
         ("Git branch", git_branch),
-        ("Optimize Level", opt_level),
+        ("Opt level", opt_level),
         ("Rustc version", rustc_version),
         ("Target", target),
         ("Build date", build_time),


### PR DESCRIPTION
## Related Issues
Part of #151

## Detailed Changes
- `libgit2` used by `vergen` takes too much time to compile, and we can configure `gitcl` feature of `vergen` to remove such dependency.
- Upgrade `vergen` to output more information about the compiled binary.
