### PR TITLE
fix: capacity should equal to total / part_num

### DIFF
--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -340,4 +340,21 @@ mod test {
             .get(&MemCacheStore::cache_key(&location, &range100_105))
             .is_some());
     }
+
+    #[test]
+    fn test_mem_cache_capacity() {
+        // 4 partitions
+        let store = prepare_store(2, 100);
+        assert_eq!(
+            "25,25,25,25",
+            store
+                .cache
+                .inner
+                .get_all_partition()
+                .iter()
+                .map(|p| p.lock().unwrap().capacity().to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+    }
 }

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -51,9 +51,9 @@ impl MemCache {
         mem_cap: NonZeroUsize,
     ) -> std::result::Result<Self, Error> {
         let partition_num = 1 << partition_bits;
-        let cap_per_part = mem_cap
-            .checked_mul(NonZeroUsize::new(partition_num).unwrap())
-            .context(InvalidCapacity)?;
+        let cap_per_part =
+            NonZeroUsize::new((mem_cap.get() as f64 / partition_num as f64) as usize)
+                .context(InvalidCapacity)?;
         let inin_lru =
             || CLruCache::with_config(CLruCacheConfig::new(cap_per_part).with_scale(CustomScale));
         let inner = PartitionedMutex::new(inin_lru, partition_bits);


### PR DESCRIPTION
## Rationale

Current mem cache will consume more memory than expected.

## Detailed Changes
Fix the wrong capacity of a partition cache.

## Test Plan
Add UT `test_mem_cache_capacity`