### PR TITLE
feat: use `get_batch` to implement `get_range`

### DIFF
--- a/components/object_store/src/obkv/mod.rs
+++ b/components/object_store/src/obkv/mod.rs
@@ -34,6 +34,8 @@ use upstream::{
 };
 use uuid::Uuid;
 
+use uuid::Uuid;
+
 use crate::{
     multipart::{CloudMultiPartUpload, CloudMultiPartUploadImpl, UploadPart},
     obkv::meta::{MetaManager, ObkvObjectMeta, OBJECT_STORE_META},

--- a/components/object_store/src/obkv/mod.rs
+++ b/components/object_store/src/obkv/mod.rs
@@ -34,8 +34,6 @@ use upstream::{
 };
 use uuid::Uuid;
 
-use uuid::Uuid;
-
 use crate::{
     multipart::{CloudMultiPartUpload, CloudMultiPartUploadImpl, UploadPart},
     obkv::meta::{MetaManager, ObkvObjectMeta, OBJECT_STORE_META},
@@ -277,11 +275,11 @@ impl<T: TableKv> ObkvObjectStore<T> {
         let table_name = self.pick_shard_table(location);
         // TODO: Let table_kv provide a api `get_batch` to avoid extra IO operations.
         let mut futures = FuturesOrdered::new();
-        for path in meta.parts {
+        for part_key in meta.parts {
             let client = self.client.clone();
             let table_name = table_name.to_string();
             let future = async move {
-                match client.get(&table_name, path.as_bytes()) {
+                match client.get(&table_name, part_key.as_bytes()) {
                     Ok(res) => Ok(Bytes::from(res.unwrap())),
                     Err(err) => Err(StoreError::Generic {
                         store: OBKV,
@@ -461,16 +459,21 @@ impl<T: TableKv> ObjectStore for ObkvObjectStore<T> {
                 source,
             })?;
 
-        for (index, key) in covered_parts.part_keys.iter().enumerate() {
-            let part_bytes = self
-                .client
-                .get(table_name, key.as_bytes())
+        let keys: Vec<&[u8]> = covered_parts
+            .part_keys
+            .iter()
+            .map(|key| key.as_bytes())
+            .collect();
+        let values =
+            self.client
+                .get_batch(table_name, keys)
                 .map_err(|source| StoreError::NotFound {
                     path: location.to_string(),
                     source: Box::new(source),
                 })?;
 
-            if let Some(bytes) = part_bytes {
+        for (index, key) in covered_parts.part_keys.iter().enumerate() {
+            if let Some(bytes) = &values[index] {
                 let mut begin = 0;
                 let mut end = bytes.len();
                 if index == 0 {

--- a/components/table_kv/src/lib.rs
+++ b/components/table_kv/src/lib.rs
@@ -186,6 +186,13 @@ pub trait TableKv: Clone + Send + Sync + fmt::Debug + 'static {
     /// Get value by key from table with `table_name`.
     fn get(&self, table_name: &str, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
+    /// Get a batch of value by keys from table with `table_name`
+    fn get_batch(
+        &self,
+        table_name: &str,
+        keys: Vec<&[u8]>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
+
     /// Delete data by key from table with `table_name`.
     fn delete(&self, table_name: &str, key: &[u8]) -> Result<(), Self::Error>;
 

--- a/components/table_kv/src/memory.rs
+++ b/components/table_kv/src/memory.rs
@@ -278,6 +278,23 @@ impl TableKv for MemoryImpl {
         Ok(table.get(key))
     }
 
+    fn get_batch(
+        &self,
+        table_name: &str,
+        keys: Vec<&[u8]>,
+    ) -> std::result::Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        let table = self
+            .find_table(table_name)
+            .context(TableNotFound { table_name })?;
+
+        let mut result = Vec::with_capacity(keys.len());
+        for key in keys {
+            result.push(table.get(key));
+        }
+
+        Ok(result)
+    }
+
     fn delete(&self, table_name: &str, key: &[u8]) -> std::result::Result<(), Self::Error> {
         let table = self
             .find_table(table_name)

--- a/components/table_kv/src/obkv.rs
+++ b/components/table_kv/src/obkv.rs
@@ -167,6 +167,14 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Unexpected batch result found, table:{table_name}.\nBacktrace:\n{backtrace}"
+    ))]
+    UnexpectedBatchResult {
+        table_name: String,
+        backtrace: Backtrace,
+    },
+
+    #[snafu(display(
         "Failed to delete data from table, table:{}, err:{}.\nBacktrace:\n{}",
         table_name,
         source,
@@ -528,7 +536,7 @@ impl TableKv for ObkvImpl {
                 TableOpResult::RetrieveRows(mut values) => {
                     batch_res.push(values.remove(VALUE_COLUMN_NAME).map(Value::as_bytes))
                 }
-                TableOpResult::AffectedRows(_) => {}
+                TableOpResult::AffectedRows(_) => UnexpectedBatchResult { table_name }.fail()?,
             }
         }
         Ok(batch_res)


### PR DESCRIPTION
## Rationale
Now the implementation of `get_range` in `ObjectStore` based on `OBKV` may cause extra IO operation, the better way is to let table_kv provide a api `get_batch` to avoid this.

## Detailed Changes
* Add a api `get_batch` in table_kv
* use `get_batch` implement `get_range` in `ObjectStore` based on `OBKV` 

## Test Plan
By unit tests