### PR TITLE
refactor: disk cache use partition lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ dependencies = [
  "murmur3",
  "paste 1.0.12",
  "prost",
+ "seahash",
  "serde",
  "serde_json",
  "snafu 0.6.10",

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -491,7 +491,6 @@ fn open_storage(
             tokio::fs::create_dir_all(&path).await.context(CreateDir {
                 path: path.to_string_lossy().into_owned(),
             })?;
-            // TODO check the partition_bits
             store = Arc::new(
                 DiskCacheStore::try_new(
                     path.to_string_lossy().into_owned(),

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -491,6 +491,7 @@ fn open_storage(
             tokio::fs::create_dir_all(&path).await.context(CreateDir {
                 path: path.to_string_lossy().into_owned(),
             })?;
+
             store = Arc::new(
                 DiskCacheStore::try_new(
                     path.to_string_lossy().into_owned(),

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -498,7 +498,7 @@ fn open_storage(
                     opts.disk_cache_capacity.as_byte() as usize,
                     opts.disk_cache_page_size.as_byte() as usize,
                     store,
-                    4,
+                    opts.disk_cache_partition_bits,
                 )
                 .await
                 .context(OpenObjectStore)?,

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -469,13 +469,14 @@ fn open_storage(
             tokio::fs::create_dir_all(&path).await.context(CreateDir {
                 path: path.to_string_lossy().into_owned(),
             })?;
-
+            // TODO check the partition_bits
             store = Arc::new(
                 DiskCacheStore::try_new(
                     path.to_string_lossy().into_owned(),
                     opts.disk_cache_capacity.as_byte() as usize,
                     opts.disk_cache_page_size.as_byte() as usize,
                     store,
+                    4,
                 )
                 .await
                 .context(OpenObjectStore)?,

--- a/analytic_engine/src/storage_options.rs
+++ b/analytic_engine/src/storage_options.rs
@@ -14,9 +14,11 @@ pub struct StorageOptions {
     pub mem_cache_capacity: ReadableSize,
     pub mem_cache_partition_bits: usize,
     // 0 means disable disk cache
-    // Note: disk_cache_capacity % disk_cache_page_size should be 0
+    // Note: disk_cache_capacity % (disk_cache_page_size * (1 << disk_cache_partition_bits)) should
+    // be 0
     pub disk_cache_capacity: ReadableSize,
     pub disk_cache_page_size: ReadableSize,
+    pub disk_cache_partition_bits: usize,
     pub disk_cache_dir: String,
     pub object_store: ObjectStoreOptions,
 }
@@ -31,6 +33,7 @@ impl Default for StorageOptions {
             disk_cache_dir: root_path.clone(),
             disk_cache_capacity: ReadableSize::gb(0),
             disk_cache_page_size: ReadableSize::mb(2),
+            disk_cache_partition_bits: 4,
             object_store: ObjectStoreOptions::Local(LocalOptions {
                 data_dir: root_path,
             }),

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -428,6 +428,7 @@ impl Builder {
                 disk_cache_dir: "".to_string(),
                 disk_cache_capacity: ReadableSize::mb(0),
                 disk_cache_page_size: ReadableSize::mb(0),
+                disk_cache_partition_bits: 0,
                 object_store: ObjectStoreOptions::Local(LocalOptions {
                     data_dir: dir.path().to_str().unwrap().to_string(),
                 }),
@@ -490,6 +491,7 @@ impl Default for RocksDBEngineBuildContext {
                 disk_cache_dir: "".to_string(),
                 disk_cache_capacity: ReadableSize::mb(0),
                 disk_cache_page_size: ReadableSize::mb(0),
+                disk_cache_partition_bits: 0,
                 object_store: ObjectStoreOptions::Local(LocalOptions {
                     data_dir: dir.path().to_str().unwrap().to_string(),
                 }),
@@ -517,6 +519,7 @@ impl Clone for RocksDBEngineBuildContext {
             disk_cache_dir: "".to_string(),
             disk_cache_capacity: ReadableSize::mb(0),
             disk_cache_page_size: ReadableSize::mb(0),
+            disk_cache_partition_bits: 0,
             object_store: ObjectStoreOptions::Local(LocalOptions {
                 data_dir: dir.path().to_str().unwrap().to_string(),
             }),
@@ -560,6 +563,7 @@ impl Default for MemoryEngineBuildContext {
                 disk_cache_dir: "".to_string(),
                 disk_cache_capacity: ReadableSize::mb(0),
                 disk_cache_page_size: ReadableSize::mb(0),
+                disk_cache_partition_bits: 0,
                 object_store: ObjectStoreOptions::Local(LocalOptions {
                     data_dir: dir.path().to_str().unwrap().to_string(),
                 }),

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -27,6 +27,7 @@ datafusion = { workspace = true, optional = true }
 murmur3 = "0.4.1"
 paste = { workspace = true }
 prost = { workspace = true }
+seahash = "4.1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -14,9 +14,9 @@ use std::hash::BuildHasher;
     https://github.com/tkaitchuck/aHash/blob/master/README.md#goals-and-non-goals
 */
 use ahash::AHasher;
-pub use seahash::SeaHasher;
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
+pub use seahash::SeaHasher;
 pub fn hash64(mut bytes: &[u8]) -> u64 {
     let mut out = [0; 16];
     murmur3_x64_128(&mut bytes, 0, &mut out);

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -14,6 +14,7 @@ use std::hash::BuildHasher;
     https://github.com/tkaitchuck/aHash/blob/master/README.md#goals-and-non-goals
 */
 use ahash::AHasher;
+pub use seahash::SeaHasher;
 use byteorder::{ByteOrder, LittleEndian};
 use murmur3::murmur3_x64_128;
 pub fn hash64(mut bytes: &[u8]) -> u64 {

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -9,6 +9,7 @@ use std::{
 
 use common_types::hash::{build_fixed_seed_ahasher, SeaHasher};
 use tokio;
+
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {
     partitions: Vec<RwLock<T>>,

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -4,8 +4,10 @@
 
 use std::{
     hash::{Hash, Hasher},
-    sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard, self},
 };
+use tokio;
+
 
 use common_types::hash::build_fixed_seed_ahasher;
 /// Simple partitioned `RwLock`
@@ -99,6 +101,51 @@ impl<T> PartitionedMutex<T> {
         &self.partitions
     }
 }
+
+#[derive(Debug)]
+pub struct PartitionedMutexAsync<T> {
+    partitions: Vec<tokio::sync::Mutex<T>>,
+    partition_mask: usize,
+}
+
+impl<T> PartitionedMutexAsync<T> {
+    pub fn new<F>(init_fn: F, partition_bit: usize) -> Self
+    where
+        F: Fn() -> T,
+    {
+        let partition_num = 1 << partition_bit;
+        let partitions = (0..partition_num)
+            .map(|_| tokio::sync::Mutex::new(init_fn()))
+            .collect::<Vec<tokio::sync::Mutex<T>>>();
+        Self {
+            partitions,
+            partition_mask: partition_num - 1,
+        }
+    }
+
+    pub async fn lock<K: Eq + Hash>(&self, key: &K) -> tokio::sync::MutexGuard<'_, T> {
+        let mutex = self.get_partition(key);
+
+        mutex.lock().await
+    }
+
+    fn get_partition<K: Eq + Hash>(&self, key: &K) -> &tokio::sync::Mutex<T> {
+        let mut hasher = build_fixed_seed_ahasher();
+        key.hash(&mut hasher);
+        &self.partitions[(hasher.finish() as usize) & self.partition_mask]
+    }
+
+    #[cfg(test)]
+    fn get_partition_by_index(&self, index: usize) -> &tokio::sync::Mutex<T> {
+        &self.partitions[index]
+    }
+
+    /// This function should be marked with `#[cfg(test)]`, but there is [an issue](https://github.com/rust-lang/cargo/issues/8379) in cargo, so public this function now.
+    pub fn get_all_partition(&self) -> &Vec<tokio::sync::Mutex<T>> {
+        &self.partitions
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -7,8 +7,7 @@ use std::{
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-use common_types::hash::build_fixed_seed_ahasher;
-use common_types::hash::SeaHasher;
+use common_types::hash::{build_fixed_seed_ahasher, SeaHasher};
 use tokio;
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -4,12 +4,11 @@
 
 use std::{
     hash::{Hash, Hasher},
-    sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard, self},
+    sync::{self, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
-use tokio;
-
 
 use common_types::hash::build_fixed_seed_ahasher;
+use tokio;
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {
     partitions: Vec<RwLock<T>>,
@@ -145,7 +144,6 @@ impl<T> PartitionedMutexAsync<T> {
         &self.partitions
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -138,11 +138,6 @@ impl<T> PartitionedMutexAsync<T> {
     async fn get_partition_by_index(&self, index: usize) -> &tokio::sync::Mutex<T> {
         &self.partitions[index]
     }
-
-    /// This function should be marked with `#[cfg(test)]`, but there is [an issue](https://github.com/rust-lang/cargo/issues/8379) in cargo, so public this function now.
-    pub fn get_all_partition(&self) -> &Vec<tokio::sync::Mutex<T>> {
-        &self.partitions
-    }
 }
 
 #[cfg(test)]
@@ -231,6 +226,7 @@ mod tests {
         assert!(mutex_second_try_lock.try_write().is_ok());
         assert!(mutex_first.try_write().is_err());
     }
+
     #[tokio::test]
     async fn test_partitioned_mutex_async_vis_different_partition() {
         let init_vec = Vec::<i32>::new;

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use common_types::hash::build_fixed_seed_ahasher;
+use common_types::hash::SeaHasher;
 use tokio;
 /// Simple partitioned `RwLock`
 pub struct PartitionedRwLock<T> {
@@ -129,7 +130,7 @@ impl<T> PartitionedMutexAsync<T> {
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &tokio::sync::Mutex<T> {
-        let mut hasher = build_fixed_seed_ahasher();
+        let mut hasher = SeaHasher::new();
         key.hash(&mut hasher);
         &self.partitions[(hasher.finish() as usize) & self.partition_mask]
     }

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -773,6 +773,7 @@ mod test {
         assert!(test_file_exists(&store.cache_dir, &location, &(96..112)));
         assert!(test_file_exists(&store.cache_dir, &location, &(128..144)));
     }
+
     #[tokio::test]
     async fn test_disk_cache_manifest() {
         let cache_dir = tempdir().unwrap();

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -546,7 +546,11 @@ mod test {
         cache_dir: TempDir,
     }
 
-    async fn prepare_store(page_size: usize, cap: usize, partition_bits: usize) -> StoreWithCacheDir {
+    async fn prepare_store(
+        page_size: usize,
+        cap: usize,
+        partition_bits: usize,
+    ) -> StoreWithCacheDir {
         let local_path = tempdir().unwrap();
         let local_store = Arc::new(LocalFileSystem::new_with_prefix(local_path.path()).unwrap());
 
@@ -722,7 +726,7 @@ mod test {
             buf.extend_from_slice(data);
         }
         store.inner.put(&location, buf.freeze()).await.unwrap();
-        // 0..16: partition 1  
+        // 0..16: partition 1
         // 16..32 partition 0
         // 32..48 partition 0
         // 48..64 partition 0
@@ -750,7 +754,7 @@ mod test {
 
         assert!(test_file_exists(&store.cache_dir, &location, &(0..16)));
         assert!(test_file_exists(&store.cache_dir, &location, &(80..96)));
-        
+
         // insert new entry into partition 0, evict partition 0's oldest entry
         let _ = store.inner.get_range(&location, 64..80).await.unwrap();
         assert!(!test_file_exists(&store.cache_dir, &location, &(32..48)));
@@ -759,7 +763,6 @@ mod test {
 
         assert!(test_file_exists(&store.cache_dir, &location, &(0..16)));
         assert!(test_file_exists(&store.cache_dir, &location, &(80..96)));
-    
 
         // insert new entry into partition 1, evict partition 1's oldest entry
         let _ = store.inner.get_range(&location, 112..128).await.unwrap();
@@ -769,8 +772,6 @@ mod test {
 
         assert!(test_file_exists(&store.cache_dir, &location, &(48..64)));
         assert!(test_file_exists(&store.cache_dir, &location, &(64..80)));
-
-
     }
     #[tokio::test]
     async fn test_disk_cache_manifest() {

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -18,7 +18,7 @@ use log::{debug, error, info};
 use lru::LruCache;
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
+use snafu::{ensure, Backtrace, ResultExt, Snafu};
 use tokio::{
     fs::{File, OpenOptions},
     io::{AsyncReadExt, AsyncWrite, AsyncWriteExt},

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -7,7 +7,7 @@
 //! Page is used for reasons below:
 //! - reduce file size in case of there are too many request with small range.
 
-use std::{collections::BTreeMap, fmt::Display, num::NonZeroUsize, ops::Range, sync::Arc};
+use std::{collections::BTreeMap, fmt::Display, ops::Range, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};

--- a/components/object_store/src/mem_cache.rs
+++ b/components/object_store/src/mem_cache.rs
@@ -54,9 +54,9 @@ impl MemCache {
         let cap_per_part =
             NonZeroUsize::new((mem_cap.get() as f64 / partition_num as f64) as usize)
                 .context(InvalidCapacity)?;
-        let inin_lru =
+        let init_lru =
             || CLruCache::with_config(CLruCacheConfig::new(cap_per_part).with_scale(CustomScale));
-        let inner = PartitionedMutex::new(inin_lru, partition_bits);
+        let inner = PartitionedMutex::new(init_lru, partition_bits);
         Ok(Self { mem_cap, inner })
     }
 


### PR DESCRIPTION
## Rationale
Close #914

## Detailed Changes
Use `partition lock` in `disk cache`

## Test Plan
add ut.