### PR TITLE
feat: support region based wal replay

### DIFF
--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -218,6 +218,18 @@ pub enum Error {
 
     #[snafu(display("Failed to open shard, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
     OpenTablesOfShard { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to replay wal, msg:{:?}, err:{}", msg, source))]
+    ReplayWalWithCause {
+        msg: Option<String>,
+        source: GenericError,
+    },
+
+    #[snafu(display("Failed to replay wal, msg:{:?}.\nBacktrace:\n{}", msg, backtrace))]
+    ReplayWalNoCause {
+        msg: Option<String>,
+        backtrace: Backtrace,
+    },
 }
 
 define_result!(Error);
@@ -250,7 +262,9 @@ impl From<Error> for table_engine::engine::Error {
             | Error::DoManifestSnapshot { .. }
             | Error::OpenManifest { .. }
             | Error::TableNotExist { .. }
-            | Error::OpenTablesOfShard { .. } => Self::Unexpected {
+            | Error::OpenTablesOfShard { .. }
+            | Error::ReplayWalNoCause { .. }
+            | Error::ReplayWalWithCause { .. } => Self::Unexpected {
                 source: Box::new(err),
             },
         }

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -295,10 +295,7 @@ impl Flusher {
             runtime: self.runtime.clone(),
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
         };
-        let flush_job = async move {
-            let _table_data = &flush_task.table_data;
-            flush_task.run().await
-        };
+        let flush_job = async move { flush_task.run().await };
 
         flush_scheduler
             .flush_sequentially(flush_job, block_on, opts, &self.runtime, table_data.clone())

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -130,6 +130,18 @@ pub enum Error {
 
     #[snafu(display("Other failure, msg:{}.\nBacktrace:\n{:?}", msg, backtrace))]
     Other { msg: String, backtrace: Backtrace },
+
+    #[snafu(display("Failed to run flush job, msg:{:?}, err:{}", msg, source))]
+    FlushJobWithCause {
+        msg: Option<String>,
+        source: GenericError,
+    },
+
+    #[snafu(display("Failed to run flush job, msg:{:?}.\nBacktrace:\n{}", msg, backtrace))]
+    FlushJobNoCause {
+        msg: Option<String>,
+        backtrace: Backtrace,
+    },
 }
 
 define_result!(Error);
@@ -285,13 +297,7 @@ impl Flusher {
         };
         let flush_job = async move {
             let table_data = &flush_task.table_data;
-            flush_task.run().await.map_err(|e| {
-                error!(
-                    "Instance flush memtables failed, table:{}, table_id:{}, err{e}",
-                    table_data.name, table_data.id
-                );
-                e
-            })
+            flush_task.run().await
         };
 
         flush_scheduler
@@ -321,7 +327,15 @@ impl FlushTask {
         // Start flush duration timer.
         let local_metrics = self.table_data.metrics.local_flush_metrics();
         let _timer = local_metrics.start_flush_timer();
-        self.dump_memtables(request_id, &mems_to_flush).await?;
+        self.dump_memtables(request_id, &mems_to_flush)
+            .await
+            .box_err()
+            .context(FlushJobWithCause {
+                msg: Some(format!(
+                    "table:{}, table_id:{}, request_id:{request_id}",
+                    self.table_data.name, self.table_data.id
+                )),
+            })?;
 
         self.table_data
             .set_last_flush_time(time::current_time_millis());

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -296,7 +296,7 @@ impl Flusher {
             write_sst_max_buffer_size: self.write_sst_max_buffer_size,
         };
         let flush_job = async move {
-            let table_data = &flush_task.table_data;
+            let _table_data = &flush_task.table_data;
             flush_task.run().await
         };
 

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -163,6 +163,7 @@ pub struct TableFlushRequest {
     pub max_sequence: SequenceNumber,
 }
 
+#[derive(Clone)]
 pub struct Flusher {
     pub space_store: SpaceStoreRef,
 

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod mem_collector;
 pub mod open;
 mod read;
 pub(crate) mod serial_executor;
+pub mod wal_replayer;
 pub(crate) mod write;
 
 use std::sync::Arc;

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         meta_data::cache::MetaCacheRef,
     },
     table::data::{TableDataRef, TableShardInfo},
-    TableOptions,
+    RecoverMode, TableOptions,
 };
 
 #[allow(clippy::enum_variant_names)]
@@ -160,6 +160,7 @@ pub struct Instance {
     /// Options for scanning sst
     pub(crate) scan_options: ScanOptions,
     pub(crate) iter_options: Option<IterOptions>,
+    pub(crate) recover_mode: RecoverMode,
 }
 
 impl Instance {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -359,15 +359,15 @@ impl ShardOpener {
         for table_data in replay_table_datas {
             let table_id = table_data.id;
             let stage = self.states.get_mut(&table_id).unwrap();
-            let table_result = table_results.remove(&table_id).unwrap();
+            let failed_table_opt = table_results.remove(&table_id);
 
-            match (&stage, table_result) {
-                (TableOpenStage::RecoverTableData(ctx), Ok(())) => {
+            match (&stage, failed_table_opt) {
+                (TableOpenStage::RecoverTableData(ctx), None) => {
                     let space_table = SpaceAndTable::new(ctx.space.clone(), ctx.table_data.clone());
                     *stage = TableOpenStage::Success(Some(space_table));
                 }
 
-                (TableOpenStage::RecoverTableData(_), Err(e)) => {
+                (TableOpenStage::RecoverTableData(_), Some(e)) => {
                     *stage = TableOpenStage::Failed(e);
                 }
 

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -3,19 +3,16 @@
 //! Open logic of instance
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::HashMap,
     sync::{Arc, RwLock},
 };
 
-use common_types::{schema::IndexInWriterSchema, table::ShardId};
-use log::{debug, error, info, trace};
+use common_types::table::ShardId;
+use log::info;
 use object_store::ObjectStoreRef;
 use snafu::ResultExt;
 use table_engine::{engine::TableDef, table::TableId};
-use wal::{
-    log_batch::LogEntry,
-    manager::{ReadBoundary, ReadContext, ReadRequest, WalManager, WalManagerRef},
-};
+use wal::manager::WalManagerRef;
 
 use super::{engine::OpenTablesOfShard, flush_compaction::Flusher};
 use crate::{
@@ -23,16 +20,12 @@ use crate::{
     context::OpenContext,
     engine,
     instance::{
-        self,
-        engine::{ApplyMemTable, FlushTable, OpenManifest, ReadMetaUpdate, ReadWal, Result},
-        flush_compaction::TableFlushOptions,
+        engine::{OpenManifest, ReadMetaUpdate, Result},
         mem_collector::MemUsageCollector,
-        serial_executor::TableOpSerialExecutor,
-        write::MemTableWriter,
+        wal_replayer::WalReplayer,
         Instance, SpaceStore,
     },
     manifest::{details::ManifestImpl, LoadRequest, Manifest, ManifestRef},
-    payload::{ReadPayload, WalDecoder},
     row_iter::IterOptions,
     space::{SpaceAndTable, SpaceRef, Spaces},
     sst::{
@@ -319,46 +312,57 @@ impl ShardOpener {
 
     /// Recover table data based on shard.
     async fn recover_table_datas(&mut self) -> Result<()> {
-        for state in self.states.values_mut() {
-            match state {
+        // Replay wal logs of tables.
+        let mut replay_table_datas = Vec::with_capacity(self.states.len());
+        for (table_id, stage) in self.states.iter_mut() {
+            match stage {
                 // Only do the wal recovery work in `RecoverTableData` state.
                 TableOpenStage::RecoverTableData(ctx) => {
-                    let table_data = ctx.table_data.clone();
-                    let read_ctx = ReadContext {
-                        batch_size: self.wal_replay_batch_size,
-                        ..Default::default()
-                    };
-
-                    let result = match Self::recover_single_table_data(
-                        &self.flusher,
-                        self.max_retry_flush_limit,
-                        self.wal_manager.as_ref(),
-                        table_data.clone(),
-                        self.wal_replay_batch_size,
-                        &read_ctx,
-                    )
-                    .await
-                    {
-                        Ok(()) => Ok((table_data, ctx.space.clone())),
-                        Err(e) => Err(e),
-                    };
-
-                    match result {
-                        Ok((table_data, space)) => {
-                            *state = TableOpenStage::Success(Some(SpaceAndTable::new(
-                                space, table_data,
-                            )));
-                        }
-                        Err(e) => *state = TableOpenStage::Failed(e),
-                    }
+                    replay_table_datas.push(ctx.table_data.clone());
                 }
                 // Table was found opened, or failed in meta recovery stage.
                 TableOpenStage::Failed(_) | TableOpenStage::Success(_) => {}
                 TableOpenStage::RecoverTableMeta(_) => {
                     return OpenTablesOfShard {
-                        msg: format!("unexpected table state:{state:?}"),
+                        msg: format!(
+                            "unexpected stage, stage:{stage:?}, table_id:{table_id}, shard_id:{}",
+                            self.shard_id
+                        ),
                     }
-                    .fail()
+                    .fail();
+                }
+            }
+        }
+        let mut wal_replayer = WalReplayer::new(
+            &replay_table_datas,
+            self.shard_id,
+            self.wal_manager.clone(),
+            self.wal_replay_batch_size,
+            self.flusher.clone(),
+            self.max_retry_flush_limit,
+        );
+        let mut table_results = wal_replayer.replay().await?;
+
+        // Process the replay results.
+        for table_data in replay_table_datas {
+            let table_id = table_data.id;
+            let stage = self.states.get_mut(&table_id).unwrap();
+            let table_result = table_results.remove(&table_id).unwrap();
+
+            match (&stage, table_result) {
+                (TableOpenStage::RecoverTableData(ctx), Ok(())) => {
+                    let space_table = SpaceAndTable::new(ctx.space.clone(), ctx.table_data.clone());
+                    *stage = TableOpenStage::Success(Some(space_table));
+                }
+
+                (TableOpenStage::RecoverTableData(_), Err(e)) => {
+                    *stage = TableOpenStage::Failed(e);
+                }
+
+                (other_stage, _) => {
+                    return OpenTablesOfShard {
+                        msg: format!("unexpected stage, stage:{other_stage:?}, table_id:{table_id}, shard_id:{}", self.shard_id),
+                    }.fail();
                 }
             }
         }
@@ -395,173 +399,6 @@ impl ShardOpener {
             "Instance recover table meta end, table_id:{}, table_name:{}, shard_id:{shard_id}",
             table_def.id, table_def.name
         );
-
-        Ok(())
-    }
-
-    /// Recover table data from wal.
-    ///
-    /// Called by write worker
-    pub(crate) async fn recover_single_table_data(
-        flusher: &Flusher,
-        max_retry_flush_limit: usize,
-        wal_manager: &dyn WalManager,
-        table_data: TableDataRef,
-        replay_batch_size: usize,
-        read_ctx: &ReadContext,
-    ) -> Result<()> {
-        debug!(
-            "Instance recover table from wal, replay batch size:{}, table id:{}, shard info:{:?}",
-            replay_batch_size, table_data.id, table_data.shard_info
-        );
-
-        let table_location = table_data.table_location();
-        let wal_location =
-            instance::create_wal_location(table_location.id, table_location.shard_info);
-        let read_req = ReadRequest {
-            location: wal_location,
-            start: ReadBoundary::Excluded(table_data.current_version().flushed_sequence()),
-            end: ReadBoundary::Max,
-        };
-
-        // Read all wal of current table.
-        let mut log_iter = wal_manager
-            .read_batch(read_ctx, &read_req)
-            .await
-            .context(ReadWal)?;
-
-        let mut serial_exec = table_data.serial_exec.lock().await;
-        let mut log_entry_buf = VecDeque::with_capacity(replay_batch_size);
-        loop {
-            // fetch entries to log_entry_buf
-            let decoder = WalDecoder::default();
-            log_entry_buf = log_iter
-                .next_log_entries(decoder, log_entry_buf)
-                .await
-                .context(ReadWal)?;
-
-            // Replay all log entries of current table
-            Self::replay_table_log_entries(
-                flusher,
-                max_retry_flush_limit,
-                &mut serial_exec,
-                &table_data,
-                &log_entry_buf,
-            )
-            .await?;
-
-            // No more entries.
-            if log_entry_buf.is_empty() {
-                break;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Replay all log entries into memtable and flush if necessary.
-    async fn replay_table_log_entries(
-        flusher: &Flusher,
-        max_retry_flush_limit: usize,
-        serial_exec: &mut TableOpSerialExecutor,
-        table_data: &TableDataRef,
-        log_entries: &VecDeque<LogEntry<ReadPayload>>,
-    ) -> Result<()> {
-        if log_entries.is_empty() {
-            info!(
-                "Instance replay an empty table log entries, table:{}, table_id:{:?}",
-                table_data.name, table_data.id
-            );
-
-            // No data in wal
-            return Ok(());
-        }
-
-        let last_sequence = log_entries.back().unwrap().sequence;
-
-        debug!(
-            "Instance replay table log entries begin, table:{}, table_id:{:?}, sequence:{}",
-            table_data.name, table_data.id, last_sequence
-        );
-
-        for log_entry in log_entries {
-            let (sequence, payload) = (log_entry.sequence, &log_entry.payload);
-
-            // Apply to memtable
-            match payload {
-                ReadPayload::Write { row_group } => {
-                    trace!(
-                        "Instance replay row_group, table:{}, row_group:{:?}",
-                        table_data.name,
-                        row_group
-                    );
-
-                    let table_schema_version = table_data.schema_version();
-                    if table_schema_version != row_group.schema().version() {
-                        // Data with old schema should already been flushed, but we avoid panic
-                        // here.
-                        error!(
-                            "Ignore data with mismatch schema version during replaying, \
-                            table:{}, \
-                            table_id:{:?}, \
-                            expect:{}, \
-                            actual:{}, \
-                            last_sequence:{}, \
-                            sequence:{}",
-                            table_data.name,
-                            table_data.id,
-                            table_schema_version,
-                            row_group.schema().version(),
-                            last_sequence,
-                            sequence,
-                        );
-
-                        continue;
-                    }
-
-                    let index_in_writer =
-                        IndexInWriterSchema::for_same_schema(row_group.schema().num_columns());
-                    let memtable_writer = MemTableWriter::new(table_data.clone(), serial_exec);
-                    memtable_writer
-                        .write(sequence, &row_group.into(), index_in_writer)
-                        .context(ApplyMemTable {
-                            space_id: table_data.space_id,
-                            table: &table_data.name,
-                            table_id: table_data.id,
-                        })?;
-
-                    // Flush the table if necessary.
-                    if table_data.should_flush_table(serial_exec) {
-                        let opts = TableFlushOptions {
-                            res_sender: None,
-                            max_retry_flush_limit,
-                        };
-                        let flush_scheduler = serial_exec.flush_scheduler();
-                        flusher
-                            .schedule_flush(flush_scheduler, table_data, opts)
-                            .await
-                            .context(FlushTable {
-                                space_id: table_data.space_id,
-                                table: &table_data.name,
-                                table_id: table_data.id,
-                            })?;
-                    }
-                }
-                ReadPayload::AlterSchema { .. } | ReadPayload::AlterOptions { .. } => {
-                    // Ignore records except Data.
-                    //
-                    // - DDL (AlterSchema and AlterOptions) should be recovered
-                    //   from Manifest on start.
-                }
-            }
-        }
-
-        debug!(
-            "Instance replay table log entries end, table:{}, table_id:{:?}, last_sequence:{}",
-            table_data.name, table_data.id, last_sequence
-        );
-
-        table_data.set_last_sequence(last_sequence);
 
         Ok(())
     }

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -210,7 +210,7 @@ impl ShardOpener {
         max_retry_flush_limit: usize,
         recover_mode: RecoverMode,
     ) -> Result<Self> {
-        let mut states = HashMap::with_capacity(shard_context.table_ctxs.len());
+        let mut stages = HashMap::with_capacity(shard_context.table_ctxs.len());
         for table_ctx in shard_context.table_ctxs {
             let space = &table_ctx.space;
             let table_id = table_ctx.table_def.id;
@@ -224,14 +224,14 @@ impl ShardOpener {
                     space: table_ctx.space,
                 })
             };
-            states.insert(table_id, state);
+            stages.insert(table_id, state);
         }
 
         Ok(Self {
             shard_id: shard_context.shard_id,
             manifest,
             wal_manager,
-            stages: states,
+            stages,
             wal_replay_batch_size,
             flusher,
             max_retry_flush_limit,
@@ -247,9 +247,9 @@ impl ShardOpener {
         self.recover_table_datas().await?;
 
         // Retrieve the table results and return.
-        let states = std::mem::take(&mut self.stages);
-        let mut table_results = HashMap::with_capacity(states.len());
-        for (table_id, state) in states {
+        let stages = std::mem::take(&mut self.stages);
+        let mut table_results = HashMap::with_capacity(stages.len());
+        for (table_id, state) in stages {
             match state {
                 TableOpenStage::Failed(e) => {
                     table_results.insert(table_id, Err(e));

--- a/analytic_engine/src/instance/serial_executor.rs
+++ b/analytic_engine/src/instance/serial_executor.rs
@@ -223,6 +223,8 @@ fn on_flush_finished(schedule_sync: ScheduleSyncRef, res: &Result<()>) {
                 *flush_state = FlushState::Ready;
             }
             Err(e) => {
+                error!("Failed to run flush task, err:{e}");
+
                 schedule_sync.inc_flush_failure_count();
                 let err_msg = e.to_string();
                 *flush_state = FlushState::Failed { err_msg };

--- a/analytic_engine/src/instance/wal_replayer.rs
+++ b/analytic_engine/src/instance/wal_replayer.rs
@@ -1,0 +1,500 @@
+// Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+use std::{collections::{VecDeque, HashMap}, fmt::Display};
+
+use async_trait::async_trait;
+use common_types::{table::ShardId, schema::IndexInWriterSchema, SequenceNumber};
+use common_util::error::{GenericError, GenericResult, BoxError};
+use log::{debug, info, trace, error};
+use snafu::ResultExt;
+use table_engine::table::TableId;
+use wal::{manager::{WalManager, ReadContext, ReadRequest, WalManagerRef, ReadBoundary, ScanRequest, RegionId, ScanContext}, log_batch::LogEntry};
+use crate::{instance::{engine::{Result, ReplayWalNoCause, ReplayWalWithCause}, 
+flush_compaction::{Flusher, TableFlushOptions}, serial_executor::TableOpSerialExecutor, self, write::MemTableWriter}, 
+table::data::TableDataRef, payload::{ReadPayload, WalDecoder}};
+
+/// Wal replayer
+pub struct WalReplayer {
+    stages: HashMap<TableId, ReplayStage>,
+    context: ReplayContext,
+    mode: ReplayMode,
+}
+
+impl WalReplayer {
+    fn build_core(mode: ReplayMode) -> Box<dyn ReplayCore> {
+        info!("Replay wal in mode:{mode:?}");
+
+        match mode {
+            ReplayMode::RegionBased => Box::new(TableBasedCore),
+            ReplayMode::TableBased => Box::new(RegionBasedCore),
+        }
+    }
+
+    pub async fn replay(&mut self) -> Result<HashMap<TableId, Result<()>>> {
+        // Build core according to mode.
+        let core = Self::build_core(self.mode); 
+        info!(
+            "Replay wal logs begin, context:{}, states:{:?}", self.context, self.stages
+        );
+        core.replay(&self.context, &mut self.stages).await?;
+        info!(
+            "Replay wal logs finish, context:{}, states:{:?}", self.context, self.stages,
+        );        
+
+        // Return the replay results.        
+        let stages = std::mem::take(&mut self.stages);
+        let mut results = HashMap::with_capacity(self.stages.len());
+        for (table_id, stage) in stages {
+            let result = match stage {
+                ReplayStage::Failed(e) => Err(e),
+                ReplayStage::Success(_) => Ok(()),
+                ReplayStage::Replay(_) => return ReplayWalNoCause {
+                    msg: Some(format!("invalid stage, stage:{stage:?}, table_id:{table_id}, context:{}, mode:{:?}", self.context, self.mode)),
+                }.fail(),
+            };
+            results.insert(table_id, result);
+        }
+
+        Ok(results)
+    }
+}
+ 
+struct ReplayContext {
+    pub shard_id: ShardId,
+    pub wal_manager: WalManagerRef,
+    pub wal_replay_batch_size: usize,
+    pub flusher: Flusher,
+    pub max_retry_flush_limit: usize,
+}
+
+impl Display for ReplayContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplayContext")
+        .field("shard_id", &self.shard_id)
+        .field("replay_batch_size", &self.wal_replay_batch_size)
+        .field("max_retry_flush_limit", &self.max_retry_flush_limit)
+        .finish()
+    }
+}
+
+#[derive(Debug)]
+enum ReplayStage {
+    Replay(TableDataRef),
+    Failed(crate::instance::engine::Error),
+    Success(()),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ReplayMode {
+    RegionBased,
+    TableBased,
+}
+
+/// Replay core, the abstract of different replay strategies
+#[async_trait]
+trait ReplayCore {
+    async fn replay(&self, context: &ReplayContext, states: &mut HashMap<TableId, ReplayStage>) -> Result<()>;
+}
+
+/// Table based wal replay core
+struct TableBasedCore;
+
+#[async_trait]
+impl ReplayCore for TableBasedCore {
+    async fn replay(&self, context: &ReplayContext, states: &mut HashMap<TableId, ReplayStage>) -> Result<()> {
+        debug!(
+            "Replay wal logs on table mode, context:{context}, states:{states:?}",
+        );
+
+        for (table_id, stage) in states.iter_mut() {
+            match stage {
+                ReplayStage::Replay(table_data) => {
+                    let read_ctx = ReadContext {
+                        batch_size: context.wal_replay_batch_size,
+                        ..Default::default()
+                    };
+        
+                    let result = Self::recover_table_logs(
+                        &context.flusher,
+                        context.max_retry_flush_limit,
+                        context.wal_manager.as_ref(),
+                        table_data.clone(),
+                        context.wal_replay_batch_size,
+                        &read_ctx,
+                    ).await;
+
+                    match result {
+                        Ok(()) => {
+                            *stage = ReplayStage::Success(());
+                        },
+                        Err(e) => {
+                            *stage = ReplayStage::Failed(e);
+                        },
+                    }
+                }
+
+                ReplayStage::Failed(_) | ReplayStage::Success(_) => {
+                    return ReplayWalNoCause {
+                        msg: Some(format!("invalid stage, stage:{stage:?}, table_id:{}, shard_id:{}", table_id, context.shard_id))
+                    }.fail();
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl TableBasedCore {
+    /// Recover table data from wal.
+    ///
+    /// Called by write worker
+    async fn recover_table_logs(
+        flusher: &Flusher,
+        max_retry_flush_limit: usize,
+        wal_manager: &dyn WalManager,
+        table_data: TableDataRef,
+        replay_batch_size: usize,
+        read_ctx: &ReadContext,
+    ) -> Result<()> {
+        let table_location = table_data.table_location();
+        let wal_location =
+            instance::create_wal_location(table_location.id, table_location.shard_info);
+        let read_req = ReadRequest {
+            location: wal_location,
+            start: ReadBoundary::Excluded(table_data.current_version().flushed_sequence()),
+            end: ReadBoundary::Max,
+        };
+
+        // Read all wal of current table.
+        let mut log_iter = wal_manager
+            .read_batch(read_ctx, &read_req)
+            .await
+            .box_err()
+            .context(ReplayWalWithCause {
+                msg: None,
+            })?;
+
+        let mut serial_exec = table_data.serial_exec.lock().await;
+        let mut log_entry_buf = VecDeque::with_capacity(replay_batch_size);
+        loop {
+            // fetch entries to log_entry_buf
+            let decoder = WalDecoder::default();
+            log_entry_buf = log_iter
+                .next_log_entries(decoder, log_entry_buf)
+                .await
+                .box_err()
+                .context(ReplayWalWithCause {
+                    msg: None,
+                })?;
+
+            if log_entry_buf.is_empty() {
+                break;
+            }
+    
+            // Replay all log entries of current table
+            let last_sequence = log_entry_buf.back().unwrap().sequence;
+            replay_table_log_entries(
+                flusher,
+                max_retry_flush_limit,
+                &mut serial_exec,
+                &table_data,
+                log_entry_buf.iter(),
+                last_sequence
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Region based wal replay core
+struct RegionBasedCore;
+
+#[async_trait]
+impl ReplayCore for RegionBasedCore {
+    async fn replay(&self, context: &ReplayContext, states: &mut HashMap<TableId, ReplayStage>) -> Result<()> {
+        debug!(
+            "Replay wal logs on region mode, context:{context}, states:{states:?}",
+        );
+
+        for (table_id, state) in states.iter_mut() {
+            match state {
+                ReplayStage::Replay(table_data) => {
+                    let read_ctx = ReadContext {
+                        batch_size: context.wal_replay_batch_size,
+                        ..Default::default()
+                    };
+                    
+                    let result = Self::replay_region_logs(
+                        &context.flusher,
+                        context.max_retry_flush_limit,
+                        context.wal_manager.as_ref(),
+                        table_data.clone(),
+                        context.wal_replay_batch_size,
+                        &read_ctx,
+                        states,
+                    ).await;
+
+                    match result {
+                        Ok(()) => {
+                            *state = ReplayStage::Success(());
+                        },
+                        Err(e) => {
+                            *state = ReplayStage::Failed(e);
+                        },
+                    }
+                },
+                ReplayStage::Failed(_) | ReplayStage::Success(_) => {
+                    return ReplayWalNoCause {
+                        msg: Some(format!("table_id:{}, shard_id:{}", table_id, context.shard_id))
+                    }.fail();
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl RegionBasedCore {
+    /// Replay logs in same region.
+    /// 
+    /// Steps:
+    /// + Scan all logs of region.
+    /// + Split logs according to table ids.
+    /// + Replay logs to recover data of tables.
+    async fn replay_region_logs(
+        shard_id: ShardId,
+        flusher: &Flusher,
+        max_retry_flush_limit: usize,
+        wal_manager: &dyn WalManager,
+        replay_batch_size: usize,
+        scan_ctx: &ScanContext,
+        states: &mut HashMap<TableId, ReplayStage>
+    ) -> Result<()> {
+        // Scan all wal logs of current shard.
+        let scan_req = ScanRequest {
+            region_id: shard_id as RegionId,
+        };
+
+        let mut log_iter = wal_manager
+            .scan(scan_ctx, &scan_req)
+            .await
+            .box_err()
+            .context(ReplayWalWithCause {
+                msg: None,
+            })?;
+        let mut log_entry_buf = VecDeque::with_capacity(replay_batch_size);
+            
+        // Lock all related tables.
+        let mut table_serial_execs = HashMap::with_capacity(states.len());
+        for (table_id, state) in states {
+            match state {
+                ReplayStage::Replay(table_data) => {
+                    let mut serial_exec = table_data.serial_exec.lock().await;
+                    table_serial_execs.insert(*table_id, &mut *serial_exec);
+                }
+                ReplayStage::Failed(_) | ReplayStage::Success(_) => {
+                    return ReplayWalNoCause {
+                        msg: Some(format!("table_id:{table_id}, shard_id:{shard_id}"))
+                    }.fail();
+                } 
+            }
+        }
+
+        // Split and replay logs.
+        loop {
+            let decoder = WalDecoder::default();
+            log_entry_buf = log_iter
+                .next_log_entries(decoder, log_entry_buf)
+                .await
+                .box_err()
+                .context(ReplayWalWithCause {
+                    msg: None,
+                })?;
+
+            if log_entry_buf.is_empty() {
+                break;
+            }
+
+            Self::replay_single_batch(&log_entry_buf, flusher, max_retry_flush_limit, wal_manager, replay_batch_size, read_ctx, &table_serial_execs, states).await;
+        }
+
+        Ok(())
+    }
+
+    async fn replay_single_batch(
+            log_batch: &VecDeque<LogEntry<ReadPayload>>, 
+            flusher: &Flusher,
+            max_retry_flush_limit: usize,
+            wal_manager: &dyn WalManager,
+            replay_batch_size: usize,
+            read_ctx: &ReadContext,
+            table_serial_execs: &HashMap<TableId, &mut TableOpSerialExecutor>,            
+            stages: &mut HashMap<TableId, ReplayStage>,
+        ) -> Result<()>
+    {
+        let mut table_batches = Vec::with_capacity(stages.len());
+        Self::split_log_batch_by_table(&log_batch, &mut table_batches);
+        for table_batch in table_batches {
+            // Replay all log entries of current table
+            let last_sequence = table_batch.last_sequence;
+            replay_table_log_entries(
+                flusher,
+                max_retry_flush_limit,
+                &mut serial_exec,
+                &table_data,
+                log_batch.range(table_batch.start_log_idx..table_batch.end_log_idx),
+                last_sequence
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    fn split_log_batch_by_table<P>(log_batch: &VecDeque<LogEntry<P>>, table_batches: &mut Vec<TableBatch>) {
+        table_batches.clear();
+
+        if log_batch.is_empty() {
+            return;
+        }
+
+        // Split log batch by table id, for example:
+        // input batch:
+        //  |1|1|2|2|2|3|3|3|3|
+        //
+        // output batches:
+        //  |1|1|, |2|2|2|, |3|3|3|3|
+        let mut start_log_idx = 0usize;
+        for log_idx in 0..log_batch.len() {
+            let last_round = log_idx + 1 == log_batch.len();
+            
+            let start_log_entry = log_batch.get(start_log_idx).unwrap();
+            let current_log_entry = log_batch.get(log_idx).unwrap();
+            
+            let start_table_id = start_log_entry.table_id;
+            let current_table_id = current_log_entry.table_id;
+            let current_sequence = current_log_entry.sequence;
+
+            if (current_table_id !=  start_table_id) || last_round {
+                let end_log_idx = if last_round {
+                    log_batch.len()
+                } else {
+                    start_log_idx = log_idx;
+                    log_idx
+                };
+                
+                table_batches.push(TableBatch {
+                    table_id: TableId::new(start_table_id),
+                    last_sequence: current_sequence,
+                    start_log_idx,
+                    end_log_idx,
+                });
+            }
+        }
+    }
+}
+
+struct TableBatch {
+    table_id: TableId,
+    last_sequence: SequenceNumber,
+    start_log_idx: usize,
+    end_log_idx: usize,
+}
+
+/// Replay all log entries into memtable and flush if necessary.
+async fn replay_table_log_entries(
+    flusher: &Flusher,
+    max_retry_flush_limit: usize,
+    serial_exec: &mut TableOpSerialExecutor,
+    table_data: &TableDataRef,
+    log_entries: impl Iterator<Item = &LogEntry<ReadPayload>>,
+    last_sequence: SequenceNumber,
+) -> Result<()> {
+    debug!(
+        "Replay table log entries begin, table:{}, table_id:{:?}, sequence:{}",
+        table_data.name, table_data.id, last_sequence
+    );
+
+    for log_entry in log_entries {
+        let (sequence, payload) = (log_entry.sequence, &log_entry.payload);
+
+        // Apply to memtable
+        match payload {
+            ReadPayload::Write { row_group } => {
+                trace!(
+                    "Instance replay row_group, table:{}, row_group:{:?}",
+                    table_data.name,
+                    row_group
+                );
+
+                let table_schema_version = table_data.schema_version();
+                if table_schema_version != row_group.schema().version() {
+                    // Data with old schema should already been flushed, but we avoid panic
+                    // here.
+                    error!(
+                        "Ignore data with mismatch schema version during replaying, \
+                        table:{}, \
+                        table_id:{:?}, \
+                        expect:{}, \
+                        actual:{}, \
+                        last_sequence:{}, \
+                        sequence:{}",
+                        table_data.name,
+                        table_data.id,
+                        table_schema_version,
+                        row_group.schema().version(),
+                        last_sequence,
+                        sequence,
+                    );
+
+                    continue;
+                }
+
+                let index_in_writer =
+                    IndexInWriterSchema::for_same_schema(row_group.schema().num_columns());
+                let memtable_writer = MemTableWriter::new(table_data.clone(), serial_exec);
+                memtable_writer
+                    .write(sequence, &row_group.into(), index_in_writer)
+                    .box_err()
+                    .context(ReplayWalWithCause {
+                        msg: Some(format!("table_id:{}, table_name:{}, space_id:{}", table_data.space_id, table_data.name, table_data.id)),
+                    })?;
+
+                // Flush the table if necessary.
+                if table_data.should_flush_table(serial_exec) {
+                    let opts = TableFlushOptions {
+                        res_sender: None,
+                        max_retry_flush_limit,
+                    };
+                    let flush_scheduler = serial_exec.flush_scheduler();
+                    flusher
+                        .schedule_flush(flush_scheduler, table_data, opts)
+                        .await
+                        .box_err()
+                        .context(ReplayWalWithCause {
+                            msg: Some(format!("table_id:{}, table_name:{}, space_id:{}", table_data.space_id, table_data.name, table_data.id)),
+                        })?;
+                }
+            }
+            ReadPayload::AlterSchema { .. } | ReadPayload::AlterOptions { .. } => {
+                // Ignore records except Data.
+                //
+                // - DDL (AlterSchema and AlterOptions) should be recovered
+                //   from Manifest on start.
+            }
+        }
+    }
+
+    debug!(
+        "Replay table log entries finish, table:{}, table_id:{:?}, last_sequence:{}",
+        table_data.name, table_data.id, last_sequence
+    );
+
+    table_data.set_last_sequence(last_sequence);
+
+    Ok(())
+}

--- a/analytic_engine/src/instance/wal_replayer.rs
+++ b/analytic_engine/src/instance/wal_replayer.rs
@@ -304,8 +304,11 @@ impl RegionBasedCore {
         serial_exec_ctxs: &mut HashMap<TableId, SerialExecContext<'_>>,
         table_results: &mut HashMap<TableId, Result<()>>,
     ) -> Result<()> {
-        let mut table_batches = Vec::with_capacity(serial_exec_ctxs.len());
+        let mut table_batches = Vec::new();
+        // TODO: No `group_by` method in `VecDeque`, so implement it manually here...
         Self::split_log_batch_by_table(log_batch, &mut table_batches);
+
+        // TODO: Replay logs of different tables in parallel.
         for table_batch in table_batches {
             // Some tables may have failed in previous replay, ignore them.
             let table_result = table_results.get(&table_batch.table_id);

--- a/analytic_engine/src/instance/wal_replayer.rs
+++ b/analytic_engine/src/instance/wal_replayer.rs
@@ -1,5 +1,7 @@
 // Copyright 2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
+//! Wal replayer
+
 use std::{
     collections::{HashMap, VecDeque},
     fmt::Display,
@@ -31,7 +33,8 @@ use crate::{
     table::data::TableDataRef,
 };
 
-/// Wal replayer
+/// Wal replayer supporting both table based and region based
+// TODO: limit the memory usage in `RegionBased` mode.
 pub struct WalReplayer<'a> {
     context: ReplayContext,
     mode: ReplayMode,
@@ -46,6 +49,7 @@ impl<'a> WalReplayer<'a> {
         wal_replay_batch_size: usize,
         flusher: Flusher,
         max_retry_flush_limit: usize,
+        replay_mode: ReplayMode,
     ) -> Self {
         let context = ReplayContext {
             shard_id,
@@ -56,7 +60,7 @@ impl<'a> WalReplayer<'a> {
         };
 
         Self {
-            mode: ReplayMode::RegionBased,
+            mode: replay_mode,
             context,
             table_datas,
         }
@@ -107,7 +111,7 @@ impl Display for ReplayContext {
 }
 
 #[derive(Debug, Clone, Copy)]
-enum ReplayMode {
+pub enum ReplayMode {
     RegionBased,
     TableBased,
 }

--- a/analytic_engine/src/instance/wal_replayer.rs
+++ b/analytic_engine/src/instance/wal_replayer.rs
@@ -428,6 +428,8 @@ async fn replay_table_log_entries(
                     row_group
                 );
 
+                // TODO: too strict check here, should be modified to like what in
+                // `ColumnSchema::compatible_for_write`.`
                 let table_schema_version = table_data.schema_version();
                 if table_schema_version != row_group.schema().version() {
                     // Data with old schema should already been flushed, but we avoid panic

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -8,7 +8,7 @@ use common_types::{
     row::{RowGroup, RowGroupSlicer},
     schema::{IndexInWriterSchema, Schema},
 };
-use common_util::{codec::row, define_result, error::GenericError};
+use common_util::{codec::row, define_result};
 use log::{debug, error, info, trace, warn};
 use smallvec::SmallVec;
 use snafu::{ensure, Backtrace, ResultExt, Snafu};

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -8,7 +8,7 @@ use common_types::{
     row::{RowGroup, RowGroupSlicer},
     schema::{IndexInWriterSchema, Schema},
 };
-use common_util::{codec::row, define_result};
+use common_util::{codec::row, define_result, error::GenericError};
 use log::{debug, error, info, trace, warn};
 use smallvec::SmallVec;
 use snafu::{ensure, Backtrace, ResultExt, Snafu};

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -97,7 +97,19 @@ pub struct Config {
     /// + Kafka
     pub wal: WalStorageConfig,
 
+    /// Recover mode
+    ///
+    /// + TableBased, tables on same shard will be recovered table by table.
+    /// + ShardBased, tables on same shard will be recovered together.
+    pub recover_mode: RecoverMode,
+
     pub remote_engine_client: remote_engine_client::config::Config,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum RecoverMode {
+    TableBased,
+    ShardBased,
 }
 
 impl Default for Config {
@@ -127,6 +139,7 @@ impl Default for Config {
             max_bytes_per_write_batch: None,
             wal: WalStorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),
+            recover_mode: RecoverMode::TableBased,
         }
     }
 }

--- a/analytic_engine/src/tests/alter_test.rs
+++ b/analytic_engine/src/tests/alter_test.rs
@@ -20,24 +20,25 @@ use crate::{
     tests::{
         row_util,
         table::{self, FixedSchemaTable},
-        util::{
-            EngineBuildContext, MemoryEngineBuildContext, Null, RocksDBEngineBuildContext,
-            TestContext, TestEnv,
-        },
+        util::{memory_ctxs, rocksdb_ctxs, EngineBuildContext, Null, TestContext, TestEnv},
     },
 };
 
 #[test]
 fn test_alter_table_add_column_rocks() {
-    let rocksdb_ctx = RocksDBEngineBuildContext::default();
-    test_alter_table_add_column(rocksdb_ctx);
+    let rocksdb_ctxs = rocksdb_ctxs();
+    for ctx in rocksdb_ctxs {
+        test_alter_table_add_column(ctx);
+    }
 }
 
 #[ignore = "Enable this test when manifest use another snapshot implementation"]
 #[test]
 fn test_alter_table_add_column_mem_wal() {
-    let memory_ctx = MemoryEngineBuildContext::default();
-    test_alter_table_add_column(memory_ctx);
+    let memory_ctxs = memory_ctxs();
+    for ctx in memory_ctxs {
+        test_alter_table_add_column(ctx);
+    }
 }
 
 fn test_alter_table_add_column<T: EngineBuildContext>(engine_context: T) {
@@ -370,15 +371,19 @@ async fn check_read_row_group<T: WalsOpener>(
 
 #[test]
 fn test_alter_table_options_rocks() {
-    let rocksdb_ctx = RocksDBEngineBuildContext::default();
-    test_alter_table_options(rocksdb_ctx);
+    let rocksdb_ctxs = rocksdb_ctxs();
+    for ctx in rocksdb_ctxs {
+        test_alter_table_options(ctx);
+    }
 }
 
 #[ignore = "Enable this test when manifest use another snapshot implementation"]
 #[test]
 fn test_alter_table_options_mem_wal() {
-    let memory_ctx = MemoryEngineBuildContext::default();
-    test_alter_table_options(memory_ctx);
+    let memory_ctxs = memory_ctxs();
+    for ctx in memory_ctxs {
+        test_alter_table_options(ctx);
+    }
 }
 
 fn test_alter_table_options<T: EngineBuildContext>(engine_context: T) {

--- a/analytic_engine/src/tests/drop_test.rs
+++ b/analytic_engine/src/tests/drop_test.rs
@@ -10,7 +10,8 @@ use table_engine::table::AlterSchemaRequest;
 use crate::tests::{
     table::FixedSchemaTable,
     util::{
-        self, EngineBuildContext, MemoryEngineBuildContext, RocksDBEngineBuildContext, TestEnv,
+        self, memory_ctxs, rocksdb_ctxs, EngineBuildContext, MemoryEngineBuildContext,
+        RocksDBEngineBuildContext, TestEnv,
     },
 };
 
@@ -209,14 +210,18 @@ fn test_drop_create_same_table_case<T: EngineBuildContext>(flush: bool, engine_c
 
 #[test]
 fn test_drop_create_same_table_rocks() {
-    let rocksdb_ctx = RocksDBEngineBuildContext::default();
-    test_drop_create_same_table(rocksdb_ctx);
+    let rocksdb_ctxs = rocksdb_ctxs();
+    for ctx in rocksdb_ctxs {
+        test_drop_create_same_table(ctx);
+    }
 }
 
 #[test]
 fn test_drop_create_same_table_mem_wal() {
-    let memory_ctx = MemoryEngineBuildContext::default();
-    test_drop_create_same_table(memory_ctx);
+    let memory_ctxs = memory_ctxs();
+    for ctx in memory_ctxs {
+        test_drop_create_same_table(ctx);
+    }
 }
 
 fn test_drop_create_same_table<T: EngineBuildContext>(engine_context: T) {
@@ -227,14 +232,18 @@ fn test_drop_create_same_table<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_alter_schema_drop_create_rocks() {
-    let rocksdb_ctx = RocksDBEngineBuildContext::default();
-    test_alter_schema_drop_create(rocksdb_ctx);
+    let rocksdb_ctxs = rocksdb_ctxs();
+    for ctx in rocksdb_ctxs {
+        test_alter_schema_drop_create(ctx);
+    }
 }
 
 #[test]
 fn test_alter_schema_drop_create_mem_wal() {
-    let memory_ctx = MemoryEngineBuildContext::default();
-    test_alter_schema_drop_create(memory_ctx);
+    let memory_ctxs = memory_ctxs();
+    for ctx in memory_ctxs {
+        test_alter_schema_drop_create(ctx);
+    }
 }
 
 fn test_alter_schema_drop_create<T: EngineBuildContext>(engine_context: T) {
@@ -284,14 +293,18 @@ fn test_alter_schema_drop_create<T: EngineBuildContext>(engine_context: T) {
 
 #[test]
 fn test_alter_options_drop_create_rocks() {
-    let rocksdb_ctx = RocksDBEngineBuildContext::default();
-    test_alter_options_drop_create(rocksdb_ctx);
+    let rocksdb_ctxs = rocksdb_ctxs();
+    for ctx in rocksdb_ctxs {
+        test_alter_options_drop_create(ctx);
+    }
 }
 
 #[test]
 fn test_alter_options_drop_create_mem_wal() {
-    let memory_ctx = MemoryEngineBuildContext::default();
-    test_alter_options_drop_create(memory_ctx);
+    let memory_ctxs = memory_ctxs();
+    for ctx in memory_ctxs {
+        test_alter_options_drop_create(ctx);
+    }
 }
 
 fn test_alter_options_drop_create<T: EngineBuildContext>(engine_context: T) {

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -249,6 +249,7 @@ impl From<TableId> for TableSeq {
 pub struct TableId(u64);
 
 impl TableId {
+    pub const MAX: TableId = TableId(u64::MAX);
     /// Min table id.
     pub const MIN: TableId = TableId(0);
 

--- a/wal/src/message_queue_impl/region.rs
+++ b/wal/src/message_queue_impl/region.rs
@@ -586,7 +586,7 @@ impl<M: MessageQueue> Region<M> {
                 table_id
             );
 
-            inner.mark_delete_to(table_id, sequence_num).await.unwrap();
+            inner.mark_delete_to(table_id, sequence_num).await?;
 
             (
                 inner.make_meta_snapshot().await,


### PR DESCRIPTION
## Rationale
Part of #799 

## Detailed Changes
- Define `WalReplayer` to carry out replay work.
- Support both `TableBased`(original) and `RegionBased` replay mode in `WalReplayer`.
- Expose related configs.

## Test Plan
- Modify exist unit tests to cover the `RegionBased` wal replay.
- Refactor the integration test to cover recovery logic(TODO).