### PR TITLE
refactor: add generic support to generate hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,6 +3982,7 @@ dependencies = [
  "ceresdbproto",
  "chrono",
  "clru",
+ "common_types",
  "common_util",
  "crc",
  "futures 0.3.28",

--- a/common_types/src/hash.rs
+++ b/common_types/src/hash.rs
@@ -4,9 +4,7 @@
 /// - Memory : aHash
 /// - Disk: SeaHash
 /// https://github.com/CeresDB/hash-benchmark-rs
-use std::{
-    hash::{BuildHasher, Hasher},
-};
+use std::hash::BuildHasher;
 
 pub use ahash;
 use byteorder::{ByteOrder, LittleEndian};

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -118,13 +118,13 @@ where
 }
 
 #[derive(Debug)]
-pub struct PartitionedMutexAsync<T, H>
+pub struct PartitionedMutexAsync<T, B>
 where
-    H: BuildHasher,
+    B: BuildHasher,
 {
     partitions: Vec<tokio::sync::Mutex<T>>,
     partition_mask: usize,
-    hash_builder: H,
+    hash_builder: B,
 }
 
 impl<T, B> PartitionedMutexAsync<T, B>

--- a/common_util/src/partitioned_lock.rs
+++ b/common_util/src/partitioned_lock.rs
@@ -3,21 +3,27 @@
 //! Partitioned locks
 
 use std::{
-    hash::{Hash, Hasher},
+    hash::{BuildHasher, Hash, Hasher},
     sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-use common_types::hash::{build_fixed_seed_ahasher, SeaHasher};
 use tokio;
 
 /// Simple partitioned `RwLock`
-pub struct PartitionedRwLock<T> {
+pub struct PartitionedRwLock<T, B>
+where
+    B: BuildHasher,
+{
     partitions: Vec<RwLock<T>>,
     partition_mask: usize,
+    hash_builder: B,
 }
 
-impl<T> PartitionedRwLock<T> {
-    pub fn new<F>(init_fn: F, partition_bit: usize) -> Self
+impl<T, B> PartitionedRwLock<T, B>
+where
+    B: BuildHasher,
+{
+    pub fn new<F>(init_fn: F, partition_bit: usize, hash_builder: B) -> Self
     where
         F: Fn() -> T,
     {
@@ -28,6 +34,7 @@ impl<T> PartitionedRwLock<T> {
         Self {
             partitions,
             partition_mask: partition_num - 1,
+            hash_builder,
         }
     }
 
@@ -44,7 +51,7 @@ impl<T> PartitionedRwLock<T> {
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &RwLock<T> {
-        let mut hasher = build_fixed_seed_ahasher();
+        let mut hasher = self.hash_builder.build_hasher();
 
         key.hash(&mut hasher);
 
@@ -59,13 +66,20 @@ impl<T> PartitionedRwLock<T> {
 
 /// Simple partitioned `Mutex`
 #[derive(Debug)]
-pub struct PartitionedMutex<T> {
+pub struct PartitionedMutex<T, B>
+where
+    B: BuildHasher,
+{
     partitions: Vec<Mutex<T>>,
     partition_mask: usize,
+    hash_builder: B,
 }
 
-impl<T> PartitionedMutex<T> {
-    pub fn new<F>(init_fn: F, partition_bit: usize) -> Self
+impl<T, B> PartitionedMutex<T, B>
+where
+    B: BuildHasher,
+{
+    pub fn new<F>(init_fn: F, partition_bit: usize, hash_builder: B) -> Self
     where
         F: Fn() -> T,
     {
@@ -76,6 +90,7 @@ impl<T> PartitionedMutex<T> {
         Self {
             partitions,
             partition_mask: partition_num - 1,
+            hash_builder,
         }
     }
 
@@ -86,7 +101,7 @@ impl<T> PartitionedMutex<T> {
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &Mutex<T> {
-        let mut hasher = build_fixed_seed_ahasher();
+        let mut hasher = self.hash_builder.build_hasher();
         key.hash(&mut hasher);
         &self.partitions[(hasher.finish() as usize) & self.partition_mask]
     }
@@ -103,13 +118,20 @@ impl<T> PartitionedMutex<T> {
 }
 
 #[derive(Debug)]
-pub struct PartitionedMutexAsync<T> {
+pub struct PartitionedMutexAsync<T, H>
+where
+    H: BuildHasher,
+{
     partitions: Vec<tokio::sync::Mutex<T>>,
     partition_mask: usize,
+    hash_builder: H,
 }
 
-impl<T> PartitionedMutexAsync<T> {
-    pub fn new<F>(init_fn: F, partition_bit: usize) -> Self
+impl<T, B> PartitionedMutexAsync<T, B>
+where
+    B: BuildHasher,
+{
+    pub fn new<F>(init_fn: F, partition_bit: usize, hash_builder: B) -> Self
     where
         F: Fn() -> T,
     {
@@ -120,6 +142,7 @@ impl<T> PartitionedMutexAsync<T> {
         Self {
             partitions,
             partition_mask: partition_num - 1,
+            hash_builder,
         }
     }
 
@@ -130,7 +153,7 @@ impl<T> PartitionedMutexAsync<T> {
     }
 
     fn get_partition<K: Eq + Hash>(&self, key: &K) -> &tokio::sync::Mutex<T> {
-        let mut hasher = SeaHasher::new();
+        let mut hasher = self.hash_builder.build_hasher();
         key.hash(&mut hasher);
         &self.partitions[(hasher.finish() as usize) & self.partition_mask]
     }
@@ -145,12 +168,15 @@ impl<T> PartitionedMutexAsync<T> {
 mod tests {
     use std::collections::HashMap;
 
+    use common_types::hash::{build_fixed_seed_ahasher_builder, SeaHasherBuilder};
+
     use super::*;
 
     #[test]
     fn test_partitioned_rwlock() {
         let init_hmap = HashMap::new;
-        let test_locked_map = PartitionedRwLock::new(init_hmap, 4);
+        let test_locked_map =
+            PartitionedRwLock::new(init_hmap, 4, build_fixed_seed_ahasher_builder());
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -168,7 +194,8 @@ mod tests {
     #[test]
     fn test_partitioned_mutex() {
         let init_hmap = HashMap::new;
-        let test_locked_map = PartitionedMutex::new(init_hmap, 4);
+        let test_locked_map =
+            PartitionedMutex::new(init_hmap, 4, build_fixed_seed_ahasher_builder());
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -186,7 +213,7 @@ mod tests {
     #[tokio::test]
     async fn test_partitioned_mutex_async() {
         let init_hmap = HashMap::new;
-        let test_locked_map = PartitionedMutexAsync::new(init_hmap, 4);
+        let test_locked_map = PartitionedMutexAsync::new(init_hmap, 4, SeaHasherBuilder);
         let test_key = "test_key".to_string();
         let test_value = "test_value".to_string();
 
@@ -204,7 +231,8 @@ mod tests {
     #[test]
     fn test_partitioned_mutex_vis_different_partition() {
         let init_vec = Vec::<i32>::new;
-        let test_locked_map = PartitionedMutex::new(init_vec, 4);
+        let test_locked_map =
+            PartitionedMutex::new(init_vec, 4, build_fixed_seed_ahasher_builder());
         let mutex_first = test_locked_map.get_partition_by_index(0);
 
         let mut _tmp_data = mutex_first.lock().unwrap();
@@ -218,7 +246,8 @@ mod tests {
     #[test]
     fn test_partitioned_rwmutex_vis_different_partition() {
         let init_vec = Vec::<i32>::new;
-        let test_locked_map = PartitionedRwLock::new(init_vec, 4);
+        let test_locked_map =
+            PartitionedRwLock::new(init_vec, 4, build_fixed_seed_ahasher_builder());
         let mutex_first = test_locked_map.get_partition_by_index(0);
         let mut _tmp = mutex_first.write().unwrap();
         assert!(mutex_first.try_write().is_err());
@@ -231,7 +260,7 @@ mod tests {
     #[tokio::test]
     async fn test_partitioned_mutex_async_vis_different_partition() {
         let init_vec = Vec::<i32>::new;
-        let test_locked_map = PartitionedMutexAsync::new(init_vec, 4);
+        let test_locked_map = PartitionedMutexAsync::new(init_vec, 4, SeaHasherBuilder);
         let mutex_first = test_locked_map.get_partition_by_index(0).await;
 
         let mut _tmp_data = mutex_first.lock().await;

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -16,6 +16,7 @@ bytes = { workspace = true }
 ceresdbproto = { workspace = true }
 chrono = { workspace = true }
 clru = { workspace = true }
+common_types = { workspace = true }
 common_util = { workspace = true }
 crc = "3.0.0"
 futures = { workspace = true }

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -11,6 +11,7 @@ use std::{collections::BTreeMap, fmt::Display, ops::Range, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
+use common_types::hash::SeaHasherBuilder;
 use common_util::{partitioned_lock::PartitionedMutexAsync, time::current_as_rfc3339};
 use crc::{Crc, CRC_32_ISCSI};
 use futures::stream::BoxStream;
@@ -119,7 +120,7 @@ struct DiskCache {
     root_dir: String,
     cap: usize,
     // Cache key is used as filename on disk.
-    cache: PartitionedMutexAsync<LruCache<String, ()>>,
+    cache: PartitionedMutexAsync<LruCache<String, ()>, SeaHasherBuilder>,
 }
 
 impl DiskCache {
@@ -128,7 +129,7 @@ impl DiskCache {
         Self {
             root_dir,
             cap,
-            cache: PartitionedMutexAsync::new(init_lru, partition_bits),
+            cache: PartitionedMutexAsync::new(init_lru, partition_bits, SeaHasherBuilder {}),
         }
     }
 


### PR DESCRIPTION
## Rationale
Add generic support to generate hasher 

## Detailed Changes
Add generic support to generate hasher  for all `PartitionedLock`.

## Test Plan
Ut.