### PR TITLE
chore: deny `dbg-macro` in clippy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ udeps:
 	cd $(DIR); cargo udeps --all-targets --all-features --workspace
 
 clippy:
-	cd $(DIR); cargo clippy --all-targets --all-features --workspace -- -D warnings
+	cd $(DIR); cargo clippy --all-targets --all-features --workspace -- -D warnings -D clippy::dbg-macro
 
 # test with address sanitizer
 asan-test:

--- a/components/message_queue/src/kafka/kafka_impl.rs
+++ b/components/message_queue/src/kafka/kafka_impl.rs
@@ -141,8 +141,7 @@ impl KafkaImplInner {
             panic!("The boost broker must be set");
         }
 
-        let mut client_builder =
-            ClientBuilder::new(config.client.boost_brokers.clone().unwrap());
+        let mut client_builder = ClientBuilder::new(config.client.boost_brokers.clone().unwrap());
         if let Some(max_message_size) = config.client.max_message_size {
             client_builder = client_builder.max_message_size(max_message_size);
         }

--- a/components/message_queue/src/kafka/kafka_impl.rs
+++ b/components/message_queue/src/kafka/kafka_impl.rs
@@ -142,7 +142,7 @@ impl KafkaImplInner {
         }
 
         let mut client_builder =
-            ClientBuilder::new(dbg!(config.client.boost_brokers.clone().unwrap()));
+            ClientBuilder::new(config.client.boost_brokers.clone().unwrap());
         if let Some(max_message_size) = config.client.max_message_size {
             client_builder = client_builder.max_message_size(max_message_size);
         }


### PR DESCRIPTION
## Rationale
`clippy::dbg-macro` lint default to allow in clippy, but we want it to be denied.

## Detailed Changes
Add `-D clippy::dbg-macro` when running `cargo clippy`.

## Test Plan
Not need.