### PR TITLE
refactor: avoid grpc forwarding twice

### DIFF
--- a/proxy/src/forward.rs
+++ b/proxy/src/forward.rs
@@ -21,6 +21,8 @@ use tonic::{
     transport::{self, Channel},
 };
 
+use crate::FORWARDED;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(
@@ -68,6 +70,12 @@ pub enum Error {
         source: tonic::transport::Error,
         backtrace: Backtrace,
     },
+
+    #[snafu(display(
+        "Request should not be forwarded multiple times, forward endpoint:{}",
+        endpoint
+    ))]
+    ForwardedErr { endpoint: String },
 }
 
 define_result!(Error);
@@ -184,6 +192,7 @@ pub struct ForwardRequest<Req> {
     pub schema: String,
     pub table: String,
     pub req: tonic::Request<Req>,
+    pub forwarded: bool,
 }
 
 impl Forwarder<DefaultClientBuilder> {
@@ -256,7 +265,12 @@ impl<B: ClientBuilder> Forwarder<B> {
         F: ForwarderRpc<Req, Resp, Err>,
         Req: std::fmt::Debug + Clone,
     {
-        let ForwardRequest { schema, table, req } = forward_req;
+        let ForwardRequest {
+            schema,
+            table,
+            req,
+            forwarded,
+        } = forward_req;
 
         let route_req = RouteRequest {
             context: Some(RequestContext { database: schema }),
@@ -281,13 +295,15 @@ impl<B: ClientBuilder> Forwarder<B> {
             }
         };
 
-        self.forward_with_endpoint(endpoint, req, do_rpc).await
+        self.forward_with_endpoint(endpoint, req, forwarded, do_rpc)
+            .await
     }
 
     pub async fn forward_with_endpoint<Req, Resp, Err, F>(
         &self,
         endpoint: Endpoint,
         mut req: tonic::Request<Req>,
+        forwarded: bool,
         do_rpc: F,
     ) -> Result<ForwardResult<Resp, Err>>
     where
@@ -310,6 +326,15 @@ impl<B: ClientBuilder> Forwarder<B> {
             "Try to forward request to {:?}, request:{:?}",
             endpoint, req,
         );
+
+        if forwarded {
+            let endpoint = endpoint.to_string();
+            return ForwardedErr { endpoint }.fail();
+        }
+
+        // mark forwarded
+        req.metadata_mut().insert(FORWARDED, "".parse().unwrap());
+
         let client = self.get_or_create_client(&endpoint).await?;
         match do_rpc(client, req, &endpoint).await {
             Err(e) => {
@@ -461,6 +486,7 @@ mod tests {
                 schema: DEFAULT_SCHEMA.to_string(),
                 table: table.to_string(),
                 req: query_request.into_request(),
+                forwarded: false,
             }
         };
 

--- a/proxy/src/grpc/sql_query.rs
+++ b/proxy/src/grpc/sql_query.rs
@@ -104,7 +104,11 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
 
         let req_context = req.context.as_ref().unwrap();
         let schema = req_context.database.clone();
-        let req = match self.clone().maybe_forward_stream_sql_query(&req).await {
+        let req = match self
+            .clone()
+            .maybe_forward_stream_sql_query(ctx.clone(), &req)
+            .await
+        {
             Some(resp) => match resp {
                 ForwardResult::Forwarded(resp) => return resp,
                 ForwardResult::Local => req,
@@ -150,6 +154,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
 
     async fn maybe_forward_stream_sql_query(
         self: Arc<Self>,
+        ctx: Context,
         req: &SqlQueryRequest,
     ) -> Option<ForwardResult<BoxStream<'static, SqlQueryResponse>, Error>> {
         if req.tables.len() != 1 {
@@ -163,6 +168,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             schema: req_ctx.database.clone(),
             table: req.tables[0].clone(),
             req: req.clone().into_request(),
+            forwarded: ctx.forwarded,
         };
         let do_query = |mut client: StorageServiceClient<Channel>,
                         request: tonic::Request<SqlQueryRequest>,

--- a/proxy/src/grpc/sql_query.rs
+++ b/proxy/src/grpc/sql_query.rs
@@ -168,7 +168,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             schema: req_ctx.database.clone(),
             table: req.tables[0].clone(),
             req: req.clone().into_request(),
-            forwarded: ctx.forwarded,
+            forwarded_from: ctx.forwarded_from,
         };
         let do_query = |mut client: StorageServiceClient<Channel>,
                         request: tonic::Request<SqlQueryRequest>,

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -62,6 +62,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             runtime: self.engine_runtimes.write_runtime.clone(),
             timeout: ctx.timeout,
             enable_partition_table_access: false,
+            forwarded: false,
         };
 
         let result = self.handle_write_internal(ctx, table_request).await?;

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -62,7 +62,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             runtime: self.engine_runtimes.write_runtime.clone(),
             timeout: ctx.timeout,
             enable_partition_table_access: false,
-            forwarded: false,
+            forwarded_from: None,
         };
 
         let result = self.handle_write_internal(ctx, table_request).await?;

--- a/proxy/src/http/sql.rs
+++ b/proxy/src/http/sql.rs
@@ -37,7 +37,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             timeout: ctx.timeout,
             runtime: self.engine_runtimes.read_runtime.clone(),
             enable_partition_table_access: true,
-            forwarded: false,
+            forwarded_from: None,
         };
 
         match self.handle_sql(context, &ctx.schema, &req.query).await? {

--- a/proxy/src/http/sql.rs
+++ b/proxy/src/http/sql.rs
@@ -37,6 +37,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             timeout: ctx.timeout,
             runtime: self.engine_runtimes.read_runtime.clone(),
             enable_partition_table_access: true,
+            forwarded: false,
         };
 
         match self.handle_sql(context, &ctx.schema, &req.query).await? {

--- a/proxy/src/influxdb/mod.rs
+++ b/proxy/src/influxdb/mod.rs
@@ -58,6 +58,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             timeout: ctx.timeout,
             runtime: self.engine_runtimes.write_runtime.clone(),
             enable_partition_table_access: false,
+            forwarded: false,
         };
         let result = self
             .handle_write_internal(proxy_context, table_request)

--- a/proxy/src/influxdb/mod.rs
+++ b/proxy/src/influxdb/mod.rs
@@ -58,7 +58,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             timeout: ctx.timeout,
             runtime: self.engine_runtimes.write_runtime.clone(),
             enable_partition_table_access: false,
-            forwarded: false,
+            forwarded_from: None,
         };
         let result = self
             .handle_write_internal(proxy_context, table_request)

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -22,7 +22,7 @@ pub mod schema_config_provider;
 mod util;
 mod write;
 
-pub const FORWARDED: &str = "forwarded";
+pub const FORWARDED_FROM: &str = "forwarded-from";
 
 use std::{
     sync::Arc,
@@ -133,7 +133,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             schema: req_ctx.database.clone(),
             table: metric,
             req: req.into_request(),
-            forwarded: false,
+            forwarded_from: None,
         };
         let do_query = |mut client: StorageServiceClient<Channel>,
                         request: tonic::Request<PrometheusRemoteQueryRequest>,
@@ -455,5 +455,5 @@ pub struct Context {
     pub timeout: Option<Duration>,
     pub runtime: Arc<Runtime>,
     pub enable_partition_table_access: bool,
-    pub forwarded: bool,
+    pub forwarded_from: Option<String>,
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -22,6 +22,8 @@ pub mod schema_config_provider;
 mod util;
 mod write;
 
+pub const FORWARDED: &str = "forwarded";
+
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -131,6 +133,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             schema: req_ctx.database.clone(),
             table: metric,
             req: req.into_request(),
+            forwarded: false,
         };
         let do_query = |mut client: StorageServiceClient<Channel>,
                         request: tonic::Request<PrometheusRemoteQueryRequest>,
@@ -452,4 +455,5 @@ pub struct Context {
     pub timeout: Option<Duration>,
     pub runtime: Arc<Runtime>,
     pub enable_partition_table_access: bool,
+    pub forwarded: bool,
 }

--- a/proxy/src/read.rs
+++ b/proxy/src/read.rs
@@ -178,7 +178,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             schema: schema.to_string(),
             table: table_name.unwrap(),
             req: sql_request.into_request(),
-            forwarded: ctx.forwarded,
+            forwarded_from: ctx.forwarded_from,
         };
         let do_query = |mut client: StorageServiceClient<Channel>,
                         request: tonic::Request<SqlQueryRequest>,

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -438,7 +438,7 @@ impl<Q: QueryExecutor + 'static> Proxy<Q> {
             .forward_with_endpoint(
                 endpoint,
                 tonic::Request::new(table_write_request),
-                ctx.forwarded,
+                ctx.forwarded_from,
                 do_write,
             )
             .await;

--- a/server/src/grpc/storage_service/mod.rs
+++ b/server/src/grpc/storage_service/mod.rs
@@ -21,7 +21,7 @@ use ceresdbproto::{
 use common_util::time::InstantExt;
 use futures::{stream, stream::BoxStream, StreamExt};
 use http::StatusCode;
-use proxy::{Context, Proxy, FORWARDED};
+use proxy::{Context, Proxy, FORWARDED_FROM};
 use query_engine::executor::Executor as QueryExecutor;
 use table_engine::engine::EngineRuntimes;
 
@@ -138,7 +138,10 @@ impl<Q: QueryExecutor + 'static> StorageService for StorageServiceImpl<Q> {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
             enable_partition_table_access: false,
-            forwarded: req.metadata().contains_key(FORWARDED),
+            forwarded_from: req
+                .metadata()
+                .get(FORWARDED_FROM)
+                .map(|value| value.to_str().unwrap().to_string()),
         };
         let stream = Self::stream_sql_query_internal(ctx, proxy, req).await;
 
@@ -160,7 +163,10 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
             enable_partition_table_access: false,
-            forwarded: req.metadata().contains_key(FORWARDED),
+            forwarded_from: req
+                .metadata()
+                .get(FORWARDED_FROM)
+                .map(|value| value.to_str().unwrap().to_string()),
         };
         let req = req.into_inner();
         let proxy = self.proxy.clone();
@@ -192,7 +198,10 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
             runtime: self.runtimes.write_runtime.clone(),
             timeout: self.timeout,
             enable_partition_table_access: false,
-            forwarded: req.metadata().contains_key(FORWARDED),
+            forwarded_from: req
+                .metadata()
+                .get(FORWARDED_FROM)
+                .map(|value| value.to_str().unwrap().to_string()),
         };
         let req = req.into_inner();
         let proxy = self.proxy.clone();
@@ -233,7 +242,10 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
             enable_partition_table_access: false,
-            forwarded: req.metadata().contains_key(FORWARDED),
+            forwarded_from: req
+                .metadata()
+                .get(FORWARDED_FROM)
+                .map(|value| value.to_str().unwrap().to_string()),
         };
         let req = req.into_inner();
         let proxy = self.proxy.clone();
@@ -298,7 +310,10 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
             runtime: self.runtimes.read_runtime.clone(),
             timeout: self.timeout,
             enable_partition_table_access: false,
-            forwarded: req.metadata().contains_key(FORWARDED),
+            forwarded_from: req
+                .metadata()
+                .get(FORWARDED_FROM)
+                .map(|value| value.to_str().unwrap().to_string()),
         };
         let req = req.into_inner();
         let proxy = self.proxy.clone();
@@ -340,7 +355,10 @@ impl<Q: QueryExecutor + 'static> StorageServiceImpl<Q> {
             runtime: self.runtimes.write_runtime.clone(),
             timeout: self.timeout,
             enable_partition_table_access: false,
-            forwarded: req.metadata().contains_key(FORWARDED),
+            forwarded_from: req
+                .metadata()
+                .get(FORWARDED_FROM)
+                .map(|value| value.to_str().unwrap().to_string()),
         };
         let mut stream = req.into_inner();
         let proxy = self.proxy.clone();


### PR DESCRIPTION
## Rationale
Close #984 

## Detailed Changes
Add a parameter to the headers of grpc to mark that it has been forwarded.

## Test Plan
Existing tests