### PR TITLE
chore: install git in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:${RUST_VERSION}-slim-bullseye as build
 # cache mounts below may already exist and owned by root
 USER root
 
-RUN apt update && apt install --yes gcc g++ libssl-dev pkg-config cmake protobuf-compiler && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install --yes git gcc g++ libssl-dev pkg-config cmake protobuf-compiler && rm -rf /var/lib/apt/lists/*
 
 COPY . /ceresdb
 WORKDIR /ceresdb


### PR DESCRIPTION
## Rationale
git version is missing in docker

## Detailed Changes
Install git in Dockerfile

## Test Plan

https://github.com/CeresDB/ceresdb/actions/runs/5252618309
```
root@35379a134476:/# ceresdb-server --version
CeresDB Server 
Version: 1.2.2
Git commit: 5c63d19
Git branch: fix-version
Opt level: 3
```