### PR TITLE
feat: use instead forked `rskafka` to support limited retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5340,8 +5340,8 @@ dependencies = [
 
 [[package]]
 name = "rskafka"
-version = "0.3.0"
-source = "git+https://github.com/influxdata/rskafka.git?rev=00988a564b1db0249d858065fc110476c075efad#00988a564b1db0249d858065fc110476c075efad"
+version = "0.4.0"
+source = "git+https://github.com/Rachelint/rskafka.git?rev=f0fd8e278d8164cb0cfca5a80476361fc308ecc3#f0fd8e278d8164cb0cfca5a80476361fc308ecc3"
 dependencies = [
  "async-trait",
  "bytes",

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -265,10 +265,6 @@ where
         }
 
         if has_logs {
-            debug!(
-                "Manifest recover with only logs, table_id:{}, space_id:{}",
-                self.table_id, self.space_id
-            );
             Ok(Some(Snapshot {
                 end_seq: latest_seq,
                 data: manifest_data_builder.build(),
@@ -494,7 +490,7 @@ impl Manifest for ManifestImpl {
     }
 
     async fn recover(&self, load_req: &LoadRequest) -> GenericResult<()> {
-        info!("Manifest recover begin, request:{:?}", load_req);
+        info!("Manifest recover begin, request:{load_req:?}");
 
         // Load table meta snapshot from storage.
         let location = WalLocation::new(load_req.shard_id as u64, load_req.table_id.as_u64());
@@ -527,7 +523,7 @@ impl Manifest for ManifestImpl {
             self.table_meta_set.apply_edit_to_table(request)?;
         }
 
-        info!("Manifest recover finish, request:{:?}", load_req);
+        info!("Manifest recover finish, request:{load_req:?}");
 
         Ok(())
     }

--- a/components/message_queue/Cargo.toml
+++ b/components/message_queue/Cargo.toml
@@ -16,8 +16,8 @@ snafu = { workspace = true }
 tokio = { workspace = true }
 
 [dependencies.rskafka]
-git = "https://github.com/influxdata/rskafka.git"
-rev = "00988a564b1db0249d858065fc110476c075efad"
+git = "https://github.com/Rachelint/rskafka.git"
+rev = "f0fd8e278d8164cb0cfca5a80476361fc308ecc3"
 default-features = false
 features = ["compression-gzip", "compression-lz4", "compression-snappy"]
 

--- a/components/message_queue/src/kafka/config.rs
+++ b/components/message_queue/src/kafka/config.rs
@@ -2,18 +2,37 @@
 
 //! Kafka implementation's config
 
+use common_util::config::ReadableDuration;
 use serde::{Deserialize, Serialize};
 
 /// Generic client config that is used for consumers, producers as well as admin
 /// operations (like "create topic").
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
     pub client: ClientConfig,
     pub topic_management: TopicManagementConfig,
     pub consumer: ConsumerConfig,
+    pub retry_interval_factor: f64,
+    pub init_retry_interval: ReadableDuration,
+    pub max_retry_interval: ReadableDuration,
+    pub max_retry: usize,
     // TODO: may need some config options for producer,
     // but it seems nothing needed now.
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            client: Default::default(),
+            topic_management: Default::default(),
+            consumer: Default::default(),
+            retry_interval_factor: 2.0,
+            init_retry_interval: ReadableDuration::secs(1),
+            max_retry_interval: ReadableDuration::secs(10),
+            max_retry: 10,
+        }
+    }
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Rationale
Part of #799 
We use `rskafka` as our kafka client.
However I found it will retry without limit even though kafka service is unavailable...
(see [https://github.com/influxdata/rskafka/issues/65](https://github.com/influxdata/rskafka/issues/65))
Worse, I found `rskafka` is almostis no longer maintained...

For quick fix, I forked it to support limited retry.

## Detailed Changes
+ Use the instead forked `rskafka`(supporting limited retry).
+ Add more logs in recovery path for better debugging.

## Test Plan
Test manually.