### PR TITLE
chore: bump ceresdbproto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d5d1c238f84dee01e671603c6a921868f3663256e0393c64ece88e58ee4869"
+checksum = "cbfdcd9746d2b027e2880ef80bb6c5735ea45ad590f21b2cd2168eb11ba66f7a"
 dependencies = [
  "prost",
  "protoc-bin-vendored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ bytes = "1.1.0"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = "1.0.4"
+ceresdbproto = "1.0.5"
 chrono = "0.4"
 clap = "3.0"
 clru = "0.6.1"


### PR DESCRIPTION
## Rationale
See https://github.com/CeresDB/ceresdbproto/pull/81

After this, developers can set `export CERESDBPROTO_ENABLE_VENDORED=false` to use protoc on their host.

## Detailed Changes


## Test Plan
No need.

