### PR TITLE
feat: expose more rocksdb options

### DIFF
--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -175,6 +175,11 @@ impl WalsOpener for RocksDBWalsOpener {
         let data_wal = RocksWalBuilder::new(wal_path, write_runtime.clone())
             .max_background_jobs(rocksdb_wal_config.data_namespace.max_background_jobs)
             .enable_statistics(rocksdb_wal_config.data_namespace.enable_statistics)
+            .write_buffer_size(rocksdb_wal_config.data_namespace.write_buffer_size)
+            .max_write_buffer_number(rocksdb_wal_config.data_namespace.max_write_buffer_number)
+            .level_zero_file_num_compaction_trigger(rocksdb_wal_config.data_namespace.level_zero_file_num_compaction_trigger)
+            .level_zero_slowdown_writes_trigger(rocksdb_wal_config.data_namespace.level_zero_slowdown_writes_trigger)
+            .level_zero_stop_writes_trigger(rocksdb_wal_config.data_namespace.level_zero_stop_writes_trigger)
             .build()
             .context(OpenWal)?;
 
@@ -182,6 +187,11 @@ impl WalsOpener for RocksDBWalsOpener {
         let manifest_wal = RocksWalBuilder::new(manifest_path, write_runtime)
             .max_background_jobs(rocksdb_wal_config.meta_namespace.max_background_jobs)
             .enable_statistics(rocksdb_wal_config.meta_namespace.enable_statistics)
+            .write_buffer_size(rocksdb_wal_config.meta_namespace.write_buffer_size)
+            .max_write_buffer_number(rocksdb_wal_config.meta_namespace.max_write_buffer_number)
+            .level_zero_file_num_compaction_trigger(rocksdb_wal_config.meta_namespace.level_zero_file_num_compaction_trigger)
+            .level_zero_slowdown_writes_trigger(rocksdb_wal_config.meta_namespace.level_zero_slowdown_writes_trigger)
+            .level_zero_stop_writes_trigger(rocksdb_wal_config.meta_namespace.level_zero_stop_writes_trigger)
             .build()
             .context(OpenManifestWal)?;
         let opened_wals = OpenedWals {

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -176,7 +176,7 @@ impl WalsOpener for RocksDBWalsOpener {
             .max_subcompactions(rocksdb_wal_config.data_namespace.max_subcompactions)
             .max_background_jobs(rocksdb_wal_config.data_namespace.max_background_jobs)
             .enable_statistics(rocksdb_wal_config.data_namespace.enable_statistics)
-            .write_buffer_size(rocksdb_wal_config.data_namespace.write_buffer_size)
+            .write_buffer_size(rocksdb_wal_config.data_namespace.write_buffer_size.0)
             .max_write_buffer_number(rocksdb_wal_config.data_namespace.max_write_buffer_number)
             .level_zero_file_num_compaction_trigger(
                 rocksdb_wal_config
@@ -196,7 +196,8 @@ impl WalsOpener for RocksDBWalsOpener {
             .fifo_compaction_max_table_files_size(
                 rocksdb_wal_config
                     .data_namespace
-                    .fifo_compaction_max_table_files_size,
+                    .fifo_compaction_max_table_files_size
+                    .0,
             )
             .build()
             .context(OpenWal)?;
@@ -206,7 +207,7 @@ impl WalsOpener for RocksDBWalsOpener {
             .max_subcompactions(rocksdb_wal_config.meta_namespace.max_subcompactions)
             .max_background_jobs(rocksdb_wal_config.meta_namespace.max_background_jobs)
             .enable_statistics(rocksdb_wal_config.meta_namespace.enable_statistics)
-            .write_buffer_size(rocksdb_wal_config.meta_namespace.write_buffer_size)
+            .write_buffer_size(rocksdb_wal_config.meta_namespace.write_buffer_size.0)
             .max_write_buffer_number(rocksdb_wal_config.meta_namespace.max_write_buffer_number)
             .level_zero_file_num_compaction_trigger(
                 rocksdb_wal_config
@@ -226,7 +227,8 @@ impl WalsOpener for RocksDBWalsOpener {
             .fifo_compaction_max_table_files_size(
                 rocksdb_wal_config
                     .meta_namespace
-                    .fifo_compaction_max_table_files_size,
+                    .fifo_compaction_max_table_files_size
+                    .0,
             )
             .build()
             .context(OpenManifestWal)?;

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -193,6 +193,11 @@ impl WalsOpener for RocksDBWalsOpener {
                     .data_namespace
                     .level_zero_stop_writes_trigger,
             )
+            .fifo_compaction_max_table_files_size(
+                rocksdb_wal_config
+                    .data_namespace
+                    .fifo_compaction_max_table_files_size,
+            )
             .build()
             .context(OpenWal)?;
 
@@ -217,6 +222,11 @@ impl WalsOpener for RocksDBWalsOpener {
                 rocksdb_wal_config
                     .meta_namespace
                     .level_zero_stop_writes_trigger,
+            )
+            .fifo_compaction_max_table_files_size(
+                rocksdb_wal_config
+                    .meta_namespace
+                    .fifo_compaction_max_table_files_size,
             )
             .build()
             .context(OpenManifestWal)?;

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -173,25 +173,51 @@ impl WalsOpener for RocksDBWalsOpener {
         let data_path = Path::new(&rocksdb_wal_config.data_dir);
         let wal_path = data_path.join(WAL_DIR_NAME);
         let data_wal = RocksWalBuilder::new(wal_path, write_runtime.clone())
+            .max_subcompactions(rocksdb_wal_config.data_namespace.max_subcompactions)
             .max_background_jobs(rocksdb_wal_config.data_namespace.max_background_jobs)
             .enable_statistics(rocksdb_wal_config.data_namespace.enable_statistics)
             .write_buffer_size(rocksdb_wal_config.data_namespace.write_buffer_size)
             .max_write_buffer_number(rocksdb_wal_config.data_namespace.max_write_buffer_number)
-            .level_zero_file_num_compaction_trigger(rocksdb_wal_config.data_namespace.level_zero_file_num_compaction_trigger)
-            .level_zero_slowdown_writes_trigger(rocksdb_wal_config.data_namespace.level_zero_slowdown_writes_trigger)
-            .level_zero_stop_writes_trigger(rocksdb_wal_config.data_namespace.level_zero_stop_writes_trigger)
+            .level_zero_file_num_compaction_trigger(
+                rocksdb_wal_config
+                    .data_namespace
+                    .level_zero_file_num_compaction_trigger,
+            )
+            .level_zero_slowdown_writes_trigger(
+                rocksdb_wal_config
+                    .data_namespace
+                    .level_zero_slowdown_writes_trigger,
+            )
+            .level_zero_stop_writes_trigger(
+                rocksdb_wal_config
+                    .data_namespace
+                    .level_zero_stop_writes_trigger,
+            )
             .build()
             .context(OpenWal)?;
 
         let manifest_path = data_path.join(MANIFEST_DIR_NAME);
         let manifest_wal = RocksWalBuilder::new(manifest_path, write_runtime)
+            .max_subcompactions(rocksdb_wal_config.meta_namespace.max_subcompactions)
             .max_background_jobs(rocksdb_wal_config.meta_namespace.max_background_jobs)
             .enable_statistics(rocksdb_wal_config.meta_namespace.enable_statistics)
             .write_buffer_size(rocksdb_wal_config.meta_namespace.write_buffer_size)
             .max_write_buffer_number(rocksdb_wal_config.meta_namespace.max_write_buffer_number)
-            .level_zero_file_num_compaction_trigger(rocksdb_wal_config.meta_namespace.level_zero_file_num_compaction_trigger)
-            .level_zero_slowdown_writes_trigger(rocksdb_wal_config.meta_namespace.level_zero_slowdown_writes_trigger)
-            .level_zero_stop_writes_trigger(rocksdb_wal_config.meta_namespace.level_zero_stop_writes_trigger)
+            .level_zero_file_num_compaction_trigger(
+                rocksdb_wal_config
+                    .meta_namespace
+                    .level_zero_file_num_compaction_trigger,
+            )
+            .level_zero_slowdown_writes_trigger(
+                rocksdb_wal_config
+                    .meta_namespace
+                    .level_zero_slowdown_writes_trigger,
+            )
+            .level_zero_stop_writes_trigger(
+                rocksdb_wal_config
+                    .meta_namespace
+                    .level_zero_stop_writes_trigger,
+            )
             .build()
             .context(OpenManifestWal)?;
         let opened_wals = OpenedWals {

--- a/wal/src/rocks_impl/config.rs
+++ b/wal/src/rocks_impl/config.rs
@@ -9,6 +9,11 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     pub max_background_jobs: i32,
     pub enable_statistics: bool,
+    pub write_buffer_size: u64,
+    pub max_write_buffer_number: i32,
+    pub level_zero_file_num_compaction_trigger: i32,
+    pub level_zero_slowdown_writes_trigger: i32,
+    pub level_zero_stop_writes_trigger: i32,
 }
 
 impl Default for Config {
@@ -18,6 +23,11 @@ impl Default for Config {
             // https://github.com/facebook/rocksdb/blob/v6.4.6/include/rocksdb/options.h#L537
             max_background_jobs: 2,
             enable_statistics: false,
+            write_buffer_size: 64 << 20,
+            max_write_buffer_number: 2,
+            level_zero_file_num_compaction_trigger: 4,
+            level_zero_slowdown_writes_trigger: 20,
+            level_zero_stop_writes_trigger: 36,
         }
     }
 }

--- a/wal/src/rocks_impl/config.rs
+++ b/wal/src/rocks_impl/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub level_zero_file_num_compaction_trigger: i32,
     pub level_zero_slowdown_writes_trigger: i32,
     pub level_zero_stop_writes_trigger: i32,
+    pub fifo_compaction_max_table_files_size: u64,
 }
 
 impl Default for Config {
@@ -30,6 +31,7 @@ impl Default for Config {
             level_zero_file_num_compaction_trigger: 4,
             level_zero_slowdown_writes_trigger: 20,
             level_zero_stop_writes_trigger: 36,
+            fifo_compaction_max_table_files_size: 0, // default is 1G, use 0 to disable fifo
         }
     }
 }

--- a/wal/src/rocks_impl/config.rs
+++ b/wal/src/rocks_impl/config.rs
@@ -2,6 +2,7 @@
 
 //! RocksDB Config
 
+use common_util::config::ReadableSize;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -10,12 +11,17 @@ pub struct Config {
     pub max_subcompactions: u32,
     pub max_background_jobs: i32,
     pub enable_statistics: bool,
-    pub write_buffer_size: u64,
+    pub write_buffer_size: ReadableSize,
     pub max_write_buffer_number: i32,
+    // Number of files to trigger level-0 compaction. A value <0 means that level-0 compaction will
+    // not be triggered by number of files at all.
     pub level_zero_file_num_compaction_trigger: i32,
+    // Soft limit on number of level-0 files. We start slowing down writes at this point. A value
+    // <0 means that no writing slow down will be triggered by number of files in level-0.
     pub level_zero_slowdown_writes_trigger: i32,
+    // Maximum number of level-0 files.  We stop writes at this point.
     pub level_zero_stop_writes_trigger: i32,
-    pub fifo_compaction_max_table_files_size: u64,
+    pub fifo_compaction_max_table_files_size: ReadableSize,
 }
 
 impl Default for Config {
@@ -26,12 +32,13 @@ impl Default for Config {
             max_subcompactions: 1,
             max_background_jobs: 2,
             enable_statistics: false,
-            write_buffer_size: 64 << 20,
+            write_buffer_size: ReadableSize::mb(64),
             max_write_buffer_number: 2,
             level_zero_file_num_compaction_trigger: 4,
             level_zero_slowdown_writes_trigger: 20,
             level_zero_stop_writes_trigger: 36,
-            fifo_compaction_max_table_files_size: 0, // default is 1G, use 0 to disable fifo
+            // default is 1G, use 0 to disable fifo
+            fifo_compaction_max_table_files_size: ReadableSize::gb(0),
         }
     }
 }

--- a/wal/src/rocks_impl/config.rs
+++ b/wal/src/rocks_impl/config.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
+    pub max_subcompactions: u32,
     pub max_background_jobs: i32,
     pub enable_statistics: bool,
     pub write_buffer_size: u64,
@@ -21,6 +22,7 @@ impl Default for Config {
         Self {
             // Same with rocksdb
             // https://github.com/facebook/rocksdb/blob/v6.4.6/include/rocksdb/options.h#L537
+            max_subcompactions: 1,
             max_background_jobs: 2,
             enable_statistics: false,
             write_buffer_size: 64 << 20,

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -35,6 +35,8 @@ use crate::{
     },
 };
 
+const ROCKSDB_DEFAULT_COLUMN_FAMILY: &str = "default";
+
 /// Table unit in the Wal.
 struct TableUnit {
     /// id of the Region
@@ -648,11 +650,15 @@ impl Builder {
             }
         }
 
-        let db = DB::open_cf(rocksdb_config, &self.wal_path, vec![("default", cf_opts)])
-            .map_err(|e| e.into())
-            .context(Open {
-                wal_path: self.wal_path.clone(),
-            })?;
+        let db = DB::open_cf(
+            rocksdb_config,
+            &self.wal_path,
+            vec![(ROCKSDB_DEFAULT_COLUMN_FAMILY, cf_opts)],
+        )
+        .map_err(|e| e.into())
+        .context(Open {
+            wal_path: self.wal_path.clone(),
+        })?;
         let rocks_impl = RocksImpl {
             wal_path: self.wal_path,
             db: Arc::new(db),

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -20,8 +20,8 @@ use common_types::{
 use common_util::{error::BoxError, runtime::Runtime};
 use log::{debug, info, warn};
 use rocksdb::{
-    ColumnFamilyOptions, DBIterator, DBOptions, FifoCompactionOptions, ReadOptions, SeekKey,
-    Statistics, Writable, WriteBatch, DB,
+    ColumnFamilyOptions, DBCompactionStyle, DBIterator, DBOptions, FifoCompactionOptions,
+    ReadOptions, SeekKey, Statistics, Writable, WriteBatch, DB,
 };
 use snafu::ResultExt;
 use tokio::sync::Mutex;
@@ -644,6 +644,7 @@ impl Builder {
                 let mut fifo_opts = FifoCompactionOptions::new();
                 fifo_opts.set_max_table_files_size(v);
                 cf_opts.set_fifo_compaction_options(fifo_opts);
+                cf_opts.set_compaction_style(DBCompactionStyle::Fifo);
             }
         }
 

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -650,10 +650,15 @@ impl Builder {
             }
         }
 
+        let default_cfd = {
+            let mut cfd = ColumnFamilyDescriptor::default();
+            cfd.options = cf_opts;
+            cfd
+         };
         let db = DB::open_cf(
             rocksdb_config,
             &self.wal_path,
-            vec![(ROCKSDB_DEFAULT_COLUMN_FAMILY, cf_opts)],
+            vec![default_cfd],
         )
         .map_err(|e| e.into())
         .context(Open {


### PR DESCRIPTION
## Rationale
Now rocksdb as the wal, it is easy to become the bottleneck of write.

## Detailed Changes
1. expose more rocksdb options to avoid write stall
2. introduce rocksdb's FIFO compaction style, which makes rocksdb looks like a message queue. 
    (FIFO is more suitable for time-series data, maybe it will become the default option in the future?)
## Test Plan
I will test it in my test env.