### PR TITLE
Revert "fix: avoid any updates after table is closed (#998)"

### DIFF
--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -650,16 +650,7 @@ impl ScheduleWorker {
                     self.max_unflushed_duration,
                 );
 
-                let mut serial_exec = if let Some(v) = table_data.acquire_serial_exec_ctx().await {
-                    v
-                } else {
-                    warn!(
-                        "Table is closed, ignore this periodical flush, table:{}",
-                        table_data.name
-                    );
-                    continue;
-                };
-
+                let mut serial_exec = table_data.serial_exec.lock().await;
                 let flush_scheduler = serial_exec.flush_scheduler();
                 // Instance flush the table asynchronously.
                 if let Err(e) = flusher

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -3,12 +3,12 @@
 //! Close table logic of instance
 
 use log::{info, warn};
-use snafu::{OptionExt, ResultExt};
+use snafu::ResultExt;
 use table_engine::engine::CloseTableRequest;
 
 use crate::{
     instance::{
-        engine::{DoManifestSnapshot, FlushTable, OperateClosedTable, Result},
+        engine::{DoManifestSnapshot, FlushTable, Result},
         flush_compaction::{Flusher, TableFlushOptions},
     },
     manifest::{ManifestRef, SnapshotRequest},
@@ -37,11 +37,8 @@ impl Closer {
 
         // Flush table.
         let opts = TableFlushOptions::default();
-        let mut serial_exec_ctx = table_data
-            .acquire_serial_exec_ctx()
-            .await
-            .context(OperateClosedTable)?;
-        let flush_scheduler = serial_exec_ctx.flush_scheduler();
+        let mut serial_exec = table_data.serial_exec.lock().await;
+        let flush_scheduler = serial_exec.flush_scheduler();
 
         self.flusher
             .do_flush(flush_scheduler, &table_data, opts)
@@ -70,10 +67,9 @@ impl Closer {
         let removed_table = self.space.remove_table(&request.table_name);
         assert!(removed_table.is_some());
 
-        serial_exec_ctx.invalidate();
         info!(
-            "table:{} has been removed from the space_id:{}, table_id:{}",
-            table_data.name, self.space.id, table_data.id,
+            "table:{}-{} has been removed from the space_id:{}",
+            table_data.name, table_data.id, self.space.id
         );
         Ok(())
     }

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -3,12 +3,12 @@
 //! Drop table logic of instance
 
 use log::{info, warn};
-use snafu::{OptionExt, ResultExt};
+use snafu::ResultExt;
 use table_engine::engine::DropTableRequest;
 
 use crate::{
     instance::{
-        engine::{FlushTable, OperateClosedTable, Result, WriteManifest},
+        engine::{FlushTable, Result, WriteManifest},
         flush_compaction::{Flusher, TableFlushOptions},
         SpaceStoreRef,
     },
@@ -36,10 +36,7 @@ impl Dropper {
             }
         };
 
-        let mut serial_exec_ctx = table_data
-            .acquire_serial_exec_ctx()
-            .await
-            .context(OperateClosedTable)?;
+        let mut serial_exec = table_data.serial_exec.lock().await;
 
         if table_data.is_dropped() {
             warn!(
@@ -54,7 +51,7 @@ impl Dropper {
         //  be avoided.
 
         let opts = TableFlushOptions::default();
-        let flush_scheduler = serial_exec_ctx.flush_scheduler();
+        let flush_scheduler = serial_exec.flush_scheduler();
         self.flusher
             .do_flush(flush_scheduler, &table_data, opts)
             .await

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -23,21 +23,29 @@ use crate::{
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
-    #[snafu(display("The space of the table does not exist, space_id:{space_id}, table:{table}.\nBacktrace:\n{backtrace}"))]
+    #[snafu(display(
+        "The space of the table does not exist, space_id:{}, table:{}.\nBacktrace:\n{}",
+        space_id,
+        table,
+        backtrace,
+    ))]
     SpaceNotExist {
         space_id: SpaceId,
         table: String,
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to read meta update, table_id:{table_id}, err:{source}"))]
+    #[snafu(display("Failed to read meta update, table_id:{}, err:{}", table_id, source))]
     ReadMetaUpdate {
         table_id: TableId,
         source: GenericError,
     },
 
     #[snafu(display(
-        "Failed to recover table data, space_id:{space_id}, table:{table}, err:{source}"
+        "Failed to recover table data, space_id:{}, table:{}, err:{}",
+        space_id,
+        table,
+        source
     ))]
     RecoverTableData {
         space_id: SpaceId,
@@ -45,11 +53,14 @@ pub enum Error {
         source: crate::table::data::Error,
     },
 
-    #[snafu(display("Failed to read wal, err:{source}"))]
+    #[snafu(display("Failed to read wal, err:{}", source))]
     ReadWal { source: wal::manager::Error },
 
     #[snafu(display(
-        "Failed to apply log entry to memtable, table:{table}, table_id:{table_id}, err:{source}",
+        "Failed to apply log entry to memtable, table:{}, table_id:{}, err:{}",
+        table,
+        table_id,
+        source
     ))]
     ApplyMemTable {
         space_id: SpaceId,
@@ -59,7 +70,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Flush failed, space_id:{space_id}, table:{table}, table_id:{table_id}, err:{source}",
+        "Flush failed, space_id:{}, table:{}, table_id:{}, err:{}",
+        space_id,
+        table,
+        table_id,
+        source
     ))]
     FlushTable {
         space_id: SpaceId,
@@ -69,7 +84,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to persist meta update to manifest, space_id:{space_id}, table:{table}, table_id:{table_id}, err:{source}",
+        "Failed to persist meta update to manifest, space_id:{}, table:{}, table_id:{}, err:{}",
+        space_id,
+        table,
+        table_id,
+        source
     ))]
     WriteManifest {
         space_id: SpaceId,
@@ -79,7 +98,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to persist meta update to WAL, space_id:{space_id}, table:{table}, table_id:{table_id}, err:{source}",
+        "Failed to persist meta update to WAL, space_id:{}, table:{}, table_id:{}, err:{}",
+        space_id,
+        table,
+        table_id,
+        source
     ))]
     WriteWal {
         space_id: SpaceId,
@@ -89,7 +112,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Invalid options, space_id:{space_id}, table:{table}, table_id:{table_id}, err:{source}",
+        "Invalid options, space_id:{}, table:{}, table_id:{}, err:{}",
+        space_id,
+        table,
+        table_id,
+        source
     ))]
     InvalidOptions {
         space_id: SpaceId,
@@ -99,7 +126,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to create table data, space_id:{space_id}, table:{table}, table_id:{table_id}, err:{source}",
+        "Failed to create table data, space_id:{}, table:{}, table_id:{}, err:{}",
+        space_id,
+        table,
+        table_id,
+        source
     ))]
     CreateTableData {
         space_id: SpaceId,
@@ -109,8 +140,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Try to update schema to elder version, table:{table}, current_version:{current_version}, \
-        given_version:{given_version}.\nBacktrace:\n{backtrace}",
+    "Try to update schema to elder version, table:{}, current_version:{}, given_version:{}.\nBacktrace:\n{}",
+    table,
+    current_version,
+    given_version,
+    backtrace,
     ))]
     InvalidSchemaVersion {
         table: String,
@@ -120,8 +154,11 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Invalid previous schema version, table:{table}, current_version:{current_version}, \
-        pre_version:{pre_version}.\nBacktrace:\n{backtrace}",
+    "Invalid previous schema version, table:{}, current_version:{}, pre_version:{}.\nBacktrace:\n{}",
+    table,
+    current_version,
+    pre_version,
+    backtrace,
     ))]
     InvalidPreVersion {
         table: String,
@@ -130,14 +167,21 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Alter schema of a dropped table:{table}.\nBacktrace:\n{backtrace}"))]
+    #[snafu(display(
+        "Alter schema of a dropped table:{}.\nBacktrace:\n{}",
+        table,
+        backtrace
+    ))]
     AlterDroppedTable { table: String, backtrace: Backtrace },
 
-    #[snafu(display("Failed to store version edit, err:{source}"))]
+    #[snafu(display("Failed to store version edit, err:{}", source))]
     StoreVersionEdit { source: GenericError },
 
     #[snafu(display(
-        "Failed to encode payloads, table:{table}, wal_location:{wal_location:?}, err:{source}"
+        "Failed to encode payloads, table:{}, wal_location:{:?}, err:{}",
+        table,
+        wal_location,
+        source
     ))]
     EncodePayloads {
         table: String,
@@ -146,7 +190,10 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Failed to do manifest snapshot for table, space_id:{space_id}, table:{table}, err:{source}",
+        "Failed to do manifest snapshot for table, space_id:{}, table:{}, err:{}",
+        space_id,
+        table,
+        source
     ))]
     DoManifestSnapshot {
         space_id: SpaceId,
@@ -155,31 +202,30 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Table open failed and can not be created again, table:{table}.\nBacktrace:\n{backtrace}",
+        "Table open failed and can not be created again, table:{}.\nBacktrace:\n{}",
+        table,
+        backtrace,
     ))]
     CreateOpenFailedTable { table: String, backtrace: Backtrace },
 
-    #[snafu(display("Failed to open manifest, err:{source}"))]
+    #[snafu(display("Failed to open manifest, err:{}", source))]
     OpenManifest {
         source: crate::manifest::details::Error,
     },
 
-    #[snafu(display("Failed to find table, msg:{msg}.\nBacktrace:\n{backtrace}"))]
+    #[snafu(display("Failed to find table, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
     TableNotExist { msg: String, backtrace: Backtrace },
 
-    #[snafu(display("Failed to open shard, msg:{msg}.\nBacktrace:\n{backtrace}"))]
+    #[snafu(display("Failed to open shard, msg:{}.\nBacktrace:\n{}", msg, backtrace))]
     OpenTablesOfShard { msg: String, backtrace: Backtrace },
 
-    #[snafu(display("Try to operate a closed table.\nBacktrace:\n{backtrace}"))]
-    OperateClosedTable { backtrace: Backtrace },
-
-    #[snafu(display("Failed to replay wal, msg:{msg:?}, err:{source}"))]
+    #[snafu(display("Failed to replay wal, msg:{:?}, err:{}", msg, source))]
     ReplayWalWithCause {
         msg: Option<String>,
         source: GenericError,
     },
 
-    #[snafu(display("Failed to replay wal, msg:{msg:?}.\nBacktrace:\n{backtrace}"))]
+    #[snafu(display("Failed to replay wal, msg:{:?}.\nBacktrace:\n{}", msg, backtrace))]
     ReplayWalNoCause {
         msg: Option<String>,
         backtrace: Backtrace,
@@ -218,7 +264,6 @@ impl From<Error> for table_engine::engine::Error {
             | Error::TableNotExist { .. }
             | Error::OpenTablesOfShard { .. }
             | Error::ReplayWalNoCause { .. }
-            | Error::OperateClosedTable { .. }
             | Error::ReplayWalWithCause { .. } => Self::Unexpected {
                 source: Box::new(err),
             },

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -608,9 +608,9 @@ impl<'a> Writer<'a> {
             "Try to trigger flush of other table:{} from the write procedure of table:{}",
             table_data.name, self.table_data.name
         );
-        match table_data.try_acquire_serial_exec_ctx() {
-            Some(mut serial_exec_ctx) => {
-                let flush_scheduler = serial_exec_ctx.flush_scheduler();
+        match table_data.serial_exec.try_lock() {
+            Ok(mut serial_exec) => {
+                let flush_scheduler = serial_exec.flush_scheduler();
                 // Set `block_on_write_thread` to false and let flush do in background.
                 flusher
                     .schedule_flush(flush_scheduler, table_data, opts)
@@ -619,7 +619,7 @@ impl<'a> Writer<'a> {
                         table: &table_data.name,
                     })
             }
-            None => {
+            Err(_) => {
                 warn!(
                     "Failed to acquire write lock for flush table:{}",
                     table_data.name,

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -7,7 +7,6 @@ use std::{
     convert::TryInto,
     fmt,
     fmt::Formatter,
-    ops::{Deref, DerefMut},
     sync::{
         atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
         Arc, Mutex,
@@ -29,7 +28,6 @@ use log::{debug, info};
 use object_store::Path;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::table::TableId;
-use tokio::sync::MutexGuard;
 
 use crate::{
     instance::serial_executor::TableOpSerialExecutor,
@@ -85,36 +83,6 @@ pub struct TableShardInfo {
 impl TableShardInfo {
     pub fn new(shard_id: ShardId) -> Self {
         Self { shard_id }
-    }
-}
-
-/// The context for execution of serial operation on the table.
-pub struct SerialExecContext {
-    /// Denotes whether `serial_exec` is valid.
-    ///
-    /// The `serial_exec` will be invalidated if the table is closed.
-    invalid: bool,
-    serial_exec: TableOpSerialExecutor,
-}
-
-impl SerialExecContext {
-    #[inline]
-    pub fn invalidate(&mut self) {
-        self.invalid = true;
-    }
-}
-
-impl Deref for SerialExecContext {
-    type Target = TableOpSerialExecutor;
-
-    fn deref(&self) -> &Self::Target {
-        &self.serial_exec
-    }
-}
-
-impl DerefMut for SerialExecContext {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.serial_exec
     }
 }
 
@@ -175,13 +143,14 @@ pub struct TableData {
     /// No write/alter is allowed if the table is dropped.
     dropped: AtomicBool,
 
-    serial_exec_ctx: tokio::sync::Mutex<SerialExecContext>,
-
     /// Metrics of this table
     pub metrics: Metrics,
 
     /// Shard info of the table
     pub shard_info: TableShardInfo,
+
+    /// The table operation serial_exec
+    pub serial_exec: tokio::sync::Mutex<TableOpSerialExecutor>,
 }
 
 impl fmt::Debug for TableData {
@@ -248,10 +217,6 @@ impl TableData {
             preflush_write_buffer_size_ratio,
         ));
 
-        let serial_exec_ctx = tokio::sync::Mutex::new(SerialExecContext {
-            invalid: false,
-            serial_exec: TableOpSerialExecutor::new(table_id),
-        });
         Ok(Self {
             id: table_id,
             name: table_name,
@@ -270,7 +235,7 @@ impl TableData {
             dropped: AtomicBool::new(false),
             metrics,
             shard_info: TableShardInfo::new(shard_id),
-            serial_exec_ctx,
+            serial_exec: tokio::sync::Mutex::new(TableOpSerialExecutor::new(table_id)),
         })
     }
 
@@ -284,17 +249,35 @@ impl TableData {
         preflush_write_buffer_size_ratio: f32,
         mem_usage_collector: CollectorRef,
     ) -> Result<Self> {
-        Self::new(
-            add_meta.space_id,
-            add_meta.table_id,
-            add_meta.table_name,
-            add_meta.schema,
-            shard_id,
-            add_meta.opts,
-            purger,
+        let memtable_factory = Arc::new(SkiplistMemTableFactory);
+        let purge_queue = purger.create_purge_queue(add_meta.space_id, add_meta.table_id);
+        let current_version = TableVersion::new(purge_queue);
+        let metrics = Metrics::default();
+        let mutable_limit = AtomicU32::new(compute_mutable_limit(
+            add_meta.opts.write_buffer_size,
             preflush_write_buffer_size_ratio,
+        ));
+
+        Ok(Self {
+            id: add_meta.table_id,
+            name: add_meta.table_name,
+            schema: Mutex::new(add_meta.schema),
+            space_id: add_meta.space_id,
+            mutable_limit,
+            mutable_limit_write_buffer_ratio: preflush_write_buffer_size_ratio,
+            opts: ArcSwap::new(Arc::new(add_meta.opts)),
+            memtable_factory,
             mem_usage_collector,
-        )
+            current_version,
+            last_sequence: AtomicU64::new(0),
+            last_memtable_id: AtomicU64::new(0),
+            last_file_id: AtomicU64::new(0),
+            last_flush_time_ms: AtomicU64::new(0),
+            dropped: AtomicBool::new(false),
+            metrics,
+            shard_info: TableShardInfo::new(shard_id),
+            serial_exec: tokio::sync::Mutex::new(TableOpSerialExecutor::new(add_meta.table_id)),
+        })
     }
 
     /// Get current schema of the table.
@@ -367,34 +350,6 @@ impl TableData {
     #[inline]
     pub fn set_dropped(&self) {
         self.dropped.store(true, Ordering::SeqCst);
-    }
-
-    /// Acquire the [`SerialExecContext`] if the table is not closed.
-    pub async fn acquire_serial_exec_ctx(&self) -> Option<MutexGuard<'_, SerialExecContext>> {
-        let v = self.serial_exec_ctx.lock().await;
-        if v.invalid {
-            None
-        } else {
-            Some(v)
-        }
-    }
-
-    /// Try to acquire the [SerialExecContext].
-    ///
-    /// [None] will be returned if the serial_exec_ctx has been acquired
-    /// already, or the table is closed.
-    pub fn try_acquire_serial_exec_ctx(&self) -> Option<MutexGuard<'_, SerialExecContext>> {
-        let v = self.serial_exec_ctx.try_lock();
-        match v {
-            Ok(ctx) => {
-                if ctx.invalid {
-                    None
-                } else {
-                    Some(ctx)
-                }
-            }
-            Err(_) => None,
-        }
     }
 
     /// Returns total memtable memory usage in bytes.

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -135,9 +135,6 @@ pub enum Error {
         source: GenericError,
     },
 
-    #[snafu(display("Try to operate a closed table.\nBacktrace:\n{backtrace}"))]
-    OperateClosedTable { backtrace: Backtrace },
-
     #[snafu(display(
         "Failed to wait for pending writes, table:{table}.\nBacktrace:\n{backtrace}"
     ))]


### PR DESCRIPTION
This reverts commit 85eb0b7d7f221ccd1aa3247d9a1699edab90a21a.

## Rationale
The changes introduced by #998 are not reasonable. Another fix will address #990.

## Detailed Changes
Revert #998 