### PR TITLE
feat: memtable bitmap for null

### DIFF
--- a/analytic_engine/src/memtable/mod.rs
+++ b/analytic_engine/src/memtable/mod.rs
@@ -48,6 +48,11 @@ pub enum Error {
         source: common_types::record_batch::Error,
     },
 
+    #[snafu(display("Failed to decode continuous row, err:{}", source))]
+    DecodeContinuousRow {
+        source: common_types::row::contiguous::Error,
+    },
+
     #[snafu(display("Failed to project memtable schema, err:{}", source))]
     ProjectSchema {
         source: common_types::projected_schema::Error,

--- a/analytic_engine/src/row_iter/tests.rs
+++ b/analytic_engine/src/row_iter/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use async_trait::async_trait;
 use common_types::{
@@ -71,7 +71,7 @@ pub fn build_record_batch_with_key(schema: Schema, rows: Vec<Row>) -> RecordBatc
 
         writer.write_row(&row).unwrap();
 
-        let source_row = ContiguousRowReader::with_schema(&buf, &schema);
+        let source_row = ContiguousRowReader::try_new(&buf, &schema).unwrap();
         let projected_row = ProjectedContiguousRow::new(source_row, &row_projected_schema);
         builder
             .append_projected_contiguous_row(&projected_row)

--- a/common_types/src/bitset.rs
+++ b/common_types/src/bitset.rs
@@ -13,16 +13,28 @@ pub struct BitSet {
 impl BitSet {
     /// Initialize a unset [`BitSet`].
     pub fn new(num_bits: usize) -> Self {
-        let len = (num_bits + 7) >> 3;
         Self {
-            buffer: vec![0; len],
+            buffer: vec![0; Self::num_bytes(num_bits)],
             num_bits,
         }
     }
 
+    #[inline]
+    pub fn num_bits(&self) -> usize {
+        self.num_bits
+    }
+
+    #[inline]
+    pub fn num_bytes(num_bits: usize) -> usize {
+        (num_bits + 7) >> 3
+    }
+
     /// Initialize directly from a buffer.
+    ///
+    /// None will be returned if the buffer's length is not enough to cover the
+    /// bits of `num_bits`.
     pub fn try_from_raw(buffer: Vec<u8>, num_bits: usize) -> Option<Self> {
-        if buffer.len() < num_bits >> 3 {
+        if buffer.len() < Self::num_bytes(num_bits) {
             None
         } else {
             Some(Self { buffer, num_bits })
@@ -74,6 +86,11 @@ impl BitSet {
         num_set_bits += count_set_bits_before(self.buffer[byte_index], bit_index) as u32;
 
         Some(num_set_bits as usize)
+    }
+
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.buffer
     }
 
     pub fn into_bytes(self) -> Vec<u8> {

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -856,6 +856,27 @@ impl Datum {
         Ok(Datum::Date(days))
     }
 
+    pub fn is_fixed_sized(&self) -> bool {
+        match self {
+            Datum::Null
+            | Datum::Timestamp(_)
+            | Datum::Double(_)
+            | Datum::Float(_)
+            | Datum::UInt64(_)
+            | Datum::UInt32(_)
+            | Datum::UInt16(_)
+            | Datum::UInt8(_)
+            | Datum::Int64(_)
+            | Datum::Int32(_)
+            | Datum::Int16(_)
+            | Datum::Int8(_)
+            | Datum::Boolean(_)
+            | Datum::Date(_)
+            | Datum::Time(_) => true,
+            Datum::Varbinary(_) | Datum::String(_) => false,
+        }
+    }
+
     pub fn size(&self) -> usize {
         match self {
             Datum::Null => 1,

--- a/common_types/src/lib.rs
+++ b/common_types/src/lib.rs
@@ -2,6 +2,7 @@
 
 //! Contains common types
 
+pub mod bitset;
 pub mod bytes;
 #[cfg(feature = "arrow")]
 pub mod column;

--- a/common_types/src/row/mod.rs
+++ b/common_types/src/row/mod.rs
@@ -106,16 +106,19 @@ pub struct Row {
 
 impl Row {
     /// Convert vec of Datum into Row
+    #[inline]
     pub fn from_datums(cols: Vec<Datum>) -> Self {
         Self { cols }
     }
 
     /// Returns the column num
+    #[inline]
     pub fn num_columns(&self) -> usize {
         self.cols.len()
     }
 
     /// Iterate all datums
+    #[inline]
     pub fn iter(&self) -> IterDatum {
         IterDatum {
             iter: self.cols.iter(),
@@ -123,12 +126,14 @@ impl Row {
     }
 
     /// Get the timestamp column
+    #[inline]
     pub fn timestamp(&self, schema: &Schema) -> Option<Timestamp> {
         let timestamp_index = schema.timestamp_index();
 
         self.cols[timestamp_index].as_timestamp()
     }
 
+    #[inline]
     pub fn size(&self) -> usize {
         self.cols.iter().map(|col| col.size()).sum()
     }

--- a/common_types/src/tests.rs
+++ b/common_types/src/tests.rs
@@ -128,9 +128,13 @@ fn default_value_schema_builder() -> schema::Builder {
         .unwrap()
 }
 
-/// Build a schema for testing:
-/// (key1(varbinary), key2(timestamp), field1(double), field2(string),
-/// field3(date), field4(time))
+/// Build a schema for testing, which contains 6 columns:
+/// - key1(varbinary)
+/// - key2(timestamp)
+/// - field1(double)
+/// - field2(string)
+/// - field3(Time)
+/// - field4(Date)
 pub fn build_schema() -> Schema {
     base_schema_builder().build().unwrap()
 }

--- a/common_types/src/tests.rs
+++ b/common_types/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 use bytes_ext::Bytes;
 use sqlparser::ast::{BinaryOperator, Expr, Value};
@@ -335,7 +335,7 @@ pub fn build_record_batch_with_key_by_rows(rows: Vec<Row>) -> RecordBatchWithKey
 
         writer.write_row(&row).unwrap();
 
-        let source_row = ContiguousRowReader::with_schema(&buf, &schema);
+        let source_row = ContiguousRowReader::try_new(&buf, &schema).unwrap();
         let projected_row = ProjectedContiguousRow::new(source_row, &row_projected_schema);
         builder
             .append_projected_contiguous_row(&projected_row)

--- a/common_util/src/bitset.rs
+++ b/common_util/src/bitset.rs
@@ -1,0 +1,164 @@
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+//! BitSet supports counting set/unset bits.
+
+#[derive(Debug, Default, Clone)]
+pub struct BitSet {
+    /// The bits are stored as bytes in the least significant bit order.
+    buffer: Vec<u8>,
+    /// The number of real bits in the `buffer`
+    num_bits: usize,
+}
+
+impl BitSet {
+    /// Initialize a unset [`BitSet`].
+    pub fn new(num_bits: usize) -> Self {
+        let len = (num_bits + 7) >> 3;
+        Self {
+            buffer: vec![0; len],
+            num_bits,
+        }
+    }
+
+    /// Initialize directly from a buffer.
+    pub fn try_from_raw(buffer: Vec<u8>, num_bits: usize) -> Option<Self> {
+        if buffer.len() < num_bits >> 3 {
+            None
+        } else {
+            Some(Self { buffer, num_bits })
+        }
+    }
+
+    /// Set the bit at the `index`.
+    ///
+    /// Return false if the index is outside the range.
+    pub fn set(&mut self, index: usize) -> bool {
+        if index >= self.num_bits {
+            return false;
+        }
+        let (byte_index, bit_index) = Self::compute_byte_bit_index(index);
+        self.buffer[byte_index] |= 1 << bit_index;
+        true
+    }
+
+    /// Tells whether the bit at the `index` is set.
+    pub fn is_set(&self, index: usize) -> Option<bool> {
+        if index >= self.num_bits {
+            return None;
+        }
+        let (byte_index, bit_index) = Self::compute_byte_bit_index(index);
+        let set = (self.buffer[byte_index] & (1 << bit_index)) != 0;
+        Some(set)
+    }
+
+    /// Compute the number of the set bits before the bit at `index`.
+    pub fn num_unset_bits_before(&self, index: usize) -> Option<usize> {
+        self.num_set_bits_before(index).map(|num_set_bits| {
+            let num_bits = 1 + index;
+            num_bits - num_set_bits
+        })
+    }
+
+    /// Compute the number of the set bits before the bit at `index`.
+    pub fn num_set_bits_before(&self, index: usize) -> Option<usize> {
+        if index >= self.num_bits {
+            return None;
+        }
+        let (byte_index, bit_index) = Self::compute_byte_bit_index(index);
+
+        let mut num_set_bits = 0;
+        for b in &self.buffer[0..byte_index] {
+            num_set_bits += count_set_bits(*b) as u32;
+        }
+
+        num_set_bits += count_set_bits_before(self.buffer[byte_index], bit_index) as u32;
+
+        Some(num_set_bits as usize)
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.buffer
+    }
+
+    #[inline]
+    fn compute_byte_bit_index(index: usize) -> (usize, usize) {
+        (index >> 3, index & 7)
+    }
+}
+
+fn count_set_bits(b: u8) -> u8 {
+    static LOOKUP: [u8; 16] = [0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4];
+
+    LOOKUP[(b & 0x0F) as usize] + LOOKUP[(b >> 4) as usize]
+}
+
+fn count_set_bits_before(b: u8, idx: usize) -> u8 {
+    let mut num_bits = 0;
+    for i in 0..idx {
+        num_bits += b >> i & 1;
+    }
+
+    num_bits
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_eq;
+
+    use super::BitSet;
+
+    #[test]
+    fn test_set_op() {
+        let mut bit_set = BitSet::new(50);
+
+        assert!(bit_set.set(1));
+        assert!(bit_set.is_set(1).unwrap());
+
+        assert!(bit_set.set(20));
+        assert!(bit_set.is_set(20).unwrap());
+        assert!(bit_set.set(49));
+        assert!(bit_set.is_set(49).unwrap());
+
+        assert!(!bit_set.set(100));
+        assert!(bit_set.is_set(100).is_none());
+
+        assert_eq!(
+            bit_set.into_bytes(),
+            vec![
+                0b00000010,
+                0b00000000,
+                0b00010000,
+                0b000000000,
+                0b00000000,
+                0b00000000,
+                0b00000010
+            ]
+        );
+    }
+
+    #[test]
+    fn test_num_bits_before() {
+        let raw_bytes: Vec<u8> = vec![0b11111111, 0b11110000, 0b00001111, 0b00001100, 0b00001001];
+        let bit_set = BitSet::try_from_raw(raw_bytes, 35).unwrap();
+        assert_eq!(bit_set.num_set_bits_before(1), Some(1));
+        assert_eq!(bit_set.num_set_bits_before(9), Some(8));
+        assert_eq!(bit_set.num_set_bits_before(13), Some(9));
+        assert_eq!(bit_set.num_set_bits_before(30), Some(18));
+        assert_eq!(bit_set.num_set_bits_before(34), Some(19));
+        assert_eq!(bit_set.num_set_bits_before(49), None);
+
+        assert_eq!(bit_set.is_set(7), Some(true));
+        assert_eq!(bit_set.is_set(8), Some(false));
+        assert_eq!(bit_set.is_set(34), Some(false));
+        assert_eq!(bit_set.is_set(35), None);
+        assert_eq!(bit_set.is_set(36), None);
+    }
+
+    #[test]
+    fn test_try_from_raw() {
+        let raw_bytes: Vec<u8> = vec![0b11111111, 0b11110000, 0b00001111, 0b00001100, 0b00001001];
+        assert!(BitSet::try_from_raw(raw_bytes.clone(), 50).is_none());
+        assert!(BitSet::try_from_raw(raw_bytes.clone(), 40).is_some());
+        assert!(BitSet::try_from_raw(raw_bytes, 1).is_some());
+    }
+}

--- a/common_util/src/lib.rs
+++ b/common_util/src/lib.rs
@@ -9,7 +9,6 @@ pub mod macros;
 
 // TODO(yingwen): Move some mod into components as a crate
 pub mod alloc_tracker;
-pub mod bitset;
 pub mod byte;
 pub mod codec;
 pub mod config;

--- a/common_util/src/lib.rs
+++ b/common_util/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Common utils shared by the whole project
 
@@ -9,6 +9,7 @@ pub mod macros;
 
 // TODO(yingwen): Move some mod into components as a crate
 pub mod alloc_tracker;
+pub mod bitset;
 pub mod byte;
 pub mod codec;
 pub mod config;


### PR DESCRIPTION
## Rationale
For a table which contains many nullable columns, many nulls may cause huge memory consumption in the memtable, leading to small ssts where null values will be compressed.

## Detailed Changes
- Introduce a bitset for continuous row encoding
- Use u32 to encode the offest in the encoded bytes rather than u64

## Test Plan
Existing unit test. And test it with tsbs's data, here is result with write buffer 32MB:
|          description                  |   version  | encoded size of one row | number of rows in memtable | sst's size |
| --------------------------- | -------- | ------------------------- | ---------------------------- | --------- |
| 20 col (not null)                    | main      | 325B                                   | 70000+                                    | 1.8M        |
| 20 col (not null)                    | current | 295B                                   | 78000                                       | 2M           |
| 20 col + 200 null col            | main      | 2135B                                  | 12100                                      | 460K       |
| 20 col + 200 null col            | current | 332B                                   | 70000                                      | 1.5M         |