### PR TITLE
fix: directly return when found no table datas to replay

### DIFF
--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -357,6 +357,15 @@ impl ShardOpener {
             }
         }
 
+        if replay_table_datas.is_empty() {
+            info!(
+                "ShardOpener recover empty table datas finish, shard_id:{}",
+                self.shard_id
+            );
+
+            return Ok(());
+        }
+
         let replay_mode = match self.recover_mode {
             RecoverMode::TableBased => ReplayMode::TableBased,
             RecoverMode::ShardBased => ReplayMode::RegionBased,


### PR DESCRIPTION
## Rationale
Now it will still scan logs from wal when no table datas needed to replay, it should directly return actually.

## Detailed Changes
Add a fast path to return directly when no table datas needed to replay.

## Test Plan
Test manually.