### PR TITLE
fix: add missing `dict_id`

### DIFF
--- a/components/arrow_ext/Cargo.toml
+++ b/components/arrow_ext/Cargo.toml
@@ -12,6 +12,6 @@ workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 snafu = { workspace = true }
 zstd = { workspace = true }

--- a/components/arrow_ext/src/ipc.rs
+++ b/components/arrow_ext/src/ipc.rs
@@ -49,6 +49,7 @@ const ZSTD_LEVEL: i32 = 3;
 pub struct RecordBatchesEncoder {
     stream_writer: Option<StreamWriter<Vec<u8>>>,
     num_rows: usize,
+    /// Whether the writer has dict fields.
     has_dict: bool,
     compress_opts: CompressOptions,
 }
@@ -192,7 +193,7 @@ impl RecordBatchesEncoder {
                 .context(ArrowError)?;
             stream_writer.write(&batch).context(ArrowError)?;
         } else {
-            stream_writer.write(&batch).context(ArrowError)?;
+            stream_writer.write(batch).context(ArrowError)?;
         }
         self.num_rows += batch.num_rows();
         Ok(())

--- a/components/arrow_ext/src/ipc.rs
+++ b/components/arrow_ext/src/ipc.rs
@@ -276,12 +276,25 @@ mod tests {
         let schema = Schema::new(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Utf8, false),
+            Field::new(
+                "c",
+                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                false,
+            ),
         ]);
 
         let a = Int32Array::from_iter_values(0..rows as i32);
         let b = StringArray::from_iter_values((0..rows).map(|i| i.to_string()));
-
-        RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap()
+        let mut cb = StringDictionaryBuilder::<Int32Type>::new();
+        for i in 0..rows {
+            cb.append_value((i % 10).to_string());
+        }
+        let c = cb.finish();
+        RecordBatch::try_new(
+            Arc::new(schema),
+            vec![Arc::new(a), Arc::new(b), Arc::new(c)],
+        )
+        .unwrap()
     }
 
     fn ensure_encoding_and_decoding(

--- a/components/arrow_ext/src/lib.rs
+++ b/components/arrow_ext/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
 
+#![feature(cow_is_borrowed)]
 pub mod ipc;
 pub mod operation;

--- a/integration_tests/cases/env/cluster/ddl/alter_table.sql
+++ b/integration_tests/cases/env/cluster/ddl/alter_table.sql
@@ -12,13 +12,6 @@ DESCRIBE TABLE `05_alter_table_t0`;
 INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic) values (2, '2', 2, "d2");
 SELECT * FROM `05_alter_table_t0`;
 
--- waiting for datafusion's bug fix
--- ALTER TABLE `05_alter_table_t0` add COLUMN (add_dic string dictionary);
--- DESCRIBE TABLE `05_alter_table_t0`;
--- INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic, add_dic) values (2, '2', 2, "d2", "d3");
--- SELECT * FROM `05_alter_table_t0`;
-
-
 -- doesn't support drop column
 ALTER TABLE `05_alter_table_t0` DROP COLUMN b;
 DESCRIBE TABLE `05_alter_table_t0`;

--- a/integration_tests/cases/env/local/ddl/alter_table.result
+++ b/integration_tests/cases/env/local/ddl/alter_table.result
@@ -45,6 +45,32 @@ UInt64(0),Timestamp(1),Int32(1),String("d1"),String(""),
 UInt64(0),Timestamp(2),Int32(2),String("d2"),String("2"),
 
 
+ALTER TABLE `05_alter_table_t0` add COLUMN (add_dic string dictionary);
+
+affected_rows: 0
+
+DESCRIBE TABLE `05_alter_table_t0`;
+
+name,type,is_primary,is_nullable,is_tag,is_dictionary,
+String("tsid"),String("uint64"),Boolean(true),Boolean(false),Boolean(false),Boolean(false),
+String("t"),String("timestamp"),Boolean(true),Boolean(false),Boolean(false),Boolean(false),
+String("a"),String("int"),Boolean(false),Boolean(true),Boolean(false),Boolean(false),
+String("dic"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean(true),
+String("b"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean(false),
+String("add_dic"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean(true),
+
+
+INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic, add_dic) values (2, '2', 2, "d2", "d3");
+
+affected_rows: 1
+
+SELECT * FROM `05_alter_table_t0`;
+
+tsid,t,a,dic,b,add_dic,
+UInt64(0),Timestamp(1),Int32(1),String("d1"),String(""),String(""),
+UInt64(0),Timestamp(2),Int32(2),String("d2"),String("2"),String("d3"),
+
+
 ALTER TABLE `05_alter_table_t0` DROP COLUMN b;
 
 Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to create plan, query: ALTER TABLE `05_alter_table_t0` DROP COLUMN b;. Caused by: Failed to create plan, err:Unsupported SQL statement" })
@@ -57,13 +83,14 @@ String("t"),String("timestamp"),Boolean(true),Boolean(false),Boolean(false),Bool
 String("a"),String("int"),Boolean(false),Boolean(true),Boolean(false),Boolean(false),
 String("dic"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean(true),
 String("b"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean(false),
+String("add_dic"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean(true),
 
 
 SELECT * FROM `05_alter_table_t0`;
 
-tsid,t,a,dic,b,
-UInt64(0),Timestamp(1),Int32(1),String("d1"),String(""),
-UInt64(0),Timestamp(2),Int32(2),String("d2"),String("2"),
+tsid,t,a,dic,b,add_dic,
+UInt64(0),Timestamp(1),Int32(1),String("d1"),String(""),String(""),
+UInt64(0),Timestamp(2),Int32(2),String("d2"),String("2"),String("d3"),
 
 
 DROP TABLE `05_alter_table_t0`;

--- a/integration_tests/cases/env/local/ddl/alter_table.result
+++ b/integration_tests/cases/env/local/ddl/alter_table.result
@@ -60,15 +60,18 @@ String("b"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean
 String("add_dic"),String("string"),Boolean(false),Boolean(true),Boolean(false),Boolean(true),
 
 
-INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic, add_dic) values (2, '2', 2, "d2", "d3");
+INSERT INTO TABLE `05_alter_table_t0` (a, b, t, dic, add_dic)
+    VALUES (2, '2', 2, "d11", "d22"),
+    (3, '3', 3, "d22", "d33");
 
-affected_rows: 1
+affected_rows: 2
 
 SELECT * FROM `05_alter_table_t0`;
 
 tsid,t,a,dic,b,add_dic,
 UInt64(0),Timestamp(1),Int32(1),String("d1"),String(""),String(""),
-UInt64(0),Timestamp(2),Int32(2),String("d2"),String("2"),String("d3"),
+UInt64(0),Timestamp(2),Int32(2),String("d11"),String("2"),String("d22"),
+UInt64(0),Timestamp(3),Int32(3),String("d22"),String("3"),String("d33"),
 
 
 ALTER TABLE `05_alter_table_t0` DROP COLUMN b;
@@ -90,7 +93,8 @@ SELECT * FROM `05_alter_table_t0`;
 
 tsid,t,a,dic,b,add_dic,
 UInt64(0),Timestamp(1),Int32(1),String("d1"),String(""),String(""),
-UInt64(0),Timestamp(2),Int32(2),String("d2"),String("2"),String("d3"),
+UInt64(0),Timestamp(2),Int32(2),String("d11"),String("2"),String("d22"),
+UInt64(0),Timestamp(3),Int32(3),String("d22"),String("3"),String("d33"),
 
 
 DROP TABLE `05_alter_table_t0`;

--- a/integration_tests/cases/env/local/ddl/alter_table.sql
+++ b/integration_tests/cases/env/local/ddl/alter_table.sql
@@ -12,12 +12,14 @@ DESCRIBE TABLE `05_alter_table_t0`;
 INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic) values (2, '2', 2, "d2");
 SELECT * FROM `05_alter_table_t0`;
 
--- waiting for datafusion's bug fix
 ALTER TABLE `05_alter_table_t0` add COLUMN (add_dic string dictionary);
 DESCRIBE TABLE `05_alter_table_t0`;
-INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic, add_dic) values (2, '2', 2, "d2", "d3");
-SELECT * FROM `05_alter_table_t0`;
+INSERT INTO TABLE `05_alter_table_t0` (a, b, t, dic, add_dic)
+    VALUES (2, '2', 2, "d11", "d22"),
+    (3, '3', 3, "d22", "d33");
 
+
+SELECT * FROM `05_alter_table_t0`;
 
 -- doesn't support drop column
 ALTER TABLE `05_alter_table_t0` DROP COLUMN b;

--- a/integration_tests/cases/env/local/ddl/alter_table.sql
+++ b/integration_tests/cases/env/local/ddl/alter_table.sql
@@ -13,10 +13,10 @@ INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic) values (2, '2', 2, "d2");
 SELECT * FROM `05_alter_table_t0`;
 
 -- waiting for datafusion's bug fix
--- ALTER TABLE `05_alter_table_t0` add COLUMN (add_dic string dictionary);
--- DESCRIBE TABLE `05_alter_table_t0`;
--- INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic, add_dic) values (2, '2', 2, "d2", "d3");
--- SELECT * FROM `05_alter_table_t0`;
+ALTER TABLE `05_alter_table_t0` add COLUMN (add_dic string dictionary);
+DESCRIBE TABLE `05_alter_table_t0`;
+INSERT INTO TABLE `05_alter_table_t0`(a, b, t, dic, add_dic) values (2, '2', 2, "d2", "d3");
+SELECT * FROM `05_alter_table_t0`;
 
 
 -- doesn't support drop column


### PR DESCRIPTION
## Rationale
When schema has more than one dict fields, datafusion may lose the `dict_id`, which will cause an error in the record batch encode, and the client decoded the record batch via ipc will throw following errors:
```
DecodeArrowPayload(InvalidArgumentError("Value at position 0 out of bounds: 0 (should be in [0, -1])"))
```
More context: https://github.com/apache/arrow-datafusion/issues/6784
## Detailed Changes
- Assign unique dict id when there are more than one dict fields. 

## Test Plan
UT and integration tests.
