### PR TITLE
feat: avoid prefetching all sst streams at once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,6 +626,7 @@ dependencies = [
  "criterion",
  "env_logger",
  "futures 0.3.28",
+ "generic_error",
  "log",
  "macros",
  "object_store 1.2.5-alpha",
@@ -6389,6 +6390,8 @@ name = "test_util"
 version = "1.2.5-alpha"
 dependencies = [
  "arrow",
+ "async-stream",
+ "async-trait",
  "backtrace",
  "ceresdbproto",
  "chrono",
@@ -6796,6 +6799,7 @@ dependencies = [
  "clap 3.2.23",
  "common_types",
  "futures 0.3.28",
+ "generic_error",
  "num_cpus",
  "object_store 1.2.5-alpha",
  "parquet",

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -88,6 +88,7 @@ impl Instance {
         let scan_options_for_compaction = ScanOptions {
             background_read_parallelism: 1,
             max_record_batches_in_flight: MAX_RECORD_BATCHES_IN_FLIGHT_WHEN_COMPACTION_READ,
+            num_streams_to_prefetch: ctx.config.num_streams_to_prefetch,
         };
         let compaction_runtime = ctx.runtimes.compact_runtime.clone();
         let compaction_scheduler = Arc::new(SchedulerImpl::new(
@@ -101,6 +102,7 @@ impl Instance {
         let scan_options = ScanOptions {
             background_read_parallelism: ctx.config.sst_background_read_parallelism,
             max_record_batches_in_flight: ctx.config.scan_max_record_batches_in_flight,
+            num_streams_to_prefetch: ctx.config.num_streams_to_prefetch,
         };
 
         let iter_options = ctx

--- a/analytic_engine/src/instance/read.rs
+++ b/analytic_engine/src/instance/read.rs
@@ -259,6 +259,7 @@ impl Instance {
                 request_id: request.request_id,
                 metrics_collector: Some(metrics_collector),
                 deadline: request.opts.deadline,
+                num_streams_to_prefetch: self.scan_options.num_streams_to_prefetch,
                 space_id: table_data.space_id,
                 table_id: table_data.id,
                 projected_schema: projected_schema.clone(),

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -10,6 +10,7 @@ mod instance;
 mod manifest;
 pub mod memtable;
 mod payload;
+pub mod prefetchable_stream;
 pub mod row_iter;
 mod sampler;
 pub mod setup;
@@ -81,6 +82,8 @@ pub struct Config {
     pub scan_max_record_batches_in_flight: usize,
     /// Sst background reading parallelism
     pub sst_background_read_parallelism: usize,
+    /// Number of streams to prefetch
+    pub num_streams_to_prefetch: usize,
     /// Max buffer size for writing sst
     pub write_sst_max_buffer_size: ReadableSize,
     /// Max retry limit After flush failed
@@ -134,6 +137,7 @@ impl Default for Config {
             preflush_write_buffer_size_ratio: 0.75,
             scan_batch_size: None,
             sst_background_read_parallelism: 8,
+            num_streams_to_prefetch: 2,
             scan_max_record_batches_in_flight: 1024,
             write_sst_max_buffer_size: ReadableSize::mb(10),
             max_retry_flush_limit: 0,

--- a/analytic_engine/src/prefetchable_stream.rs
+++ b/analytic_engine/src/prefetchable_stream.rs
@@ -1,0 +1,172 @@
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
+
+// A stream can be prefetchable.
+
+use async_stream::stream;
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+
+pub type BoxedStream<T> = Box<dyn Stream<Item = T> + Send + Unpin>;
+
+#[async_trait]
+pub trait PrefetchableStream: Send {
+    type Item;
+
+    /// Start the prefetch procedure in background. In most implementation, this
+    /// method should not block the caller, that is to say, the prefetching
+    /// procedure should be run in the background.
+    async fn start_prefetch(&mut self);
+
+    /// Fetch the next record batch.
+    ///
+    /// If None is returned, all the following batches will be None.
+    async fn fetch_next(&mut self) -> Option<Self::Item>;
+}
+
+pub trait PrefetchableStreamExt: PrefetchableStream {
+    fn into_boxed_stream(mut self) -> BoxedStream<Self::Item>
+    where
+        Self: 'static + Sized,
+        Self::Item: Send,
+    {
+        let stream = stream! {
+            while let Some(v) = self.fetch_next().await {
+                yield v;
+            }
+        };
+
+        // FIXME: Will this conversion to a stream introduce overhead?
+        Box::new(Box::pin(stream))
+    }
+
+    fn filter_map<F, O>(self, f: F) -> FilterMap<Self, F>
+    where
+        F: FnMut(Self::Item) -> Option<O>,
+        Self: Sized,
+    {
+        FilterMap { stream: self, f }
+    }
+
+    fn map<F, O>(self, f: F) -> Map<Self, F>
+    where
+        F: FnMut(Self::Item) -> O,
+        Self: Sized,
+    {
+        Map { stream: self, f }
+    }
+}
+
+impl<T: ?Sized> PrefetchableStreamExt for T where T: PrefetchableStream {}
+
+#[async_trait]
+impl<T> PrefetchableStream for Box<dyn PrefetchableStream<Item = T>> {
+    type Item = T;
+
+    async fn start_prefetch(&mut self) {
+        (**self).start_prefetch().await;
+    }
+
+    async fn fetch_next(&mut self) -> Option<T> {
+        (**self).fetch_next().await
+    }
+}
+
+/// The implementation for `filter_map` operator on the PrefetchableStream.
+pub struct FilterMap<St, F> {
+    stream: St,
+    f: F,
+}
+
+#[async_trait]
+impl<St, F, O> PrefetchableStream for FilterMap<St, F>
+where
+    St: PrefetchableStream,
+    F: FnMut(St::Item) -> Option<O> + Send,
+    O: Send,
+{
+    type Item = O;
+
+    async fn start_prefetch(&mut self) {
+        self.stream.start_prefetch().await;
+    }
+
+    async fn fetch_next(&mut self) -> Option<O> {
+        loop {
+            match self.stream.fetch_next().await {
+                Some(v) => {
+                    let filtered_batch = (self.f)(v);
+                    if filtered_batch.is_some() {
+                        return filtered_batch;
+                    }
+                    // If the filtered batch is none, just continue to fetch and
+                    // filter until the underlying stream is exhausted.
+                }
+                None => return None,
+            }
+        }
+    }
+}
+
+/// The implementation for `map` operator on the PrefetchableStream.
+pub struct Map<St, F> {
+    stream: St,
+    f: F,
+}
+
+#[async_trait]
+impl<St, F, O> PrefetchableStream for Map<St, F>
+where
+    St: PrefetchableStream,
+    F: FnMut(St::Item) -> O + Send,
+    O: Send,
+{
+    type Item = O;
+
+    async fn start_prefetch(&mut self) {
+        self.stream.start_prefetch().await;
+    }
+
+    async fn fetch_next(&mut self) -> Option<O> {
+        self.stream.fetch_next().await.map(|v| (self.f)(v))
+    }
+}
+
+/// A noop prefetcher.
+///
+/// A wrapper with a underlying stream without prefetch logic.
+pub struct NoopPrefetcher<T>(pub BoxedStream<T>);
+
+#[async_trait]
+impl<T> PrefetchableStream for NoopPrefetcher<T> {
+    type Item = T;
+
+    async fn start_prefetch(&mut self) {
+        // It's just a noop operation.
+    }
+
+    async fn fetch_next(&mut self) -> Option<T> {
+        self.0.next().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_trait_object_prefetchable_stream() {
+        let numbers = vec![1, 2, 3];
+        let stream = stream::iter(numbers.clone());
+        let stream = NoopPrefetcher(Box::new(stream));
+        let mut stream: Box<dyn PrefetchableStream<Item = i32>> = Box::new(stream);
+
+        let mut fetched_numbers = Vec::with_capacity(numbers.len());
+        while let Some(v) = stream.fetch_next().await {
+            fetched_numbers.push(v);
+        }
+
+        assert_eq!(numbers, fetched_numbers);
+    }
+}

--- a/analytic_engine/src/sst/factory.rs
+++ b/analytic_engine/src/sst/factory.rs
@@ -103,6 +103,8 @@ pub struct ScanOptions {
     pub background_read_parallelism: usize,
     /// The max record batches in flight
     pub max_record_batches_in_flight: usize,
+    /// The number of streams to prefetch when scan
+    pub num_streams_to_prefetch: usize,
 }
 
 impl Default for ScanOptions {
@@ -110,6 +112,7 @@ impl Default for ScanOptions {
         Self {
             background_read_parallelism: 1,
             max_record_batches_in_flight: 64,
+            num_streams_to_prefetch: 2,
         }
     }
 }

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -455,7 +455,11 @@ mod tests {
                 .await
                 .unwrap();
             let sst_info = writer
-                .write(RequestId::next_id(), &sst_meta, record_batch_stream)
+                .write(
+                    RequestId::next_id(),
+                    &sst_meta,
+                    Box::new(record_batch_stream),
+                )
                 .await
                 .unwrap();
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true }
 common_types = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
+generic_error = { workspace = true }
 log = { workspace = true }
 macros = { workspace = true }
 object_store = { workspace = true }

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -199,6 +199,7 @@ fn mock_sst_read_options(
     let scan_options = ScanOptions {
         background_read_parallelism: 1,
         max_record_batches_in_flight: 1024,
+        num_streams_to_prefetch: 0,
     };
     SstReadOptions {
         reverse: false,

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -64,6 +64,7 @@ impl MergeSstBench {
         let scan_options = ScanOptions {
             background_read_parallelism: 1,
             max_record_batches_in_flight: 1024,
+            num_streams_to_prefetch: 0,
         };
         let sst_read_options = SstReadOptions {
             reverse: false,
@@ -192,6 +193,7 @@ impl MergeSstBench {
             sst_factory: &sst_factory,
             sst_read_options: self.sst_read_options.clone(),
             store_picker: &store_picker,
+            num_streams_to_prefetch: 0,
         })
         .ssts(vec![self.file_handles.clone()]);
 

--- a/benchmarks/src/sst_bench.rs
+++ b/benchmarks/src/sst_bench.rs
@@ -12,7 +12,6 @@ use analytic_engine::sst::{
     meta_data::cache::{MetaCache, MetaCacheRef},
 };
 use common_types::{projected_schema::ProjectedSchema, schema::Schema};
-use futures::stream::StreamExt;
 use log::info;
 use object_store::{LocalFileSystem, ObjectStoreRef, Path};
 use runtime::Runtime;
@@ -43,6 +42,7 @@ impl SstBench {
         let scan_options = ScanOptions {
             background_read_parallelism: 1,
             max_record_batches_in_flight: 1024,
+            num_streams_to_prefetch: 0,
         };
         let sst_read_options = SstReadOptions {
             reverse: config.reverse,
@@ -100,7 +100,7 @@ impl SstBench {
 
             let mut total_rows = 0;
             let mut batch_num = 0;
-            while let Some(batch) = sst_stream.next().await {
+            while let Some(batch) = sst_stream.fetch_next().await {
                 let num_rows = batch.unwrap().num_rows();
                 total_rows += num_rows;
                 batch_num += 1;

--- a/components/test_util/Cargo.toml
+++ b/components/test_util/Cargo.toml
@@ -16,6 +16,8 @@ test = ["env_logger"]
 [dependencies]
 # In alphabetical order
 arrow = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
 backtrace = "0.3.9"
 ceresdbproto = { workspace = true }
 chrono = { workspace = true }

--- a/table_engine/src/provider.rs
+++ b/table_engine/src/provider.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 CeresDB Project Authors. Licensed under Apache-2.0.
+// Copyright 2022-2023 CeresDB Project Authors. Licensed under Apache-2.0.
 
 //! Datafusion `TableProvider` adapter
 

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = { version = "1.0", features = ["backtrace"] }
 clap = { workspace = true, features = ["derive"] }
 common_types = { workspace = true }
 futures = { workspace = true }
+generic_error = { workspace = true }
 num_cpus = "1.15.0"
 object_store = { workspace = true }
 parquet = { workspace = true }


### PR DESCRIPTION
## Rationale
Close #959

The current procedure to fetch sst data is started immediately, and it may lead to high memory consumption when massive concurrent queries reaches.

## Detailed Changes
Introduce a prefetchable stream to replace the normal stream, with which a way to trigger the fetching data is provided and when to trigger it can also be determined by the caller.

## Test Plan
The memory usage and latency of the old version and new one will be attached here.