### PR TITLE
fix: make `is_dictionary` optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
  "bytes_ext",
  "ceresdbproto",
  "chrono",
+ "common_util",
  "datafusion",
  "murmur3",
  "paste 1.0.12",

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -32,3 +32,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 snafu = { workspace = true }
 sqlparser = { workspace = true }
+
+[dev-dependencies]
+common_util = { workspace = true }

--- a/common_types/src/column_schema.rs
+++ b/common_types/src/column_schema.rs
@@ -125,8 +125,8 @@ pub enum ReadOp {
 struct ArrowFieldMeta {
     id: u32,
     is_tag: bool,
-    is_dictionary: bool,
     comment: String,
+    is_dictionary: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -142,8 +142,8 @@ impl ArrowFieldMetaKey {
         match self {
             ArrowFieldMetaKey::Id => "field::id",
             ArrowFieldMetaKey::IsTag => "field::is_tag",
-            ArrowFieldMetaKey::IsDictionary => "field::is_dictionary",
             ArrowFieldMetaKey::Comment => "field::comment",
+            ArrowFieldMetaKey::IsDictionary => "field::is_dictionary",
         }
     }
 
@@ -624,8 +624,8 @@ mod tests {
                 ArrowFieldMeta {
                     id: 1,
                     is_tag: true,
-                    is_dictionary: false,
                     comment: "".to_string(),
+                    is_dictionary: false,
                 },
             ),
             (
@@ -638,8 +638,8 @@ mod tests {
                 ArrowFieldMeta {
                     id: 1,
                     is_tag: false,
-                    is_dictionary: true,
                     comment: "abc".to_string(),
+                    is_dictionary: true,
                 },
             ),
         ];

--- a/common_types/src/column_schema.rs
+++ b/common_types/src/column_schema.rs
@@ -147,8 +147,8 @@ impl ArrowFieldMetaKey {
         }
     }
 
-    // Only id,is_tag,comment are required fields, other fields should be optional
-    // to keep backward compatible
+    // Only id,is_tag,comment are required meta keys, other keys should be optional
+    // to keep backward compatible.
     fn is_required(&self) -> bool {
         matches!(self, Self::Id | Self::IsTag | Self::Comment)
     }


### PR DESCRIPTION
## Rationale
We support tag to be dictionary encoding, but in a back-incompatible way, it will throw following errors:

```
err:Arrow field meta key is not found, key:IsDictionary.
```
## Detailed Changes
- When parse arrow meta, make is_dictionary optional

## Test Plan
UT

