### PR TITLE
feat: use manifest updates stats in `TableData` to trigger snapshot

### DIFF
--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -4,7 +4,6 @@
 
 use std::{
     collections::HashMap,
-    num::NonZeroUsize,
     sync::{Arc, RwLock},
 };
 
@@ -61,14 +60,11 @@ impl Instance {
             store_picker.default_store().clone(),
         ));
 
-        let manifest_snapshot_every_n_updates =
-            NonZeroUsize::new(ctx.config.manifest.snapshot_every_n_updates)
-                .expect("manifest_snapshot_every_n_updates must be greater than 0");
         let table_meta_set_impl = Arc::new(TableMetaSetImpl {
             spaces: spaces.clone(),
             file_purger: file_purger.clone(),
             preflush_write_buffer_size_ratio: ctx.config.preflush_write_buffer_size_ratio,
-            manifest_snapshot_every_n_updates,
+            manifest_snapshot_every_n_updates: ctx.config.manifest.snapshot_every_n_updates,
         });
         let manifest = ManifestImpl::open(
             ctx.config.manifest.clone(),

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -64,6 +64,7 @@ impl Instance {
             spaces: spaces.clone(),
             file_purger: file_purger.clone(),
             preflush_write_buffer_size_ratio: ctx.config.preflush_write_buffer_size_ratio,
+            manifest_snapshot_every_n_updates: ctx.config.manifest.snapshot_every_n_updates,
         });
         let manifest = ManifestImpl::open(
             ctx.config.manifest.clone(),

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -4,6 +4,7 @@
 
 use std::{
     collections::HashMap,
+    num::NonZeroUsize,
     sync::{Arc, RwLock},
 };
 
@@ -60,11 +61,14 @@ impl Instance {
             store_picker.default_store().clone(),
         ));
 
+        let manifest_snapshot_every_n_updates =
+            NonZeroUsize::new(ctx.config.manifest.snapshot_every_n_updates)
+                .expect("manifest_snapshot_every_n_updates must be greater than 0");
         let table_meta_set_impl = Arc::new(TableMetaSetImpl {
             spaces: spaces.clone(),
             file_purger: file_purger.clone(),
             preflush_write_buffer_size_ratio: ctx.config.preflush_write_buffer_size_ratio,
-            manifest_snapshot_every_n_updates: ctx.config.manifest.snapshot_every_n_updates,
+            manifest_snapshot_every_n_updates,
         });
         let manifest = ManifestImpl::open(
             ctx.config.manifest.clone(),

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -328,6 +328,7 @@ where
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Options {
     /// Steps to do snapshot
+    // TODO: move this field to suitable place.
     pub snapshot_every_n_updates: usize,
 
     /// Timeout to read manifest entries
@@ -480,9 +481,10 @@ impl Manifest for ManifestImpl {
         let table_data = self.table_meta_set.apply_edit_to_table(request).box_err()?;
 
         // Judge if snapshot is needed.
-        if table_data.should_do_manifest_snapshot(self.opts.snapshot_every_n_updates) {
+        if table_data.should_do_manifest_snapshot() {
             self.do_snapshot_internal(space_id, table_id, location)
                 .await?;
+            table_data.reset_manifest_updates();
         }
 
         Ok(())
@@ -814,6 +816,7 @@ mod tests {
                 &purger,
                 0.75,
                 collector,
+                usize::MAX,
             )
             .unwrap();
 

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -710,7 +710,7 @@ impl MetaUpdateLogStore for WalBasedLogStore {
 
 #[cfg(test)]
 mod tests {
-    use std::{path::PathBuf, sync::Arc, vec};
+    use std::{num::NonZeroUsize, path::PathBuf, sync::Arc, vec};
 
     use arena::NoopCollector;
     use common_types::{
@@ -818,7 +818,7 @@ mod tests {
                 &purger,
                 0.75,
                 collector,
-                usize::MAX,
+                NonZeroUsize::new(usize::MAX).unwrap(),
             )
             .unwrap();
 

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -344,7 +344,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            snapshot_every_n_updates: 10_000,
+            snapshot_every_n_updates: 100,
             scan_timeout: ReadableDuration::secs(5),
             scan_batch_size: 100,
             store_timeout: ReadableDuration::secs(5),

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -480,6 +480,8 @@ impl Manifest for ManifestImpl {
         // Update memory.
         let table_data = self.table_meta_set.apply_edit_to_table(request).box_err()?;
 
+        // Update manifest updates count.
+        table_data.increase_manifest_updates(1);
         // Judge if snapshot is needed.
         if table_data.should_do_manifest_snapshot() {
             self.do_snapshot_internal(space_id, table_id, location)

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -681,7 +681,7 @@ pub mod tests {
 
     const DEFAULT_SPACE_ID: SpaceId = 1;
 
-    fn default_schema() -> Schema {
+    pub fn default_schema() -> Schema {
         table::create_schema_builder(
             &[("key", DatumKind::Timestamp)],
             &[("value", DatumKind::Double)],

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -894,22 +894,37 @@ pub mod tests {
 
     #[test]
     fn test_manifest_snapshot_trigger() {
+        // When snapshot_every_n_updates is not zero.
         let table_data = TableDataMocker::default()
             .manifest_snapshot_every_n_updates(5)
             .build();
-        // When no updates yet, result should be false.
-        assert!(!table_data.should_do_manifest_snapshot());
 
-        // Normal case.
-        table_data.increase_manifest_updates(5);
-        assert!(table_data.should_do_manifest_snapshot());
+        check_manifest_snapshot_trigger(&table_data);
+        // Reset and check again.
+        table_data.reset_manifest_updates();
+        check_manifest_snapshot_trigger(&table_data);
 
-        // When snapshot_every_n_updates is set to zero, result should be always false.
+        // When snapshot_every_n_updates is set to zero.
         let table_data = TableDataMocker::default()
             .manifest_snapshot_every_n_updates(0)
             .build();
         assert!(!table_data.should_do_manifest_snapshot());
         table_data.increase_manifest_updates(5);
         assert!(!table_data.should_do_manifest_snapshot());
+        table_data.increase_manifest_updates(5);
+        assert!(!table_data.should_do_manifest_snapshot());
+    }
+
+    fn check_manifest_snapshot_trigger(table_data: &TableData) {
+        // When no updates yet, result should be false.
+        assert!(!table_data.should_do_manifest_snapshot());
+
+        // Eq case.
+        table_data.increase_manifest_updates(5);
+        assert!(table_data.should_do_manifest_snapshot());
+
+        // Greater case.
+        table_data.increase_manifest_updates(5);
+        assert!(table_data.should_do_manifest_snapshot());
     }
 }

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -894,6 +894,22 @@ pub mod tests {
 
     #[test]
     fn test_manifest_snapshot_trigger() {
-        let table_data = TableDataMocker::default().build();
+        let table_data = TableDataMocker::default()
+            .manifest_snapshot_every_n_updates(5)
+            .build();
+        // When no updates yet, result should be false.
+        assert!(!table_data.should_do_manifest_snapshot());
+
+        // Normal case.
+        table_data.increase_manifest_updates(5);
+        assert!(table_data.should_do_manifest_snapshot());
+
+        // When snapshot_every_n_updates is set to zero, result should be always false.
+        let table_data = TableDataMocker::default()
+            .manifest_snapshot_every_n_updates(0)
+            .build();
+        assert!(!table_data.should_do_manifest_snapshot());
+        table_data.increase_manifest_updates(5);
+        assert!(!table_data.should_do_manifest_snapshot());
     }
 }

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -83,7 +83,12 @@ impl TableMetaSetImpl {
             }
         };
 
-        apply_edit(space.clone(), table_data)
+        apply_edit(space.clone(), table_data.clone())?;
+
+        // Increase manifest updates after apply edit successfully.
+        table_data.increase_manifest_updates(1);
+
+        Ok(())
     }
 
     fn apply_update(

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -2,7 +2,7 @@
 
 //! Table data set impl based on spaces
 
-use std::{fmt, sync::Arc};
+use std::{fmt, num::NonZeroUsize, sync::Arc};
 
 use common_util::{error::BoxError, id_allocator::IdAllocator};
 use log::debug;
@@ -36,7 +36,7 @@ pub(crate) struct TableMetaSetImpl {
     pub(crate) file_purger: FilePurgerRef,
     // TODO: maybe not suitable to place this parameter here?
     pub(crate) preflush_write_buffer_size_ratio: f32,
-    pub(crate) manifest_snapshot_every_n_updates: usize,
+    pub(crate) manifest_snapshot_every_n_updates: NonZeroUsize,
 }
 
 impl fmt::Debug for TableMetaSetImpl {

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -36,6 +36,7 @@ pub(crate) struct TableMetaSetImpl {
     pub(crate) file_purger: FilePurgerRef,
     // TODO: maybe not suitable to place this parameter here?
     pub(crate) preflush_write_buffer_size_ratio: f32,
+    pub(crate) manifest_snapshot_every_n_updates: usize,
 }
 
 impl fmt::Debug for TableMetaSetImpl {
@@ -123,6 +124,7 @@ impl TableMetaSetImpl {
                         &self.file_purger,
                         self.preflush_write_buffer_size_ratio,
                         space.mem_usage_collector.clone(),
+                        self.manifest_snapshot_every_n_updates,
                     )
                     .box_err()
                     .with_context(|| ApplyUpdateToTableWithCause {
@@ -249,6 +251,7 @@ impl TableMetaSetImpl {
                 self.preflush_write_buffer_size_ratio,
                 space.mem_usage_collector.clone(),
                 allocator,
+                self.manifest_snapshot_every_n_updates,
             )
             .box_err()
             .with_context(|| ApplySnapshotToTableWithCause {

--- a/analytic_engine/src/table_meta_set_impl.rs
+++ b/analytic_engine/src/table_meta_set_impl.rs
@@ -86,9 +86,6 @@ impl TableMetaSetImpl {
 
         apply_edit(space.clone(), table_data.clone())?;
 
-        // Increase manifest updates after apply edit successfully.
-        table_data.increase_manifest_updates(1);
-
         Ok(table_data)
     }
 


### PR DESCRIPTION
## Rationale
Now we stats manifest updates of all tables in `Manifest` to trigger snapshot. 
However when snapshot is triggered, it will just do snapshot of latest table storing update.
It is obvious unreasonable...

Worse, this mechanism lead to bug #1075 ...

So In this pr, I place the manifest updates stats into `TableData` , and each table can only trigger snapshot of itself rather than others.

## Detailed Changes
+ Place the manifest updates stats into `TableData`.
+ Use it to trigger manifest snapshot.

## Test Plan
Test by new ut.
