### PR TITLE
fix: ensure shard is opened once

### DIFF
--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -102,10 +102,8 @@ impl ClusterImpl {
             loop {
                 let shard_infos = inner
                     .shard_set
-                    .all_shards()
+                    .all_opened_shards()
                     .iter()
-                    // Only report opened shards to meta, other shards may need retry.
-                    .filter(|shard| shard.is_opened())
                     .map(|shard| shard.shard_info())
                     .collect();
                 info!("Node heartbeat to meta, shard infos:{:?}", shard_infos);

--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -100,12 +100,14 @@ impl ClusterImpl {
 
         let handle = self.runtime.spawn(async move {
             loop {
-                let shards = inner.shard_set.all_shards();
-                let mut shard_infos = Vec::with_capacity(shards.len());
-                for shard in shards {
-                    let shard_info = shard.shard_info();
-                    shard_infos.push(shard_info);
-                }
+                let shard_infos = inner
+                    .shard_set
+                    .all_shards()
+                    .iter()
+                    // Only report opened shards to meta, other shards may need retry.
+                    .filter(|shard| shard.is_opened())
+                    .map(|shard| shard.shard_info())
+                    .collect();
                 info!("Node heartbeat to meta, shard infos:{:?}", shard_infos);
 
                 let resp = inner.meta_client.send_heartbeat(shard_infos).await;


### PR DESCRIPTION
## Rationale
In current implementation, open shard process have following issue:
1. When tables of shard is not fully opened, it will report to meta the shard is opened. It should wait all tables are opened.
2. Open shard may get executed multiple times, since meta may keep sending open shard request

## Detailed Changes
1. Introduce ShardStatus, which will be set to `Opened` when all tables are opened, and only after this, shard can be sent to meta.
2. Before open shard, check status, if it's already in opening, return an Error.

## Test Plan
WIP

