### PR TITLE
feat: add shard status when heartbeat to meta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff289995b93a0f20dd77342a2ac85447a68e62c03b56704b588630c4d98b08d3"
+checksum = "25926e49d9d931b3089b26aba55cd5057631db452137f45d0d24f8b5dae8a28c"
 dependencies = [
  "prost",
  "protoc-bin-vendored",

--- a/catalog/src/table_operator.rs
+++ b/catalog/src/table_operator.rs
@@ -5,10 +5,7 @@ use std::time::Instant;
 use generic_error::BoxError;
 use log::{error, info, warn};
 use snafu::{OptionExt, ResultExt};
-use table_engine::{
-    engine,
-    table::{FlushRequest, TableRef},
-};
+use table_engine::{engine, table::TableRef};
 use time_ext::InstantExt;
 
 use crate::{
@@ -77,12 +74,6 @@ impl TableOperator {
 
             match table_result {
                 Ok(Some(table)) => {
-                    // When table open successfully, try flush to reduce WAL size, so when reopen
-                    // this shard the WAL required to fetch is reduced.
-                    if let Err(e) = table.flush(FlushRequest { sync: false }).await {
-                        warn!("Try flush after open table failed, err:{e}");
-                    }
-
                     schema.register_table(table);
                     success_count += 1;
                 }

--- a/catalog/src/table_operator.rs
+++ b/catalog/src/table_operator.rs
@@ -5,7 +5,10 @@ use std::time::Instant;
 use generic_error::BoxError;
 use log::{error, info, warn};
 use snafu::{OptionExt, ResultExt};
-use table_engine::{engine, table::TableRef};
+use table_engine::{
+    engine,
+    table::{FlushRequest, TableRef},
+};
 use time_ext::InstantExt;
 
 use crate::{
@@ -74,6 +77,12 @@ impl TableOperator {
 
             match table_result {
                 Ok(Some(table)) => {
+                    // When table open successfully, try flush to reduce WAL size, so when reopen
+                    // this shard the WAL required to fetch is reduced.
+                    if let Err(e) = table.flush(FlushRequest { sync: false }).await {
+                        warn!("Try flush after open table failed, err:{e}");
+                    }
+
                     schema.register_table(table);
                     success_count += 1;
                 }

--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -102,7 +102,7 @@ impl ClusterImpl {
             loop {
                 let shard_infos = inner
                     .shard_set
-                    .all_opened_shards()
+                    .all_shards()
                     .iter()
                     .map(|shard| shard.shard_info())
                     .collect();

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -181,10 +181,10 @@ pub struct NodeInfo {
 /// - `Opening`, which means it has been opened before, but failed.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize)]
 pub enum ShardStatus {
-    /// Not allowed report to ceresmeta
+    /// Created, but not opened
     #[default]
     Init,
-    /// Not allowed report to ceresmeta
+    /// In opening
     Opening,
     /// Healthy
     Ready,

--- a/router/src/cluster_based.rs
+++ b/router/src/cluster_based.rs
@@ -224,7 +224,7 @@ mod tests {
                                 id: 0,
                                 role: Leader,
                                 version: 100,
-                                status: None,
+                                status: Default::default(),
                             },
                         }],
                     },

--- a/router/src/cluster_based.rs
+++ b/router/src/cluster_based.rs
@@ -224,6 +224,7 @@ mod tests {
                                 id: 0,
                                 role: Leader,
                                 version: 100,
+                                status: None,
                             },
                         }],
                     },

--- a/server/src/grpc/meta_event_service/mod.rs
+++ b/server/src/grpc/meta_event_service/mod.rs
@@ -299,7 +299,7 @@ async fn do_open_shard(ctx: HandlerContext, shard_info: ShardInfo) -> Result<()>
 
     shard.open(open_ctx).await.box_err().context(ErrWithCause {
         code: StatusCode::Internal,
-        msg: "fail to open shard",
+        msg: format!("fail to open shard, id:{}", shard_info.id),
     })
 }
 


### PR DESCRIPTION
## Rationale
After #1080, ceresdb will not heartbeat to meta until all table open finished, that is to say that all tables inside a shard will not be used for write/read, which is unreasonable.

## Detailed Changes
- Introduce PartialOpen status sent to meta, and it will send this status when part of tables are opened, and meta will route table in this status.
- <del>Flush table when open successfully to reduce WAL size.</del>
## Test Plan

Manually