### PR TITLE
fix:  out of range error in module ObjectStore base on OBKV

### DIFF
--- a/components/object_store/src/obkv/meta.rs
+++ b/components/object_store/src/obkv/meta.rs
@@ -178,8 +178,8 @@ impl ObkvObjectMeta {
         let start_index = range.start / batch_size;
         let start_offset = range.start % batch_size;
 
-        // if `range.end` is zero, it means the range is empty
-        let inclusive_end = if range.end == 0 {
+        // if the range is empty, return empty parts
+        let inclusive_end = if range.is_empty() {
             return Ok(ConveredParts {
                 part_keys: &self.parts[0..0],
                 start_offset: 0,

--- a/components/object_store/src/obkv/meta.rs
+++ b/components/object_store/src/obkv/meta.rs
@@ -387,7 +387,7 @@ mod test {
 
         let range1 = Range { start: 0, end: 0 };
         let expect = meta.compute_covered_parts(range1).unwrap();
-        assert!(expect.part_keys.len() == 0);
+        assert!(expect.part_keys.is_empty());
         assert!(expect.start_offset == 0);
         assert!(expect.end_offset == 0);
     }

--- a/components/object_store/src/obkv/meta.rs
+++ b/components/object_store/src/obkv/meta.rs
@@ -218,7 +218,7 @@ impl<T: TableKv> MetaManager<T> {
     pub async fn save(&self, meta: ObkvObjectMeta) -> Result<()> {
         let mut batch = T::WriteBatch::default();
         let encode_bytes = meta.encode()?;
-        batch.insert(meta.location.as_bytes(), &encode_bytes);
+        batch.insert_or_update(meta.location.as_bytes(), &encode_bytes);
         self.client
             .as_ref()
             .write(WriteContext::default(), OBJECT_STORE_META, batch)

--- a/components/object_store/src/obkv/mod.rs
+++ b/components/object_store/src/obkv/mod.rs
@@ -468,6 +468,10 @@ impl<T: TableKv> ObjectStore for ObkvObjectStore<T> {
                 source,
             })?;
 
+        if covered_parts.part_keys.is_empty() {
+            return Ok(Bytes::new());
+        }
+
         let keys: Vec<&[u8]> = covered_parts
             .part_keys
             .iter()
@@ -496,7 +500,7 @@ impl<T: TableKv> ObjectStore for ObkvObjectStore<T> {
         for (index, (key, value)) in covered_parts.part_keys.iter().zip(values).enumerate() {
             if let Some(bytes) = value {
                 let mut begin = 0;
-                let mut end = bytes.len();
+                let mut end = bytes.len() - 1;
                 if index == 0 {
                     begin = covered_parts.start_offset;
                 }
@@ -504,7 +508,7 @@ impl<T: TableKv> ObjectStore for ObkvObjectStore<T> {
                 if index == covered_parts.part_keys.len() - 1 {
                     end = covered_parts.end_offset;
                 }
-                range_buffer.extend_from_slice(&bytes[begin..end]);
+                range_buffer.extend_from_slice(&bytes[begin..=end]);
             } else {
                 DataPartNotFound { part_key: key }
                     .fail()

--- a/components/object_store/src/obkv/mod.rs
+++ b/components/object_store/src/obkv/mod.rs
@@ -459,72 +459,69 @@ impl<T: TableKv> ObjectStore for ObkvObjectStore<T> {
                     source,
                 })?;
 
-        let mut range_buffer = Vec::with_capacity(range.end - range.start);
         let covered_parts = meta
-            .compute_covered_parts(range)
+            .compute_covered_parts(range.clone())
             .box_err()
             .map_err(|source| StoreError::NotFound {
                 path: location.to_string(),
                 source,
             })?;
 
-        if covered_parts.part_keys.is_empty() {
-            return Ok(Bytes::new());
-        }
-
-        let keys: Vec<&[u8]> = covered_parts
-            .part_keys
-            .iter()
-            .map(|key| key.as_bytes())
-            .collect();
-        let values =
-            self.client
-                .get_batch(table_name, keys)
-                .map_err(|source| StoreError::NotFound {
-                    path: location.to_string(),
-                    source: Box::new(source),
-                })?;
-
-        if covered_parts.part_keys.len() != values.len() {
-            DataPartsLength {
-                part_len: covered_parts.part_keys.len(),
-                value_len: values.len(),
-            }
-            .fail()
-            .map_err(|source| StoreError::Generic {
-                store: OBKV,
-                source: Box::new(source),
-            })?
-        }
-
-        for (index, (key, value)) in covered_parts.part_keys.iter().zip(values).enumerate() {
-            if let Some(bytes) = value {
-                let mut begin = 0;
-                let mut end = bytes.len() - 1;
-                if index == 0 {
-                    begin = covered_parts.start_offset;
-                }
-                // the last one
-                if index == covered_parts.part_keys.len() - 1 {
-                    end = covered_parts.end_offset;
-                }
-                range_buffer.extend_from_slice(&bytes[begin..=end]);
-            } else {
-                DataPartNotFound { part_key: key }
-                    .fail()
+        if let Some(covered_parts) = covered_parts {
+            let mut range_buffer = Vec::with_capacity(range.end - range.start);
+            let keys: Vec<&[u8]> = covered_parts
+                .part_keys
+                .iter()
+                .map(|key| key.as_bytes())
+                .collect();
+            let values =
+                self.client
+                    .get_batch(table_name, keys)
                     .map_err(|source| StoreError::NotFound {
                         path: location.to_string(),
                         source: Box::new(source),
                     })?;
+
+            if covered_parts.part_keys.len() != values.len() {
+                DataPartsLength {
+                    part_len: covered_parts.part_keys.len(),
+                    value_len: values.len(),
+                }
+                .fail()
+                .map_err(|source| StoreError::Generic {
+                    store: OBKV,
+                    source: Box::new(source),
+                })?
             }
+
+            for (index, (key, value)) in covered_parts.part_keys.iter().zip(values).enumerate() {
+                if let Some(bytes) = value {
+                    let mut begin = 0;
+                    let mut end = bytes.len() - 1;
+                    if index == 0 {
+                        begin = covered_parts.start_offset;
+                    }
+                    // the last one
+                    if index == covered_parts.part_keys.len() - 1 {
+                        end = covered_parts.end_offset;
+                    }
+                    range_buffer.extend_from_slice(&bytes[begin..=end]);
+                } else {
+                    DataPartNotFound { part_key: key }
+                        .fail()
+                        .map_err(|source| StoreError::NotFound {
+                            path: location.to_string(),
+                            source: Box::new(source),
+                        })?;
+                }
+            }
+
+            debug!("ObkvObjectStore get_range operation, location:{location}, table:{table_name}, cost:{:?}", instant.elapsed());
+
+            return Ok(range_buffer.into());
+        } else {
+            return Ok(Bytes::new());
         }
-
-        debug!(
-            "ObkvObjectStore get_range operation, location:{location}, table:{table_name}, cost:{:?}",
-            instant.elapsed()
-        );
-
-        Ok(range_buffer.into())
     }
 
     /// Return the metadata for the specified location


### PR DESCRIPTION
## Rationale
In current version, there are two bugs in module `ObjectStore` based on OBKV.
* `Out of range` error occurs when calling  method `get_range` 
*  Save meta info error when putting an existing file.

## Detailed Changes
* Fix these bugs
* Add some unit tests

## Test Plan
* Test by unit tests
