### PR TITLE
feat: refactor stats method in wal

### DIFF
--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -37,7 +37,7 @@ use warp::{
     http::StatusCode,
     reject,
     reply::{self, Reply},
-    Filter,
+    Filter, Rejection,
 };
 
 use crate::{
@@ -204,7 +204,7 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
             .or(self.profile_heap())
             .or(self.server_config())
             .or(self.shards())
-            .or(self.stats())
+            .or(self.wal_stats())
             .with(warp::log("http_requests"))
             .with(warp::log::custom(|info| {
                 let path = info.path();
@@ -516,24 +516,30 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
     }
 
     // GET /debug/stats
-    fn stats(&self) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-        let opened_wals = self.opened_wals.clone();
-        warp::path!("debug" / "stats")
+    fn wal_stats(
+        &self,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        warp::path!("debug" / "wal_stats")
             .and(warp::get())
-            .map(move || {
-                [
-                    "Data wal stats:",
-                    &opened_wals
+            .and(self.with_opened_wals())
+            .and_then(|wals: OpenedWals| async move {
+                let stats = [
+                    "[Data wal stats]:",
+                    &wals
                         .data_wal
                         .get_statistics()
+                        .await
                         .unwrap_or_else(|| "Unknown".to_string()),
-                    "Manifest wal stats:",
-                    &opened_wals
+                    "[Manifest wal stats]:",
+                    &wals
                         .manifest_wal
                         .get_statistics()
+                        .await
                         .unwrap_or_else(|| "Unknown".to_string()),
                 ]
-                .join("\n")
+                .join("\n");
+
+                std::result::Result::<_, Rejection>::Ok(reply::json(&stats))
             })
     }
 
@@ -652,6 +658,11 @@ impl<Q: QueryExecutor + 'static> Service<Q> {
     ) -> impl Filter<Extract = (Arc<RuntimeLevel>,), Error = Infallible> + Clone {
         let log_runtime = self.log_runtime.clone();
         warp::any().map(move || log_runtime.clone())
+    }
+
+    fn with_opened_wals(&self) -> impl Filter<Extract = (OpenedWals,), Error = Infallible> + Clone {
+        let wals = self.opened_wals.clone();
+        warp::any().map(move || wals.clone())
     }
 }
 

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -3,8 +3,8 @@
 //! Http service
 
 use std::{
-    collections::HashMap, convert::Infallible, error::Error as StdError, fmt::format, net::IpAddr,
-    sync::Arc, time::Duration,
+    collections::HashMap, convert::Infallible, error::Error as StdError, net::IpAddr, sync::Arc,
+    time::Duration,
 };
 
 use analytic_engine::setup::OpenedWals;

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -318,7 +318,7 @@ pub trait WalManager: Send + Sync + fmt::Debug + 'static {
     async fn scan(&self, ctx: &ScanContext, req: &ScanRequest) -> Result<BatchLogIteratorAdapter>;
 
     /// Get statistics
-    fn get_statistics(&self) -> Option<String> {
+    async fn get_statistics(&self) -> Option<String> {
         None
     }
 }

--- a/wal/src/manager.rs
+++ b/wal/src/manager.rs
@@ -318,9 +318,7 @@ pub trait WalManager: Send + Sync + fmt::Debug + 'static {
     async fn scan(&self, ctx: &ScanContext, req: &ScanRequest) -> Result<BatchLogIteratorAdapter>;
 
     /// Get statistics
-    async fn get_statistics(&self) -> Option<String> {
-        None
-    }
+    async fn get_statistics(&self) -> Option<String>;
 }
 
 #[derive(Debug)]

--- a/wal/src/message_queue_impl/namespace.rs
+++ b/wal/src/message_queue_impl/namespace.rs
@@ -206,6 +206,18 @@ impl<M: MessageQueue> Namespace<M> {
     ) -> Result<()> {
         self.inner.mark_delete_to(location, sequence_num).await
     }
+
+    pub async fn get_statistics(&self) -> String {
+        let regions = self.inner.regions.read().await;
+        let mut region_stats = Vec::with_capacity(regions.len());
+        for (region_id, region) in regions.iter() {
+            let snapshot = region.make_meta_snapshot().await;
+            let region_stat = format!("region_id:{region_id}, snapshot:{snapshot:?}",);
+            region_stats.push(region_stat);
+        }
+
+        region_stats.join("\n")
+    }
 }
 
 // TODO: more information should be included.

--- a/wal/src/message_queue_impl/region.rs
+++ b/wal/src/message_queue_impl/region.rs
@@ -682,8 +682,7 @@ impl<M: MessageQueue> Region<M> {
     }
 
     /// Return snapshot, just used for test.
-    #[allow(dead_code)]
-    async fn make_meta_snapshot(&self) -> RegionMetaSnapshot {
+    pub async fn make_meta_snapshot(&self) -> RegionMetaSnapshot {
         let inner = self.inner.write().await;
         inner.make_meta_snapshot().await
     }

--- a/wal/src/message_queue_impl/wal.rs
+++ b/wal/src/message_queue_impl/wal.rs
@@ -95,6 +95,12 @@ impl<M: MessageQueue> WalManager for MessageQueueImpl<M> {
     async fn write(&self, ctx: &WriteContext, batch: &LogWriteBatch) -> Result<SequenceNumber> {
         self.0.write(ctx, batch).await.box_err().context(Write)
     }
+
+    async fn get_statistics(&self) -> Option<String> {
+        let stats = self.0.get_statistics().await;
+
+        Some(stats)
+    }
 }
 
 #[async_trait]

--- a/wal/src/message_queue_impl/wal.rs
+++ b/wal/src/message_queue_impl/wal.rs
@@ -97,7 +97,8 @@ impl<M: MessageQueue> WalManager for MessageQueueImpl<M> {
     }
 
     async fn get_statistics(&self) -> Option<String> {
-        let stats = self.0.get_statistics().await;
+        let wal_stats = self.0.get_statistics().await;
+        let stats = format!("#MessageQueueWal stats:\n{wal_stats}\n");
 
         Some(stats)
     }

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -911,6 +911,7 @@ impl WalManager for RocksImpl {
         } else {
             None
         };
+        let rocksdb_stats = rocksdb_stats.unwrap_or_default();
 
         // Wal stats.
         let table_units = self.table_units.read().unwrap();
@@ -920,10 +921,7 @@ impl WalManager for RocksImpl {
         }
         let wal_stats = wal_stats.join("\n");
 
-        let stats = format!(
-            "#RocksDB stats:\n{rocksdb_stats:?}\n\n
-                                    #Wal stats:\n{wal_stats:?}\n"
-        );
+        let stats = format!("#RocksDB stats:\n{rocksdb_stats}\n#RocksDBWal stats:\n{wal_stats}\n");
 
         Some(stats)
     }

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -256,6 +256,19 @@ impl<T> NamespaceInner<T> {
         let mut table_units = self.table_units.write().unwrap();
         table_units.clear();
     }
+
+    fn get_statistics(&self) -> String {
+        let table_units = self.table_units.read().unwrap();
+        let mut wal_stats = Vec::with_capacity(table_units.len());
+        for table_unit in table_units.values() {
+            wal_stats.push(format!("{:?}", table_unit.as_ref()));
+        }
+        let stats = wal_stats.join("\n");
+
+        let stats = format!("#TableKvWal stats:\n{stats}\n");
+
+        stats
+    }
 }
 
 // Blocking operations.
@@ -1103,6 +1116,10 @@ impl<T: TableKv> Namespace<T> {
             namespace_entry,
             config,
         )
+    }
+
+    pub fn get_statistics(&self) -> String {
+        self.inner.get_statistics()
     }
 }
 

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -190,6 +190,17 @@ pub struct TableUnit {
     writer: Mutex<TableUnitWriter>,
 }
 
+impl std::fmt::Debug for TableUnit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableUnit")
+            .field("region_id", &self.state.region_id)
+            .field("table_id", &self.state.table_id)
+            .field("start_sequence", &self.state.start_sequence)
+            .field("last_sequence", &self.state.last_sequence)
+            .finish()
+    }
+}
+
 // Async or non-blocking operations.
 impl TableUnit {
     /// Open table unit of given `region_id` and `table_id`, the caller should

--- a/wal/src/table_kv_impl/wal.rs
+++ b/wal/src/table_kv_impl/wal.rs
@@ -182,4 +182,10 @@ impl<T: TableKv> WalManager for WalNamespaceImpl<T> {
             ctx.batch_size,
         ))
     }
+
+    async fn get_statistics(&self) -> Option<String> {
+        let stats = self.namespace.get_statistics();
+
+        Some(stats)
+    }
 }


### PR DESCRIPTION
## Rationale
Although `get_statistic` method exist in `WalManager`, it print so less message and just impl in RocksDB wal.
In this pr, I impl this method in all wal impls, and print the detail inner infos through it.

The output example(RocksDB wal):
```
[Data wal stats]:
#RocksDB stats:
#Wal stats:
TableUnit { id: 2199023255724, next_sequence_num: 59 }
TableUnit { id: 2199023255777, next_sequence_num: 50 }
TableUnit { id: 2199023255627, next_sequence_num: 50 }
...

------------------------------------------------------

[Manifest wal stats]:
#RocksDB stats:
#Wal stats:
TableUnit { id: 2199023255739, next_sequence_num: 2 }
TableUnit { id: 2199023255669, next_sequence_num: 2 }
TableUnit { id: 2199023255740, next_sequence_num: 2 }
...

```


## Detailed Changes
Impl and improve the `get_statistic` method in `WalManager`.

## Test Plan
Test manually.