### PR TITLE
feat: Improve performance of thetasketch dinstinct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "siphasher",
  "snafu 0.6.10",
  "sqlparser",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3030,8 +3030,8 @@ dependencies = [
 
 [[package]]
 name = "hyperloglog"
-version = "1.0.1"
-source = "git+https://github.com/jedisct1/rust-hyperloglog.git?rev=ed1b9b915072ba90c6b93fbfbba30c03215ba682#ed1b9b915072ba90c6b93fbfbba30c03215ba682"
+version = "1.0.2"
+source = "git+https://github.com/jedisct1/rust-hyperloglog.git?rev=425487ce910f26636fbde8c4d640b538431aad50#425487ce910f26636fbde8c4d640b538431aad50"
 dependencies = [
  "bytecount",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,6 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "siphasher",
  "snafu 0.6.10",
  "sqlparser",
 ]

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -27,5 +27,6 @@ paste = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+siphasher = "0.3.10"
 snafu = { workspace = true }
 sqlparser = { workspace = true }

--- a/common_types/Cargo.toml
+++ b/common_types/Cargo.toml
@@ -27,6 +27,5 @@ paste = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-siphasher = "0.3.10"
 snafu = { workspace = true }
 sqlparser = { workspace = true }

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -90,6 +90,23 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+// Float wrapper over f32/f64. Just because we cannot build std::hash::Hash for
+// floats directly we have to do it through type wrapper Fork from datafusion
+struct Fl<T>(T);
+
+macro_rules! hash_float_value {
+    ($(($t:ty, $i:ty)),+) => {
+        $(impl std::hash::Hash for Fl<$t> {
+            #[inline]
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                state.write(&<$i>::from_ne_bytes(self.0.to_ne_bytes()).to_ne_bytes())
+            }
+        })+
+    };
+}
+
+hash_float_value!((f64, u64), (f32, u32));
+
 // FIXME(yingwen): How to handle timezone?
 
 /// Data type of datum
@@ -1138,6 +1155,37 @@ impl<'a> DatumView<'a> {
             }
         }
     }
+
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            DatumView::String(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> std::hash::Hash for DatumView<'a> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            DatumView::Null => 1.hash(state),
+            DatumView::Timestamp(v) => v.hash(state),
+            DatumView::Double(v) => Fl(*v).hash(state),
+            DatumView::Float(v) => Fl(*v).hash(state),
+            DatumView::Varbinary(v) => v.hash(state),
+            DatumView::String(v) => v.hash(state),
+            DatumView::UInt64(v) => v.hash(state),
+            DatumView::UInt32(v) => v.hash(state),
+            DatumView::UInt16(v) => v.hash(state),
+            DatumView::UInt8(v) => v.hash(state),
+            DatumView::Int64(v) => v.hash(state),
+            DatumView::Int32(v) => v.hash(state),
+            DatumView::Int16(v) => v.hash(state),
+            DatumView::Int8(v) => v.hash(state),
+            DatumView::Boolean(v) => v.hash(state),
+            DatumView::Date(v) => v.hash(state),
+            DatumView::Time(v) => v.hash(state),
+        }
+    }
 }
 
 impl DatumKind {
@@ -1359,6 +1407,11 @@ impl From<DatumKind> for DataType {
 
 #[cfg(test)]
 mod tests {
+    
+
+    
+    
+
     use super::*;
 
     #[test]
@@ -1581,4 +1634,20 @@ mod tests {
             }
         }
     }
+
+    // #[test]
+    // fn test_hash() {
+    //     let a = DatumView::Int32(142);
+    //     let b = ScalarValue::Int32(Some(142));
+    //     println!("dv:{}, sc:{}, Some:{}", get_hash(&a, 0), get_hash(&b, 0),
+    // get_hash(&Some(142), 0)); }
+
+    // fn get_hash<V: Hash>(value: &V, seed: u128) -> u64 {
+    //     let key0 = (seed >> 64) as u64;
+    //     let key1 = seed as u64;
+    //     let mut sip = SipHasher13::new_with_keys(key0, key1);
+    //     value.hash(&mut sip);
+    //     let x = sip.finish();
+    //     x
+    // }
 }

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -21,6 +21,7 @@ use crate::{hex, string::StringBytes, time::Timestamp};
 
 const DATE_FORMAT: &str = "%Y-%m-%d";
 const TIME_FORMAT: &str = "%H:%M:%S%.3f";
+const NULL_VALUE_FOR_HASH: u128 = u128::MAX;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -1167,7 +1168,7 @@ impl<'a> DatumView<'a> {
 impl<'a> std::hash::Hash for DatumView<'a> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
-            DatumView::Null => 1.hash(state),
+            DatumView::Null => NULL_VALUE_FOR_HASH.hash(state),
             DatumView::Timestamp(v) => v.hash(state),
             DatumView::Double(v) => Fl(*v).hash(state),
             DatumView::Float(v) => Fl(*v).hash(state),
@@ -1667,7 +1668,7 @@ mod tests {
         assert_datum_view_hash!(true, Boolean);
 
         // Null case.
-        let null_expected = get_hash(&1);
+        let null_expected = get_hash(&NULL_VALUE_FOR_HASH);
         let null_actual = get_hash(&DatumView::Null);
         assert_eq!(null_expected, null_actual);
 

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -92,7 +92,9 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 // Float wrapper over f32/f64. Just because we cannot build std::hash::Hash for
-// floats directly we have to do it through type wrapper Fork from datafusion
+// floats directly we have to do it through type wrapper
+// Fork from datafusion:
+//  https://github.com/apache/arrow-datafusion/blob/1a0542acbc01e5243471ae0fc3586c2f1f40013b/datafusion/common/src/scalar.rs#L1493
 struct Fl<T>(T);
 
 macro_rules! hash_float_value {

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -1407,10 +1407,6 @@ impl From<DatumKind> for DataType {
 
 #[cfg(test)]
 mod tests {
-    
-
-    
-    
 
     use super::*;
 

--- a/df_operator/Cargo.toml
+++ b/df_operator/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { workspace = true }
 common_types = { workspace = true }
 datafusion = { workspace = true }
 generic_error = { workspace = true }
-hyperloglog = { git = "https://github.com/jedisct1/rust-hyperloglog.git", rev = "ed1b9b915072ba90c6b93fbfbba30c03215ba682", features = ["with_serde"] }
+hyperloglog = { git = "https://github.com/jedisct1/rust-hyperloglog.git", rev = "425487ce910f26636fbde8c4d640b538431aad50", features = ["with_serde"] }
 macros = { workspace = true }
 smallvec = { workspace = true }
 snafu = { workspace = true }

--- a/df_operator/src/aggregate.rs
+++ b/df_operator/src/aggregate.rs
@@ -120,12 +120,15 @@ impl<T: Accumulator> DfAccumulator for ToDfAccumulator<T> {
         if values.is_empty() {
             return Ok(());
         };
+
+        let mut row = Vec::with_capacity(values.len());
         (0..values[0].len()).try_for_each(|index| {
-            let v = values
-                .iter()
-                .map(|array| DfScalarValue::try_from_array(array, index))
-                .collect::<DfResult<Vec<DfScalarValue>>>()?;
-            let input = Input(&v);
+            row.clear();
+
+            for col in values {
+                row.push(DfScalarValue::try_from_array(col, index)?);
+            }
+            let input = Input(&row);
 
             self.accumulator.update(input).map_err(|e| {
                 DataFusionError::Execution(format!("Accumulator failed to update, err:{e}"))

--- a/df_operator/src/aggregate.rs
+++ b/df_operator/src/aggregate.rs
@@ -48,10 +48,6 @@ impl From<ScalarValue> for State {
 pub struct Input<'a>(&'a [ColumnBlock]);
 
 impl<'a> Input<'a> {
-    // pub fn column_iter(&self) -> impl Iterator<Item = &ColumnBlock> {
-    //     self.0.iter()
-    // }
-
     pub fn num_columns(&self) -> usize {
         self.0.len()
     }
@@ -80,7 +76,7 @@ impl<'a> Deref for StateRef<'a> {
 ///
 /// An accumulator knows how to:
 /// * update its state from inputs via `update`
-/// * convert its internal state to a vector of scalar values
+/// * convert its internal state to column blocks
 /// * update its state from multiple accumulators' states via `merge`
 /// * compute the final value from its internal state via `evaluate`
 pub trait Accumulator: Send + Sync + fmt::Debug {
@@ -90,10 +86,10 @@ pub trait Accumulator: Send + Sync + fmt::Debug {
     // TODO: Use `Datum` rather than `ScalarValue`.
     fn state(&self) -> Result<State>;
 
-    /// updates the accumulator's state from a vector of scalars.
+    /// updates the accumulator's state from column blocks.
     fn update(&mut self, values: Input) -> Result<()>;
 
-    /// updates the accumulator's state from a vector of scalars.
+    /// updates the accumulator's state from column blocks.
     fn merge(&mut self, states: StateRef) -> Result<()>;
 
     /// returns its value based on its current state.

--- a/df_operator/src/aggregate.rs
+++ b/df_operator/src/aggregate.rs
@@ -29,6 +29,7 @@ pub enum Error {
 
 define_result!(Error);
 
+// TODO: Use `Datum` rather than `ScalarValue`.
 pub struct State(Vec<DfScalarValue>);
 
 impl State {
@@ -86,6 +87,7 @@ pub trait Accumulator: Send + Sync + fmt::Debug {
     /// Returns the state of the accumulator at the end of the accumulation.
     // in the case of an average on which we track `sum` and `n`, this function
     // should return a vector of two values, sum and n.
+    // TODO: Use `Datum` rather than `ScalarValue`.
     fn state(&self) -> Result<State>;
 
     /// updates the accumulator's state from a vector of scalars.
@@ -95,6 +97,7 @@ pub trait Accumulator: Send + Sync + fmt::Debug {
     fn merge(&mut self, states: StateRef) -> Result<()>;
 
     /// returns its value based on its current state.
+    // TODO: Use `Datum` rather than `ScalarValue`.
     fn evaluate(&self) -> Result<ScalarValue>;
 }
 

--- a/df_operator/src/udfs/thetasketch_distinct.rs
+++ b/df_operator/src/udfs/thetasketch_distinct.rs
@@ -104,7 +104,7 @@ struct HllDistinct {
 }
 
 // binary datatype to scalarvalue.
-// TODO: Can we avoid clone?
+// TODO: maybe we can remove base64 encoding?
 impl HllDistinct {
     fn merge_impl(&mut self, states: StateRef) -> Result<()> {
         // The states are serialize from hll.
@@ -133,6 +133,7 @@ impl fmt::Debug for HllDistinct {
 }
 
 impl Accumulator for HllDistinct {
+    // TODO: maybe we can remove base64 encoding?
     fn state(&self) -> aggregate::Result<State> {
         // Serialize `self.hll` to bytes.
         let buf = bincode::serialize(&self.hll).box_err().context(GetState)?;

--- a/df_operator/src/udfs/thetasketch_distinct.rs
+++ b/df_operator/src/udfs/thetasketch_distinct.rs
@@ -103,13 +103,14 @@ struct HllDistinct {
     hll: HyperLogLog,
 }
 
-// TODO(yingwen): Avoid base64 encode/decode if datafusion supports converting
 // binary datatype to scalarvalue.
+// TODO: Can we avoid clone?
 impl HllDistinct {
     fn merge_impl(&mut self, states: StateRef) -> Result<()> {
         // The states are serialize from hll.
         ensure!(states.len() == 1, InvalidStateLen);
         let value_ref = states.value(0);
+        // Try to deserialize the hll.
         let hll_string = value_ref.as_str().context(StateNotString)?;
         let hll_bytes = base64::decode(hll_string).context(DecodeBase64)?;
         // Try to deserialize the hll.
@@ -145,7 +146,7 @@ impl Accumulator for HllDistinct {
     fn update(&mut self, values: Input) -> aggregate::Result<()> {
         for value_ref in values.iter() {
             // Insert value into hll.
-            self.hll.insert(&value_ref);
+            self.hll.insert(value_ref);
         }
 
         Ok(())

--- a/integration_tests/cases/common/function/thetasketch_distinct.result
+++ b/integration_tests/cases/common/function/thetasketch_distinct.result
@@ -423,7 +423,7 @@ affected_rows: 400
 SELECT thetasketch_distinct(`value`) FROM `02_function_thetasketch_distinct_table`;
 
 thetasketch_distinct(02_function_thetasketch_distinct_table.value),
-UInt64(147),
+UInt64(148),
 
 
 SELECT
@@ -439,7 +439,7 @@ ORDER BY
     `arch` DESC;
 
 arch,thetasketch_distinct(02_function_thetasketch_distinct_table.value),
-String("x86"),UInt64(115),
+String("x86"),UInt64(113),
 String("arm"),UInt64(117),
 
 


### PR DESCRIPTION
## Rationale
Our impl for `thetasketch_dinstinct` udf is so rough, that leading to the bad performance.
The aggregate stage cost `17s` in our production...

In this pr, I refactor the impl `thetasketch_dinstinct` for the better performance, now the aggregate stage will just cost `6s` for the same sample sql.

## Detailed Changes
+ Update `hyperloglog` crate for better performance.
+ Use `DatumView` instead of `DfScalarValue` in `HllDistinct` to eliminate the unnecessary clone.
+ Fix related test.

## Test Plan
Test by new ut and integration.