### PR TITLE
fix: wrong encoding when write schema is different

### DIFF
--- a/common_types/src/row/contiguous.rs
+++ b/common_types/src/row/contiguous.rs
@@ -516,6 +516,8 @@ impl<'a, T: RowBuffer + 'a> ContiguousRowWriter<'a, T> {
                     let len = datum.size();
                     encoded_len += encoded_len_varint(len as u64) + len;
                 }
+            } else {
+                unreachable!("The column is ensured to be non-null");
             }
         }
 
@@ -537,8 +539,7 @@ impl<'a, T: RowBuffer + 'a> ContiguousRowWriter<'a, T> {
                     &mut next_string_offset,
                 )?;
             } else {
-                datum_offset +=
-                    byte_size_of_datum(&self.table_schema.column(index_in_table).data_type);
+                unreachable!("The column is ensured to be non-null");
             }
         }
 
@@ -747,7 +748,7 @@ mod tests {
             index_schema.reserve_columns(schema.num_columns());
             // Make the final column is None.
             for i in 0..schema.num_columns() {
-                let col_idx = (i != schema.num_columns() - 1).then(|| i);
+                let col_idx = (i != schema.num_columns() - 1).then_some(i);
                 index_schema.push_column(col_idx);
             }
             index_schema

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -340,8 +340,21 @@ impl IndexInWriterSchema {
     /// this column should be filled by null.
     ///
     /// Panic if the index_in_table is out of bound
+    #[inline]
     pub fn column_index_in_writer(&self, index_in_table: usize) -> Option<usize> {
         self.0[index_in_table]
+    }
+
+    /// Reserve the capacity for the additional columns.
+    #[inline]
+    pub fn reserve_columns(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Push a new column index.
+    #[inline]
+    pub fn push_column(&mut self, column_index: Option<usize>) {
+        self.0.push(column_index)
     }
 }
 
@@ -791,7 +804,7 @@ impl Schema {
         writer_schema: &Schema,
         index_in_writer: &mut IndexInWriterSchema,
     ) -> std::result::Result<(), CompatError> {
-        index_in_writer.0.reserve(self.num_columns());
+        index_in_writer.reserve_columns(self.num_columns());
 
         let mut num_col_in_writer = 0;
         for column in self.columns() {
@@ -809,7 +822,7 @@ impl Schema {
                         .context(IncompatWriteColumn)?;
 
                     // Column is compatible, push index mapping
-                    index_in_writer.0.push(Some(writer_index));
+                    index_in_writer.push_column(Some(writer_index));
                 }
                 None => {
                     // Column is not found in writer, then the column should be nullable.
@@ -819,7 +832,7 @@ impl Schema {
                     );
 
                     // Column is nullable, push index mapping
-                    index_in_writer.0.push(None);
+                    index_in_writer.push_column(None);
                 }
             }
         }


### PR DESCRIPTION
## Rationale
Close #1097 

The row encoding will be wrong when processing null columns which is caused by a different write schema from the logical table schema.

## Detailed Changes
- Set the correct column index for the null bit sets in the row's encoding

## Test Plan
Add a new designed test for different write schema.