### PR TITLE
chore: remove unused codes about the page index

### DIFF
--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -363,19 +363,7 @@ impl<'a> Reader<'a> {
                     file_path: self.path.to_string(),
                 })?;
 
-        // TODO: reopen following code until https://github.com/CeresDB/ceresdb/issues/1040 is fixed
-        // let object_store_reader = parquet_ext::reader::ObjectStoreReader::new(
-        //     self.store.clone(),
-        //     self.path.clone(),
-        //     Arc::new(parquet_meta_data),
-        // );
-
-        // let parquet_meta_data =
-        // parquet_ext::meta_data::meta_with_page_indexes(object_store_reader)
-        //     .await
-        //     .with_context(|| DecodePageIndexes {
-        //         file_path: self.path.to_string(),
-        //     })?;
+        // TODO: Support page index until https://github.com/CeresDB/ceresdb/issues/1040 is fixed.
 
         MetaData::try_new(&parquet_meta_data, ignore_sst_filter)
             .box_err()


### PR DESCRIPTION
## Rationale
The code about the page index is not used for now and remove it.

## Detailed Changes
Remove the unused codes about the page index.

## Test Plan
No need.