### PR TITLE
fix: obkv wal open

### DIFF
--- a/wal/src/kv_encoder.rs
+++ b/wal/src/kv_encoder.rs
@@ -326,7 +326,7 @@ impl Decoder<MetaKey> for MetaKeyEncoder {
             }
         );
 
-        let region_id = buf.try_get_u64().context(DecodeMetaKey)?;
+        let table_id = buf.try_get_u64().context(DecodeMetaKey)?;
 
         // check version
         let version = buf.try_get_u8().context(DecodeMetaKey)?;
@@ -338,9 +338,7 @@ impl Decoder<MetaKey> for MetaKeyEncoder {
             }
         );
 
-        Ok(MetaKey {
-            table_id: region_id,
-        })
+        Ok(MetaKey { table_id })
     }
 }
 

--- a/wal/src/kv_encoder.rs
+++ b/wal/src/kv_encoder.rs
@@ -263,7 +263,7 @@ pub struct MetaKeyEncoder {
 
 #[derive(Clone, Debug)]
 pub struct MetaKey {
-    pub region_id: u64,
+    pub table_id: u64,
 }
 
 impl MetaKeyEncoder {
@@ -291,7 +291,7 @@ impl Encoder<MetaKey> for MetaKeyEncoder {
         buf.try_put_u8(self.namespace as u8)
             .context(EncodeMetaKey)?;
         buf.try_put_u8(self.key_type as u8).context(EncodeMetaKey)?;
-        buf.try_put_u64(meta_key.region_id).context(EncodeMetaKey)?;
+        buf.try_put_u64(meta_key.table_id).context(EncodeMetaKey)?;
         buf.try_put_u8(self.version).context(EncodeMetaKey)?;
 
         Ok(())
@@ -338,7 +338,9 @@ impl Decoder<MetaKey> for MetaKeyEncoder {
             }
         );
 
-        Ok(MetaKey { region_id })
+        Ok(MetaKey {
+            table_id: region_id,
+        })
     }
 }
 

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -134,7 +134,7 @@ impl TableUnit {
                 .context(Delete)?;
 
             // Update the max sequence number.
-            let meta_key = MetaKey { region_id: self.id };
+            let meta_key = MetaKey { table_id: self.id };
             let meta_value = MaxSeqMetaValue { max_seq };
             let (mut meta_key_buf, mut meta_value_buf) = (BytesMut::new(), BytesMut::new());
             self.max_seq_meta_encoding
@@ -440,7 +440,7 @@ impl RocksImpl {
         &self,
         table_max_seqs: &mut HashMap<TableId, SequenceNumber>,
     ) -> Result<()> {
-        let meta_key = MetaKey { region_id: 0 };
+        let meta_key = MetaKey { table_id: 0 };
         let mut start_boundary_key_buf = BytesMut::new();
         self.max_seq_meta_encoding
             .encode_key(&mut start_boundary_key_buf, &meta_key)?;
@@ -463,8 +463,15 @@ impl RocksImpl {
             let meta_key = self.max_seq_meta_encoding.decode_key(iter.key())?;
             let meta_value = self.max_seq_meta_encoding.decode_value(iter.value())?;
             table_max_seqs
-                .entry(meta_key.region_id)
+                .entry(meta_key.table_id)
                 .and_modify(|v| {
+                    if meta_value.max_seq > *v {
+                        warn!(
+                            "RocksDB WAL found flushed_seq greater than actual_last_sequence, 
+                        flushed_seq:{}, actual_last_sequence:{}, table_id:{}",
+                            meta_value.max_seq, *v, meta_key.table_id
+                        );
+                    }
                     *v = meta_value.max_seq.max(*v);
                 })
                 .or_insert(meta_value.max_seq);

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -465,6 +465,8 @@ impl RocksImpl {
             table_max_seqs
                 .entry(meta_key.table_id)
                 .and_modify(|v| {
+                    // FIXME: In some cases(such as `Manifest::do_snapshot`), `actual_last_sequence`
+                    // maybe less than `meta_value.max_seq`.
                     if meta_value.max_seq > *v {
                         warn!(
                             "RocksDB WAL found flushed_seq greater than actual_last_sequence, 

--- a/wal/src/rocks_impl/manager.rs
+++ b/wal/src/rocks_impl/manager.rs
@@ -468,7 +468,7 @@ impl RocksImpl {
                     if meta_value.max_seq > *v {
                         warn!(
                             "RocksDB WAL found flushed_seq greater than actual_last_sequence, 
-                        flushed_seq:{}, actual_last_sequence:{}, table_id:{}",
+                        flushed_sequence:{}, actual_last_sequence:{}, table_id:{}",
                             meta_value.max_seq, *v, meta_key.table_id
                         );
                     }

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -466,8 +466,8 @@ impl TableUnit {
                 // maybe less than `start_sequence`.
                 let actual_next_sequence = sequence + 1;
                 if actual_next_sequence < start_sequence {
-                    warn!("TableKv WAL found flushed_seq greater than actual_next_sequence, 
-                    flushed_seq:{start_sequence}, actual_next_sequence:{actual_next_sequence}, table_id:{table_id}, region_id:{region_id}");
+                    warn!("TableKv WAL found start_sequence greater than actual_next_sequence, 
+                    start_sequence:{start_sequence}, actual_next_sequence:{actual_next_sequence}, table_id:{table_id}, region_id:{region_id}");
 
                     break;
                 }

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -462,8 +462,14 @@ impl TableUnit {
                 region_id,
                 table_id,
             )? {
-                // FIXME: In some cases(such as `Manifest::do_snapshot`), `actual_next_sequence`
-                // maybe less than `start_sequence`.
+                #[rustfmt::skip]
+                // FIXME: In some cases, the `flushed sequence`
+                // may be greater than the `actual last sequence of written logs`.
+                //
+                // Such as following case:
+                //  + Write wal logs failed(last sequence stored in memory will increase when write failed). 
+                //  + Get last sequence from memory(greater then actual last sequence now). 
+                //  + Mark the got last sequence as flushed sequence.
                 let actual_next_sequence = sequence + 1;
                 if actual_next_sequence < start_sequence {
                     warn!("TableKv WAL found start_sequence greater than actual_next_sequence, 


### PR DESCRIPTION
## Rationale
In some cases(such as `Manifest::do_snapshot`), `actual_next_sequence` maybe less than `start_sequence`, and it will check this then return error in OBKV WAl.

In this pr, I refactor this open logic.

## Detailed Changes
Refactor wal open logic to allow `actual_next_sequence` less than `start_sequence`.

## Test Plan
Test by exist tests.
