### PR TITLE
fix: meta service change to meta_runtime

### DIFF
--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -272,7 +272,7 @@ impl<Q: QueryExecutor + 'static> Builder<Q> {
             let builder = meta_event_service::Builder {
                 cluster: v,
                 instance: instance.clone(),
-                runtime: runtimes.default_runtime.clone(),
+                runtime: runtimes.meta_runtime.clone(),
                 opened_wals,
             };
             MetaEventServiceServer::new(builder.build())


### PR DESCRIPTION
## Rationale
Currently meta service is running inside default runtime, which may cause some operation of meta service take very long time.


## Detailed Changes


## Test Plan
No need.