### PR TITLE
refactor: use `BinaryExpr` to present regex filter

### DIFF
--- a/query_frontend/src/promql/remote.rs
+++ b/query_frontend/src/promql/remote.rs
@@ -8,7 +8,7 @@ use common_types::{schema::Schema, time::TimeRange};
 use datafusion::{
     logical_expr::{LogicalPlanBuilder, Operator},
     optimizer::utils::conjunction,
-    prelude::{ident, lit, regexp_match, Expr},
+    prelude::{ident, lit, Expr},
     sql::{planner::ContextProvider, TableReference},
 };
 use prom_remote_api::types::{label_matcher, LabelMatcher, Query};
@@ -17,7 +17,7 @@ use snafu::{OptionExt, ResultExt};
 use crate::{
     plan::{Plan, QueryPlan},
     promql::{
-        convert::{Selector},
+        convert::Selector,
         datafusion_util::{default_sort_exprs, timerange_to_expr},
         error::*,
     },
@@ -101,17 +101,18 @@ fn normalize_matchers(matchers: Vec<LabelMatcher>) -> Result<(String, String, Ve
                     label_matcher::Type::Neq => col_name.not_eq(lit(m.value)),
                     // https://github.com/prometheus/prometheus/blob/2ce94ac19673a3f7faf164e9e078a79d4d52b767/model/labels/regexp.go#L29
                     label_matcher::Type::Re => {
-                        let tmp = datafusion::logical_expr::BinaryExpr::new(
+                        Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
                             Box::new(col_name),
                             Operator::RegexMatch,
                             Box::new(lit(format!("^(?:{})$", m.value))),
-                        );
-                        Expr::BinaryExpr(tmp)
-                        // regexp_match(vec![col_name, lit(format!("^(?:{})$",
-                        // m.value))]) .is_not_null()
+                        ))
                     }
                     label_matcher::Type::Nre => {
-                        regexp_match(vec![col_name, lit(format!("^(?:{})$", m.value))]).is_null()
+                        Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
+                            Box::new(col_name),
+                            Operator::RegexNotMatch,
+                            Box::new(lit(format!("^(?:{})$", m.value))),
+                        ))
                     }
                 };
                 filters.push(expr);
@@ -232,7 +233,7 @@ Query(QueryPlan { df_plan: Sort: cpu.tsid ASC NULLS FIRST, cpu.time ASC NULLS FI
                 r#"a = Utf8("1")
 b != Utf8("2")
 c ~ Utf8("^(?:3)$")
-regexp_match(D, Utf8("^(?:4)$")) IS NULL"#,
+D !~ Utf8("^(?:4)$")"#,
                 filters
                     .iter()
                     .map(|f| f.to_string())

--- a/query_frontend/src/promql/remote.rs
+++ b/query_frontend/src/promql/remote.rs
@@ -219,10 +219,10 @@ Query(QueryPlan { df_plan: Sort: cpu.tsid ASC NULLS FIRST, cpu.time ASC NULLS FI
 
         {
             let matchers = make_matchers(vec![
-                ("a", "1", Type::Eq),
-                ("b", "2", Type::Neq),
-                ("c", "3", Type::Re),
-                ("D", "4", Type::Nre),
+                ("a", "a", Type::Eq),
+                ("b", "b", Type::Neq),
+                ("c", "C", Type::Re),
+                ("D", "D", Type::Nre),
                 (NAME_LABEL, "cpu", Type::Eq),
             ]);
 
@@ -230,10 +230,10 @@ Query(QueryPlan { df_plan: Sort: cpu.tsid ASC NULLS FIRST, cpu.time ASC NULLS FI
             assert_eq!("cpu", metric);
             assert_eq!("value", field);
             assert_eq!(
-                r#"a = Utf8("1")
-b != Utf8("2")
-c ~ Utf8("^(?:3)$")
-D !~ Utf8("^(?:4)$")"#,
+                r#"a = Utf8("a")
+b != Utf8("b")
+c ~ Utf8("^(?:C)$")
+D !~ Utf8("^(?:D)$")"#,
                 filters
                     .iter()
                     .map(|f| f.to_string())

--- a/query_frontend/src/promql/remote.rs
+++ b/query_frontend/src/promql/remote.rs
@@ -221,7 +221,9 @@ Query(QueryPlan { df_plan: Sort: cpu.tsid ASC NULLS FIRST, cpu.time ASC NULLS FI
             let matchers = make_matchers(vec![
                 ("a", "a", Type::Eq),
                 ("b", "b", Type::Neq),
+                ("c", "c", Type::Re),
                 ("c", "C", Type::Re),
+                ("D", "d", Type::Nre),
                 ("D", "D", Type::Nre),
                 (NAME_LABEL, "cpu", Type::Eq),
             ]);
@@ -232,7 +234,9 @@ Query(QueryPlan { df_plan: Sort: cpu.tsid ASC NULLS FIRST, cpu.time ASC NULLS FI
             assert_eq!(
                 r#"a = Utf8("a")
 b != Utf8("b")
+c ~ Utf8("^(?:c)$")
 c ~ Utf8("^(?:C)$")
+D !~ Utf8("^(?:d)$")
 D !~ Utf8("^(?:D)$")"#,
                 filters
                     .iter()


### PR DESCRIPTION
## Rationale
Now `promql` uses `regexp_match` macro to present the regex expr, which is not friendly for optimizing.
## Detailed Changes


## Test Plan
ut
