### PR TITLE
feat: make obkv wal opening more parallelly

### DIFF
--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -179,6 +179,7 @@ pub struct ManifestNamespaceConfig {
     pub init_scan_batch_size: i32,
     pub clean_scan_timeout: ReadableDuration,
     pub clean_scan_batch_size: usize,
+    pub bucket_create_parallelism: usize,
 }
 
 impl Default for ManifestNamespaceConfig {
@@ -192,6 +193,7 @@ impl Default for ManifestNamespaceConfig {
             init_scan_batch_size: namespace_config.init_scan_batch_size,
             clean_scan_timeout: namespace_config.clean_scan_timeout,
             clean_scan_batch_size: namespace_config.clean_scan_batch_size,
+            bucket_create_parallelism: namespace_config.bucket_create_parallelism,
         }
     }
 }
@@ -206,6 +208,7 @@ impl From<ManifestNamespaceConfig> for NamespaceConfig {
             init_scan_batch_size: manifest_config.init_scan_batch_size,
             clean_scan_timeout: manifest_config.clean_scan_timeout,
             clean_scan_batch_size: manifest_config.clean_scan_batch_size,
+            bucket_create_parallelism: manifest_config.bucket_create_parallelism,
         }
     }
 }
@@ -227,6 +230,7 @@ pub struct WalNamespaceConfig {
     pub ttl: ReadableDuration,
     pub init_scan_timeout: ReadableDuration,
     pub init_scan_batch_size: i32,
+    pub bucket_create_parallelism: usize,
 }
 
 impl Default for WalNamespaceConfig {
@@ -239,6 +243,7 @@ impl Default for WalNamespaceConfig {
             ttl: namespace_config.ttl.unwrap(),
             init_scan_timeout: namespace_config.init_scan_timeout,
             init_scan_batch_size: namespace_config.init_scan_batch_size,
+            bucket_create_parallelism: namespace_config.bucket_create_parallelism,
         }
     }
 }
@@ -251,6 +256,7 @@ impl From<WalNamespaceConfig> for NamespaceConfig {
             ttl: Some(wal_config.ttl),
             init_scan_timeout: wal_config.init_scan_timeout,
             init_scan_batch_size: wal_config.init_scan_batch_size,
+            bucket_create_parallelism: wal_config.bucket_create_parallelism,
             ..Default::default()
         }
     }

--- a/wal/src/table_kv_impl/model.rs
+++ b/wal/src/table_kv_impl/model.rs
@@ -265,6 +265,7 @@ pub struct NamespaceConfig {
     pub init_scan_batch_size: i32,
     pub clean_scan_timeout: ReadableDuration,
     pub clean_scan_batch_size: usize,
+    pub bucket_create_parallelism: usize,
 }
 
 impl NamespaceConfig {
@@ -325,6 +326,7 @@ impl Default for NamespaceConfig {
             init_scan_batch_size: 100,
             clean_scan_timeout: default_clean_ctx.scan_timeout.into(),
             clean_scan_batch_size: default_clean_ctx.batch_size,
+            bucket_create_parallelism: 32,
         }
     }
 }

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -1237,7 +1237,7 @@ impl TableOperator {
         let wal_shard_num_per_group = wal_shard_num / wal_shard_group_num;
         let wal_shard_groups = wal_shards
             .chunks(wal_shard_num_per_group)
-            .map(|a| a.to_owned())
+            .map(|group| group.to_owned())
             .collect::<Vec<_>>();
         let (tx, rx) = std::sync::mpsc::channel();
         let stop = Arc::new(AtomicBool::new(false));

--- a/wal/src/table_kv_impl/namespace.rs
+++ b/wal/src/table_kv_impl/namespace.rs
@@ -392,9 +392,10 @@ impl<T: TableKv> NamespaceInner<T> {
     /// Open bucket, ensure all tables are created, and insert the bucket into
     /// the bucket set in memory.
     fn open_bucket(&self, bucket: Bucket) -> Result<BucketRef> {
+        let bucket_info = bucket.entry;
         info!(
-            "TableKvWal begin to open bucket, bucket:{:?}, namespace:{}",
-            bucket.entry,
+            "TableKvWal begin to open bucket, bucket_info:{:?}, namespace:{}",
+            bucket_info,
             self.name()
         );
 
@@ -414,9 +415,9 @@ impl<T: TableKv> NamespaceInner<T> {
         bucket_set.insert_bucket(bucket.clone());
 
         info!(
-            "TableKvWal success to open bucket, cost:{:?}, bucket:{:?}, namespace:{}",
-            timer.elapsed()
-            bucket.entry,
+            "TableKvWal success to open bucket, cost:{:?}, bucket_info:{:?}, namespace:{}",
+            timer.elapsed(),
+            bucket_info,
             self.name(),
         );
 
@@ -1286,7 +1287,6 @@ impl TableOperator {
                     info!(
                         "TableOperator monitor tables creating periodically, namespace:{namespace}"
                     );
-                    continue;
                 }
             };
         }


### PR DESCRIPTION
## Rationale
When initing obkv wal, we need to check and create bucket table one by one...
However this process can be runned in parallel.

## Detailed Changes
Check and create tables in parallel when opening obkv wal.

## Test Plan
Test manually.
