### PR TITLE
fix: avoid panic when the file is corrupted in disk cache

### DIFF
--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -154,29 +154,15 @@ impl PageFileEncoder {
     where
         W: AsyncWrite + std::marker::Unpin,
     {
-        let n = writer
-            .write(&self.payload[..])
+        writer
+            .write_all(&self.payload[..])
             .await
             .context(Io { file: name })?;
-        ensure!(
-            self.payload.len() == n,
-            PartialWrite {
-                expect: self.payload.len(),
-                written: n,
-            }
-        );
 
-        let n = writer
-            .write(&Self::MAGIC_FOOTER)
+        writer
+            .write_all(&Self::MAGIC_FOOTER)
             .await
             .context(Io { file: name })?;
-        ensure!(
-            Self::MAGIC_FOOTER.len() == n,
-            PartialWrite {
-                expect: Self::MAGIC_FOOTER.len(),
-                written: n,
-            }
-        );
 
         writer.flush().await.context(Io { file: name })?;
 

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -45,7 +45,7 @@ use upstream::{
 const MANIFEST_FILE: &str = "manifest.json";
 const CURRENT_VERSION: usize = 2;
 const FILE_SIZE_CACHE_CAP: usize = 1 << 18;
-const FILE_SIZE_CACHE_PARTITION_BITS: usize = 1 << 8;
+const FILE_SIZE_CACHE_PARTITION_BITS: usize = 8;
 pub const CASTAGNOLI: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
 
 #[derive(Debug, Snafu)]


### PR DESCRIPTION
## Rationale
- The corrupted file in the disk cache will lead to the panic of the server
- The whole cache page file is fetched when only a range of the file is accessed, leading to high memory consumption

## Detailed Changes
- Store the file size in the memory for file integrity check
- Omit the corrupted file in the disk cache rather than panic
- Do IO operation outside the meta data cache lock
- Read only the involved range of a cached paged file instead of the whole file

## Test Plan
Existing tests and a newly designed test.