### PR TITLE
chore: update datafusion's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ dependencies = [
  "ceresdbproto",
  "codec",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "env_logger",
  "future_ext",
  "futures 0.3.28",
@@ -1625,7 +1625,7 @@ dependencies = [
  "bytes_ext",
  "ceresdbproto",
  "chrono",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "hash_ext",
  "macros",
  "paste 1.0.12",
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "27.0.0"
-source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
 dependencies = [
  "ahash 0.8.3",
  "arrow 43.0.0",
@@ -2061,13 +2061,13 @@ dependencies = [
  "bzip2",
  "chrono",
  "dashmap 5.4.0",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-optimizer",
- "datafusion-physical-expr",
- "datafusion-row",
- "datafusion-sql",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-execution 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-optimizer 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-physical-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-row 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-sql 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "flate2",
  "futures 0.3.28",
  "glob",
@@ -2095,6 +2095,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion"
+version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow 43.0.0",
+ "arrow-array 43.0.0",
+ "arrow-schema 43.0.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "dashmap 5.4.0",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-execution 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-optimizer 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-physical-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-row 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-sql 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "futures 0.3.28",
+ "glob",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "object_store 0.6.1",
+ "parking_lot 0.12.1",
+ "parquet",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "smallvec",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid 1.3.3",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
+dependencies = [
+ "arrow 43.0.0",
+ "arrow-array 43.0.0",
+ "chrono",
+ "num_cpus",
+ "object_store 0.6.1",
+ "parquet",
+ "sqlparser",
+]
+
+[[package]]
 name = "datafusion-common"
 version = "27.0.0"
 source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
@@ -2111,11 +2168,28 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
+dependencies = [
+ "dashmap 5.4.0",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "hashbrown 0.14.0",
+ "log",
+ "object_store 0.6.1",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-execution"
+version = "27.0.0"
 source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
 dependencies = [
  "dashmap 5.4.0",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "hashbrown 0.14.0",
  "log",
  "object_store 0.6.1",
@@ -2128,15 +2202,46 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "27.0.0"
-source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
 dependencies = [
  "ahash 0.8.3",
  "arrow 43.0.0",
- "datafusion-common",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "lazy_static",
  "sqlparser",
  "strum 0.25.0",
  "strum_macros 0.25.1",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
+dependencies = [
+ "ahash 0.8.3",
+ "arrow 43.0.0",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "lazy_static",
+ "sqlparser",
+ "strum 0.25.0",
+ "strum_macros 0.25.1",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
+dependencies = [
+ "arrow 43.0.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-physical-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "hashbrown 0.14.0",
+ "itertools 0.11.0",
+ "log",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -2147,9 +2252,9 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-physical-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "hashbrown 0.14.0",
  "itertools 0.11.0",
  "log",
@@ -2159,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "27.0.0"
-source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
 dependencies = [
  "ahash 0.8.3",
  "arrow 43.0.0",
@@ -2170,9 +2275,9 @@ dependencies = [
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-row",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-row 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "half 2.2.1",
  "hashbrown 0.14.0",
  "hex",
@@ -2192,17 +2297,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-proto"
+name = "datafusion-physical-expr"
 version = "27.0.0"
 source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
 dependencies = [
+ "ahash 0.8.3",
+ "arrow 43.0.0",
+ "arrow-array 43.0.0",
+ "arrow-buffer 43.0.0",
+ "arrow-schema 43.0.0",
+ "chrono",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-row 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "half 2.2.1",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
+ "itertools 0.11.0",
+ "lazy_static",
+ "libc",
+ "log",
+ "paste 1.0.12",
+ "petgraph",
+ "rand 0.8.5",
+ "uuid 1.3.3",
+]
+
+[[package]]
+name = "datafusion-proto"
+version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
+dependencies = [
  "arrow 43.0.0",
  "chrono",
- "datafusion",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "object_store 0.6.1",
  "prost",
+]
+
+[[package]]
+name = "datafusion-row"
+version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
+dependencies = [
+ "arrow 43.0.0",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "paste 1.0.12",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2211,9 +2354,22 @@ version = "27.0.0"
 source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0#a6dcd943051a083693c352c6b4279156548490a0"
 dependencies = [
  "arrow 43.0.0",
- "datafusion-common",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "paste 1.0.12",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "27.0.0"
+source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d#9c3a537e25e5ab3299922864034f67fb2f79805d"
+dependencies = [
+ "arrow 43.0.0",
+ "arrow-schema 43.0.0",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
+ "log",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2223,8 +2379,8 @@ source = "git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a08
 dependencies = [
  "arrow 43.0.0",
  "arrow-schema 43.0.0",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
+ "datafusion-expr 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "log",
  "sqlparser",
 ]
@@ -2235,7 +2391,7 @@ version = "0.1.0"
 source = "git+https://github.com/CeresDB/influxql.git?rev=b4520c6d5dfb6d68e4c7671555050391292dbffe#b4520c6d5dfb6d68e4c7671555050391292dbffe"
 dependencies = [
  "async-trait",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "futures 0.3.28",
  "observability_deps",
  "pin-project",
@@ -2292,7 +2448,7 @@ dependencies = [
  "bincode",
  "chrono",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "generic_error",
  "hyperloglog",
  "macros",
@@ -3242,7 +3398,7 @@ dependencies = [
  "catalog_impls",
  "codec",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "datafusion-proto",
  "df_operator",
  "generic_error",
@@ -3279,7 +3435,7 @@ dependencies = [
  "arrow_util",
  "async-trait",
  "chrono",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "datafusion_util",
  "futures 0.3.28",
  "hashbrown 0.13.2",
@@ -3302,7 +3458,7 @@ dependencies = [
  "arrow 43.0.0",
  "chrono",
  "chrono-tz",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "datafusion_util",
  "generated_types",
  "influxdb_influxql_parser",
@@ -4561,7 +4717,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "futures 0.3.28",
  "generic_error",
  "log",
@@ -5130,7 +5286,7 @@ dependencies = [
  "clru",
  "cluster",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "df_operator",
  "futures 0.3.28",
  "generic_error",
@@ -5224,7 +5380,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "df_operator",
  "futures 0.3.28",
  "generic_error",
@@ -5250,7 +5406,7 @@ dependencies = [
  "cluster",
  "codec",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "datafusion-proto",
  "df_operator",
  "generic_error",
@@ -5279,7 +5435,7 @@ source = "git+https://github.com/CeresDB/influxql.git?rev=b4520c6d5dfb6d68e4c767
 dependencies = [
  "arrow 43.0.0",
  "chrono",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=a6dcd943051a083693c352c6b4279156548490a0)",
  "itertools 0.10.5",
  "observability_deps",
  "once_cell",
@@ -6049,7 +6205,7 @@ dependencies = [
  "clru",
  "cluster",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "df_operator",
  "future_ext",
  "futures 0.3.28",
@@ -6621,7 +6777,7 @@ dependencies = [
  "bytes_ext",
  "ceresdbproto",
  "common_types",
- "datafusion",
+ "datafusion 27.0.0 (git+https://github.com/CeresDB/arrow-datafusion.git?rev=9c3a537e25e5ab3299922864034f67fb2f79805d)",
  "datafusion-proto",
  "df_operator",
  "futures 0.3.28",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,8 +91,8 @@ clru = "0.6.1"
 cluster = { path = "cluster" }
 criterion = "0.5"
 common_types = { path = "common_types" }
-datafusion = { git = "https://github.com/CeresDB/arrow-datafusion.git", rev = "a6dcd943051a083693c352c6b4279156548490a0" }
-datafusion-proto = { git = "https://github.com/CeresDB/arrow-datafusion.git", rev = "a6dcd943051a083693c352c6b4279156548490a0" }
+datafusion = { git = "https://github.com/CeresDB/arrow-datafusion.git", rev = "9c3a537e25e5ab3299922864034f67fb2f79805d" }
+datafusion-proto = { git = "https://github.com/CeresDB/arrow-datafusion.git", rev = "9c3a537e25e5ab3299922864034f67fb2f79805d" }
 df_operator = { path = "df_operator" }
 future_ext = { path = "components/future_ext" }
 etcd-client = "0.10.3"


### PR DESCRIPTION
## Rationale
Our datafusion fork repo already cherry-pick datafusion's upstream pr, we need update the datafusion's version.

## Detailed Changes


## Test Plan
