### PR TITLE
fix: record remote engine requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5622,7 +5622,6 @@ dependencies = [
  "generic_error",
  "log",
  "macros",
- "proxy",
  "router",
  "runtime",
  "serde",

--- a/remote_engine_client/Cargo.toml
+++ b/remote_engine_client/Cargo.toml
@@ -33,7 +33,6 @@ futures = { workspace = true }
 generic_error = { workspace = true }
 log = { workspace = true }
 macros = { workspace = true }
-proxy = { workspace = true }
 router = { workspace = true }
 runtime = { workspace = true }
 serde = { workspace = true }

--- a/remote_engine_client/src/lib.rs
+++ b/remote_engine_client/src/lib.rs
@@ -33,17 +33,13 @@ use common_types::{record_batch::RecordBatch, schema::RecordSchema};
 pub use config::Config;
 use futures::{Stream, StreamExt};
 use generic_error::BoxError;
-use proxy::hotspot::{HotspotRecorder, Message};
 use router::RouterRef;
 use runtime::Runtime;
 use snafu::ResultExt;
 use table_engine::{
     remote::{
         self,
-        model::{
-            GetTableInfoRequest, ReadRequest, TableIdentifier, TableInfo, WriteBatchResult,
-            WriteRequest,
-        },
+        model::{GetTableInfoRequest, ReadRequest, TableInfo, WriteBatchResult, WriteRequest},
         RemoteEngine,
     },
     stream::{self, ErrWithSource, RecordBatchStream, SendableRecordBatchStream},
@@ -122,55 +118,19 @@ pub mod error {
 
 pub struct RemoteEngineImpl {
     client: Client,
-    hotspot_recorder: Arc<HotspotRecorder>,
 }
 
 impl RemoteEngineImpl {
-    pub fn new(
-        config: Config,
-        router: RouterRef,
-        worker_runtime: Arc<Runtime>,
-        hotspot_recorder: Arc<HotspotRecorder>,
-    ) -> Self {
+    pub fn new(config: Config, router: RouterRef, worker_runtime: Arc<Runtime>) -> Self {
         let client = Client::new(config, router, worker_runtime);
 
-        Self {
-            client,
-            hotspot_recorder,
-        }
-    }
-
-    fn format_hot_key(table: &TableIdentifier) -> String {
-        format!("{}/{}", table.schema, table.table)
-    }
-
-    async fn record_write(&self, request: &WriteRequest) {
-        let hot_key = Self::format_hot_key(&request.table);
-        let row_count = request.write_request.row_group.num_rows();
-        let field_count = row_count * request.write_request.row_group.schema().num_columns();
-        self.hotspot_recorder
-            .send_msg_or_log(
-                "inc_write_reqs",
-                Message::Write {
-                    key: hot_key,
-                    row_count,
-                    field_count,
-                },
-            )
-            .await;
+        Self { client }
     }
 }
 
 #[async_trait]
 impl RemoteEngine for RemoteEngineImpl {
     async fn read(&self, request: ReadRequest) -> remote::Result<SendableRecordBatchStream> {
-        self.hotspot_recorder
-            .send_msg_or_log(
-                "inc_query_reqs",
-                Message::Query(Self::format_hot_key(&request.table)),
-            )
-            .await;
-
         let client_read_stream = self
             .client
             .read(request)
@@ -181,8 +141,6 @@ impl RemoteEngine for RemoteEngineImpl {
     }
 
     async fn write(&self, request: WriteRequest) -> remote::Result<usize> {
-        self.record_write(&request).await;
-
         self.client
             .write(request)
             .await
@@ -194,10 +152,6 @@ impl RemoteEngine for RemoteEngineImpl {
         &self,
         requests: Vec<WriteRequest>,
     ) -> remote::Result<Vec<WriteBatchResult>> {
-        for req in &requests {
-            self.record_write(req).await;
-        }
-
         self.client
             .write_batch(requests)
             .await

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -435,7 +435,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> RemoteEngineService
             self.hotspot_recorder
                 .send_msg_or_log(
                     "inc_query_reqs",
-                    Message::Query(format!("{}/{}", table.schema, table.table)),
+                    Message::Query(format_hot_key(&table.schema, &table.table)),
                 )
                 .await
         }
@@ -580,15 +580,15 @@ async fn handle_stream_read(
     }
 }
 
-fn format_hot_key(table: &TableIdentifier) -> String {
-    format!("{}/{}", table.schema, table.table)
+fn format_hot_key(schema: &str, table: &str) -> String {
+    format!("{schema}/{table}")
 }
 
 async fn record_write(
     hotspot_recorder: &Arc<HotspotRecorder>,
     request: &table_engine::remote::model::WriteRequest,
 ) {
-    let hot_key = format_hot_key(&request.table);
+    let hot_key = format_hot_key(&request.table.schema, &request.table.table);
     let row_count = request.write_request.row_group.num_rows();
     let field_count = row_count * request.write_request.row_group.schema().num_columns();
     hotspot_recorder

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -351,7 +351,6 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Builder<Q, P> {
             self.remote_engine_client_config.clone(),
             router.clone(),
             engine_runtimes.io_runtime.clone(),
-            hotspot_recorder.clone(),
         ));
 
         let partition_table_engine = Arc::new(PartitionTableEngine::new(remote_engine_ref.clone()));
@@ -396,7 +395,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Builder<Q, P> {
             self.server_config.resp_compress_min_length.as_byte() as usize,
             self.server_config.auto_create_table,
             provider.clone(),
-            hotspot_recorder,
+            hotspot_recorder.clone(),
             engine_runtimes.clone(),
             self.cluster.is_some(),
         ));
@@ -433,6 +432,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Builder<Q, P> {
             .opened_wals(opened_wals)
             .timeout(self.server_config.timeout.map(|v| v.0))
             .proxy(proxy)
+            .hotspot_recorder(hotspot_recorder)
             .request_notifiers(self.server_config.enable_query_dedup)
             .build()
             .context(BuildGrpcService)?;


### PR DESCRIPTION
## Rationale
#1127 add support for remote engine, but in client, it should be for server.

## Detailed Changes
- Remove remote client record, add add for remote server.

## Test Plan
Manually