### PR TITLE
chore: add apache license template

### DIFF
--- a/scripts/license-header.txt
+++ b/scripts/license-header.txt
@@ -1,0 +1,13 @@
+Copyright 2023 The CeresDB Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
## Rationale
The missing license template leads to git pre-commit failure.

## Detailed Changes
Add license template for pre-commit.
