### PR TITLE
refactor: use new protocol for remote engine service write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "codec",
  "common_types",
  "datafusion",
@@ -1276,7 +1276,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ceresdbproto",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1302,21 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25926e49d9d931b3089b26aba55cd5057631db452137f45d0d24f8b5dae8a28c"
-dependencies = [
- "prost",
- "protoc-bin-vendored",
- "tonic 0.8.3",
- "tonic-build",
- "walkdir",
-]
-
-[[package]]
-name = "ceresdbproto"
-version = "1.0.9"
-source = "git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96#c33cc342c64521a25dfd00da8c6ce746f682ab96"
+checksum = "ea8a61d72d30452b689e761344d9502bcc5feb2dbd06f08b507b2e164b549aee"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1523,7 +1511,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1600,7 +1588,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -3849,7 +3837,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4377,7 +4365,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "chrono",
  "clru",
  "crc",
@@ -5254,7 +5242,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -5374,7 +5362,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "cluster",
  "codec",
  "common_types",
@@ -5684,7 +5672,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5813,7 +5801,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "cluster",
  "common_types",
  "generic_error",
@@ -6181,7 +6169,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -6737,7 +6725,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6759,7 +6747,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6967,7 +6955,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "chrono",
  "common_types",
  "macros",
@@ -7623,7 +7611,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
+ "ceresdbproto",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "codec",
  "common_types",
  "datafusion",
@@ -1276,7 +1276,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1305,6 +1305,18 @@ name = "ceresdbproto"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25926e49d9d931b3089b26aba55cd5057631db452137f45d0d24f8b5dae8a28c"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic 0.8.3",
+ "tonic-build",
+ "walkdir",
+]
+
+[[package]]
+name = "ceresdbproto"
+version = "1.0.9"
+source = "git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96#c33cc342c64521a25dfd00da8c6ce746f682ab96"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1511,7 +1523,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1588,7 +1600,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -3837,7 +3849,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4365,7 +4377,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "chrono",
  "clru",
  "crc",
@@ -5242,7 +5254,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "clru",
  "cluster",
  "common_types",
@@ -5362,7 +5374,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "cluster",
  "codec",
  "common_types",
@@ -5672,7 +5684,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5801,7 +5813,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "cluster",
  "common_types",
  "generic_error",
@@ -6169,7 +6181,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "clru",
  "cluster",
  "common_types",
@@ -6725,7 +6737,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6747,7 +6759,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6955,7 +6967,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "chrono",
  "common_types",
  "macros",
@@ -7611,7 +7623,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.9 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=c33cc342c64521a25dfd00da8c6ce746f682ab96)",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ bytes = "1.1.0"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = "1.0"
+ceresdbproto = { git = "https://github.com/ShiKaiWi/ceresdbproto.git", rev = "c33cc342c64521a25dfd00da8c6ce746f682ab96" }
 codec = { path = "components/codec" }
 chrono = "0.4"
 clap = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ bytes = "1.1.0"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = { git = "https://github.com/ShiKaiWi/ceresdbproto.git", rev = "c33cc342c64521a25dfd00da8c6ce746f682ab96" }
+ceresdbproto = "1.0.10"
 codec = { path = "components/codec" }
 chrono = "0.4"
 clap = "3.0"

--- a/common_types/src/column_schema.rs
+++ b/common_types/src/column_schema.rs
@@ -346,7 +346,7 @@ impl TryFrom<&Arc<Field>> for ColumnSchema {
 impl From<&ColumnSchema> for Field {
     fn from(col_schema: &ColumnSchema) -> Self {
         let metadata = encode_arrow_field_meta_data(col_schema);
-        // If the column sholud use dictionary, create correspond dictionary type.
+        // If the column should use dictionary, create correspond dictionary type.
         let mut field = if col_schema.is_dictionary {
             Field::new_dict(
                 &col_schema.name,

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -1177,6 +1177,28 @@ impl<'a> DatumView<'a> {
             _ => None,
         }
     }
+
+    pub fn to_datum(&self) -> Datum {
+        match self {
+            DatumView::Null => Datum::Null,
+            DatumView::Timestamp(v) => Datum::Timestamp(*v),
+            DatumView::Double(v) => Datum::Double(*v),
+            DatumView::Float(v) => Datum::Float(*v),
+            DatumView::Varbinary(v) => Datum::Varbinary(Bytes::from(v.to_vec())),
+            DatumView::String(v) => Datum::String(StringBytes::copy_from_str(v)),
+            DatumView::UInt64(v) => Datum::UInt64(*v),
+            DatumView::UInt32(v) => Datum::UInt32(*v),
+            DatumView::UInt16(v) => Datum::UInt16(*v),
+            DatumView::UInt8(v) => Datum::UInt8(*v),
+            DatumView::Int64(v) => Datum::Int64(*v),
+            DatumView::Int32(v) => Datum::Int32(*v),
+            DatumView::Int16(v) => Datum::Int16(*v),
+            DatumView::Int8(v) => Datum::Int8(*v),
+            DatumView::Boolean(v) => Datum::Boolean(*v),
+            DatumView::Date(v) => Datum::Date(*v),
+            DatumView::Time(v) => Datum::Time(*v),
+        }
+    }
 }
 
 impl<'a> std::hash::Hash for DatumView<'a> {

--- a/server/src/grpc/metrics.rs
+++ b/server/src/grpc/metrics.rs
@@ -16,8 +16,8 @@
 
 use lazy_static::lazy_static;
 use prometheus::{
-    exponential_buckets, register_histogram_vec, register_int_counter_vec, HistogramVec,
-    IntCounterVec,
+    exponential_buckets, register_histogram, register_histogram_vec, register_int_counter_vec,
+    Histogram, HistogramVec, IntCounterVec,
 };
 use prometheus_static_metric::{auto_flush_from, make_auto_flush_static_metric};
 
@@ -102,6 +102,12 @@ lazy_static! {
             &["type"]
         )
         .unwrap();
+    pub static ref REMOTE_ENGINE_WRITE_BATCH_NUM_ROWS_HISTOGRAM: Histogram = register_histogram!(
+        "remote_engine_write_batch_num_rows",
+        "Bucketed histogram of grpc server handler",
+        vec![1.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 2000.0]
+    )
+    .unwrap();
     pub static ref META_EVENT_GRPC_HANDLER_DURATION_HISTOGRAM_VEC_GLOBAL: HistogramVec =
         register_histogram_vec!(
             "meta_event_grpc_handler_duration",

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -220,6 +220,8 @@ impl WriteRequest {
         let max_timestamp = row_group.max_timestamp().as_i64();
 
         let mut encoded_rows = Vec::with_capacity(row_group.num_rows());
+        // TODO: The schema of the written row group may be different from the original
+        // one, so the compatibility for that should be taken consideration.
         let index_in_schema = IndexInWriterSchema::for_same_schema(table_schema.num_columns());
         for row in &row_group {
             let mut buf = ByteVec::new();

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -16,19 +16,19 @@
 
 use std::collections::HashMap;
 
-use arrow_ext::{
-    ipc,
-    ipc::{CompressOptions, CompressionMethod},
-};
+use arrow_ext::{ipc, ipc::CompressionMethod};
+use bytes_ext::ByteVec;
 use ceresdbproto::{
-    remote_engine,
-    remote_engine::row_group::Rows::Arrow,
+    remote_engine::{self, row_group::Rows::Contiguous},
     storage::{arrow_payload, ArrowPayload},
 };
 use common_types::{
-    record_batch::{RecordBatch, RecordBatchWithKeyBuilder},
-    row::{RowGroup, RowGroupBuilder},
-    schema::Schema,
+    record_batch::RecordBatch,
+    row::{
+        contiguous::{ContiguousRow, ContiguousRowReader, ContiguousRowWriter},
+        Row, RowGroup, RowGroupBuilder,
+    },
+    schema::{IndexInWriterSchema, Schema},
 };
 use generic_error::{BoxError, GenericError, GenericResult};
 use macros::define_result;
@@ -47,15 +47,11 @@ pub enum Error {
     ReadRequestToPb { source: crate::table::Error },
 
     #[snafu(display(
-        "Failed to convert write request to pb, table_ident:{:?}, msg:{}.\nBacktrace:\n{}",
-        table_ident,
-        msg,
-        backtrace
+        "Failed to convert write request to pb, table_ident:{table_ident:?}, err:{source}",
     ))]
-    WriteRequestToPbNoCause {
+    WriteRequestToPb {
         table_ident: TableIdentifier,
-        msg: String,
-        backtrace: Backtrace,
+        source: common_types::row::contiguous::Error,
     },
 
     #[snafu(display("Empty table identifier.\nBacktrace:\n{}", backtrace))]
@@ -120,9 +116,7 @@ pub struct ReadRequest {
 impl TryFrom<ceresdbproto::remote_engine::ReadRequest> for ReadRequest {
     type Error = Error;
 
-    fn try_from(
-        pb: ceresdbproto::remote_engine::ReadRequest,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(pb: ceresdbproto::remote_engine::ReadRequest) -> Result<Self> {
         let table_identifier = pb.table.context(EmptyTableIdentifier)?;
         let table_read_request = pb.read_request.context(EmptyTableReadRequest)?;
         Ok(Self {
@@ -138,7 +132,7 @@ impl TryFrom<ceresdbproto::remote_engine::ReadRequest> for ReadRequest {
 impl TryFrom<ReadRequest> for ceresdbproto::remote_engine::ReadRequest {
     type Error = Error;
 
-    fn try_from(request: ReadRequest) -> std::result::Result<Self, Self::Error> {
+    fn try_from(request: ReadRequest) -> Result<Self> {
         let table_pb = request.table.into();
         let request_pb = request.read_request.try_into().context(ReadRequestToPb)?;
 
@@ -154,32 +148,13 @@ pub struct WriteBatchRequest {
     pub batch: Vec<WriteRequest>,
 }
 
-impl TryFrom<ceresdbproto::remote_engine::WriteBatchRequest> for WriteBatchRequest {
-    type Error = Error;
-
-    fn try_from(
-        pb: ceresdbproto::remote_engine::WriteBatchRequest,
-    ) -> std::result::Result<Self, Self::Error> {
-        let batch = pb
-            .batch
-            .into_iter()
-            .map(WriteRequest::try_from)
-            .collect::<std::result::Result<Vec<_>, Self::Error>>()?;
-
-        Ok(WriteBatchRequest { batch })
-    }
-}
-
 impl WriteBatchRequest {
-    pub fn convert_write_batch_to_pb(
-        batch_request: WriteBatchRequest,
-        compress_options: CompressOptions,
-    ) -> std::result::Result<ceresdbproto::remote_engine::WriteBatchRequest, Error> {
-        let batch = batch_request
+    pub fn convert_into_pb(self) -> Result<ceresdbproto::remote_engine::WriteBatchRequest> {
+        let batch = self
             .batch
             .into_iter()
-            .map(|req| WriteRequest::convert_to_pb(req, compress_options))
-            .collect::<std::result::Result<Vec<_>, Error>>()?;
+            .map(|req| req.convert_into_pb())
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(remote_engine::WriteBatchRequest { batch })
     }
@@ -190,89 +165,83 @@ pub struct WriteRequest {
     pub write_request: TableWriteRequest,
 }
 
-impl TryFrom<ceresdbproto::remote_engine::WriteRequest> for WriteRequest {
-    type Error = Error;
+impl WriteRequest {
+    pub fn new(table_ident: TableIdentifier, row_group: RowGroup) -> Self {
+        Self {
+            table: table_ident,
+            write_request: TableWriteRequest { row_group },
+        }
+    }
 
-    fn try_from(
-        pb: ceresdbproto::remote_engine::WriteRequest,
-    ) -> std::result::Result<Self, Self::Error> {
-        let table_identifier = pb.table.context(EmptyTableIdentifier)?;
-        let row_group_pb = pb.row_group.context(EmptyRowGroup)?;
-        let rows = row_group_pb.rows.context(EmptyRowGroup)?;
-        let row_group = match rows {
-            Arrow(v) => {
-                ensure!(!v.record_batches.is_empty(), EmptyRecordBatch);
+    pub fn decode_row_group_from_arrow_payload(payload: ArrowPayload) -> Result<RowGroup> {
+        ensure!(!payload.record_batches.is_empty(), EmptyRecordBatch);
 
-                let compression = match v.compression() {
-                    arrow_payload::Compression::None => CompressionMethod::None,
-                    arrow_payload::Compression::Zstd => CompressionMethod::Zstd,
-                };
-
-                let mut record_batch_vec = vec![];
-                for data in v.record_batches {
-                    let mut arrow_record_batch_vec = ipc::decode_record_batches(data, compression)
-                        .map_err(|e| Box::new(e) as _)
-                        .context(ConvertRowGroup)?;
-                    record_batch_vec.append(&mut arrow_record_batch_vec);
-                }
-
-                build_row_group_from_record_batch(record_batch_vec)?
-            }
+        let compression = match payload.compression() {
+            arrow_payload::Compression::None => CompressionMethod::None,
+            arrow_payload::Compression::Zstd => CompressionMethod::Zstd,
         };
 
-        Ok(Self {
-            table: table_identifier.into(),
-            write_request: TableWriteRequest { row_group },
-        })
-    }
-}
+        let mut record_batch_vec = vec![];
+        for data in payload.record_batches {
+            let mut arrow_record_batch_vec = ipc::decode_record_batches(data, compression)
+                .map_err(|e| Box::new(e) as _)
+                .context(ConvertRowGroup)?;
+            record_batch_vec.append(&mut arrow_record_batch_vec);
+        }
 
-impl WriteRequest {
-    pub fn convert_to_pb(
-        request: WriteRequest,
-        compress_options: CompressOptions,
-    ) -> std::result::Result<ceresdbproto::remote_engine::WriteRequest, Error> {
-        // Row group to pb.
-        let row_group = request.write_request.row_group;
+        build_row_group_from_record_batch(record_batch_vec)
+    }
+
+    pub fn decode_row_group_from_contiguous_payload(
+        payload: ceresdbproto::remote_engine::ContiguousRows,
+        schema: &Schema,
+    ) -> Result<RowGroup> {
+        let mut row_group_builder =
+            RowGroupBuilder::with_capacity(schema.clone(), payload.encoded_rows.len());
+        for encoded_row in payload.encoded_rows {
+            let reader = ContiguousRowReader::try_new(&encoded_row, schema)
+                .box_err()
+                .context(ConvertRowGroup)?;
+
+            let mut datums = Vec::with_capacity(schema.num_columns());
+            for (index, column_schema) in schema.columns().iter().enumerate() {
+                let datum_view = reader.datum_view_at(index, &column_schema.data_type);
+                datums.push(datum_view.to_datum());
+            }
+            row_group_builder.push_checked_row(Row::from_datums(datums));
+        }
+        Ok(row_group_builder.build())
+    }
+
+    pub fn convert_into_pb(self) -> Result<ceresdbproto::remote_engine::WriteRequest> {
+        let row_group = self.write_request.row_group;
         let table_schema = row_group.schema();
         let min_timestamp = row_group.min_timestamp().as_i64();
         let max_timestamp = row_group.max_timestamp().as_i64();
 
-        let mut builder = RecordBatchWithKeyBuilder::new(table_schema.to_record_schema_with_key());
-
-        for row in row_group {
-            builder
-                .append_row(row)
-                .map_err(|e| Box::new(e) as _)
-                .context(ConvertRowGroup)?;
+        let mut encoded_rows = Vec::with_capacity(row_group.num_rows());
+        let index_in_schema = IndexInWriterSchema::for_same_schema(table_schema.num_columns());
+        for row in &row_group {
+            let mut buf = ByteVec::new();
+            let mut writer = ContiguousRowWriter::new(&mut buf, table_schema, &index_in_schema);
+            writer.write_row(row).with_context(|| WriteRequestToPb {
+                table_ident: self.table.clone(),
+            })?;
+            encoded_rows.push(buf);
         }
 
-        let record_batch_with_key = builder
-            .build()
-            .map_err(|e| Box::new(e) as _)
-            .context(ConvertRowGroup)?;
-        let record_batch = record_batch_with_key.into_record_batch();
-        let compress_output =
-            ipc::encode_record_batch(&record_batch.into_arrow_record_batch(), compress_options)
-                .map_err(|e| Box::new(e) as _)
-                .context(ConvertRowGroup)?;
-
-        let compression = match compress_output.method {
-            CompressionMethod::None => arrow_payload::Compression::None,
-            CompressionMethod::Zstd => arrow_payload::Compression::Zstd,
+        let contiguous_rows = ceresdbproto::remote_engine::ContiguousRows {
+            schema_version: table_schema.version(),
+            encoded_rows,
         };
-
         let row_group_pb = ceresdbproto::remote_engine::RowGroup {
             min_timestamp,
             max_timestamp,
-            rows: Some(Arrow(ArrowPayload {
-                record_batches: vec![compress_output.payload],
-                compression: compression as i32,
-            })),
+            rows: Some(Contiguous(contiguous_rows)),
         };
 
         // Table ident to pb.
-        let table_pb = request.table.into();
+        let table_pb = self.table.into();
 
         Ok(ceresdbproto::remote_engine::WriteRequest {
             table: Some(table_pb),
@@ -293,9 +262,7 @@ pub struct GetTableInfoRequest {
 impl TryFrom<ceresdbproto::remote_engine::GetTableInfoRequest> for GetTableInfoRequest {
     type Error = Error;
 
-    fn try_from(
-        value: ceresdbproto::remote_engine::GetTableInfoRequest,
-    ) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: ceresdbproto::remote_engine::GetTableInfoRequest) -> Result<Self> {
         let table = value.table.context(EmptyTableIdentifier)?.into();
         Ok(Self { table })
     }
@@ -304,7 +271,7 @@ impl TryFrom<ceresdbproto::remote_engine::GetTableInfoRequest> for GetTableInfoR
 impl TryFrom<GetTableInfoRequest> for ceresdbproto::remote_engine::GetTableInfoRequest {
     type Error = Error;
 
-    fn try_from(value: GetTableInfoRequest) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: GetTableInfoRequest) -> Result<Self> {
         let table = value.table.into();
         Ok(Self { table: Some(table) })
     }


### PR DESCRIPTION
## Rationale
According to the cpu profile results, it costs too much cpu resource when encode/decode the payloads for the remote engine write service.

## Detailed Changes
- Impose a new protocol for communication between remote engine client and service
- Avoid attaching the schema information in the payload
- Do the encoding work outside the io thread pool

## Test Plan
Proved 60% traffic drop and 25% cpu performance improvement in one of our prod environment.