### PR TITLE
refactor: improve the partition compute

### DIFF
--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -1056,7 +1056,7 @@ impl Serialize for Datum {
 /// A view to a datum.
 ///
 /// Holds copy of integer like datum and reference of string like datum.
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum DatumView<'a> {
     Null,
     Timestamp(Timestamp),
@@ -1075,6 +1075,30 @@ pub enum DatumView<'a> {
     Boolean(bool),
     Date(i32),
     Time(i64),
+}
+
+impl<'a> From<&'a Datum> for DatumView<'a> {
+    fn from(src: &'a Datum) -> DatumView<'a> {
+        match src {
+            Datum::Null => DatumView::Null,
+            Datum::Timestamp(v) => DatumView::Timestamp(*v),
+            Datum::Double(v) => DatumView::Double(*v),
+            Datum::Float(v) => DatumView::Float(*v),
+            Datum::Varbinary(v) => DatumView::Varbinary(v),
+            Datum::String(v) => DatumView::String(v),
+            Datum::UInt64(v) => DatumView::UInt64(*v),
+            Datum::UInt32(v) => DatumView::UInt32(*v),
+            Datum::UInt16(v) => DatumView::UInt16(*v),
+            Datum::UInt8(v) => DatumView::UInt8(*v),
+            Datum::Int64(v) => DatumView::Int64(*v),
+            Datum::Int32(v) => DatumView::Int32(*v),
+            Datum::Int16(v) => DatumView::Int16(*v),
+            Datum::Int8(v) => DatumView::Int8(*v),
+            Datum::Boolean(v) => DatumView::Boolean(*v),
+            Datum::Date(v) => DatumView::Date(*v),
+            Datum::Time(v) => DatumView::Time(*v),
+        }
+    }
 }
 
 impl<'a> DatumView<'a> {

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -937,7 +937,6 @@ impl Datum {
         }
     }
 
-    #[cfg(test)]
     pub fn as_view(&self) -> DatumView {
         match self {
             Datum::Null => DatumView::Null,
@@ -1075,30 +1074,6 @@ pub enum DatumView<'a> {
     Boolean(bool),
     Date(i32),
     Time(i64),
-}
-
-impl<'a> From<&'a Datum> for DatumView<'a> {
-    fn from(src: &'a Datum) -> DatumView<'a> {
-        match src {
-            Datum::Null => DatumView::Null,
-            Datum::Timestamp(v) => DatumView::Timestamp(*v),
-            Datum::Double(v) => DatumView::Double(*v),
-            Datum::Float(v) => DatumView::Float(*v),
-            Datum::Varbinary(v) => DatumView::Varbinary(v),
-            Datum::String(v) => DatumView::String(v),
-            Datum::UInt64(v) => DatumView::UInt64(*v),
-            Datum::UInt32(v) => DatumView::UInt32(*v),
-            Datum::UInt16(v) => DatumView::UInt16(*v),
-            Datum::UInt8(v) => DatumView::UInt8(*v),
-            Datum::Int64(v) => DatumView::Int64(*v),
-            Datum::Int32(v) => DatumView::Int32(*v),
-            Datum::Int16(v) => DatumView::Int16(*v),
-            Datum::Int8(v) => DatumView::Int8(*v),
-            Datum::Boolean(v) => DatumView::Boolean(*v),
-            Datum::Date(v) => DatumView::Date(*v),
-            Datum::Time(v) => DatumView::Time(*v),
-        }
-    }
 }
 
 impl<'a> DatumView<'a> {

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -498,7 +498,7 @@ impl Datum {
             Datum::Timestamp(v) => v.as_i64() as u64,
             Datum::Double(v) => *v as u64,
             Datum::Float(v) => *v as u64,
-            Datum::Varbinary(v) => hash64(v),
+            Datum::Varbinary(v) => hash64(&v[..]),
             Datum::String(v) => hash64(v.as_bytes()),
             Datum::UInt64(v) => *v,
             Datum::UInt32(v) => *v as u64,

--- a/components/hash_ext/src/lib.rs
+++ b/components/hash_ext/src/lib.rs
@@ -16,7 +16,7 @@
 /// - Memory: aHash
 /// - Disk: SeaHash
 /// https://github.com/CeresDB/hash-benchmark-rs
-use std::hash::BuildHasher;
+use std::{hash::BuildHasher, io::Read};
 
 pub use ahash;
 use byteorder::{ByteOrder, LittleEndian};
@@ -32,6 +32,13 @@ impl BuildHasher for SeaHasherBuilder {
     fn build_hasher(&self) -> Self::Hasher {
         SeaHasher::new()
     }
+}
+
+pub fn hash64_over_read<R: Read>(mut source: R) -> u64 {
+    let mut out = [0; 16];
+    murmur3_x64_128(&mut source, 0, &mut out);
+    // in most cases we run on little endian target
+    LittleEndian::read_u64(&out[0..8])
 }
 
 pub fn hash64(mut bytes: &[u8]) -> u64 {

--- a/components/hash_ext/src/lib.rs
+++ b/components/hash_ext/src/lib.rs
@@ -34,16 +34,9 @@ impl BuildHasher for SeaHasherBuilder {
     }
 }
 
-pub fn hash64_over_read<R: Read>(mut source: R) -> u64 {
+pub fn hash64<R: Read>(mut source: R) -> u64 {
     let mut out = [0; 16];
     murmur3_x64_128(&mut source, 0, &mut out);
-    // in most cases we run on little endian target
-    LittleEndian::read_u64(&out[0..8])
-}
-
-pub fn hash64(mut bytes: &[u8]) -> u64 {
-    let mut out = [0; 16];
-    murmur3_x64_128(&mut bytes, 0, &mut out);
     // in most cases we run on little endian target
     LittleEndian::read_u64(&out[0..8])
 }
@@ -60,13 +53,13 @@ mod test {
 
     #[test]
     fn test_murmur_hash() {
-        assert_eq!(hash64(&[]), 0);
+        assert_eq!(hash64(&(vec![])[..]), 0);
 
         for (key, code) in [
             (b"cse_engine_hash_mod_test_bytes1", 6401327391689448380),
             (b"cse_engine_hash_mod_test_bytes2", 10824100215277000151),
         ] {
-            assert_eq!(code, hash64(key));
+            assert_eq!(code, hash64(&key[..]));
         }
     }
 

--- a/components/hash_ext/src/lib.rs
+++ b/components/hash_ext/src/lib.rs
@@ -59,7 +59,7 @@ mod test {
             (b"cse_engine_hash_mod_test_bytes1", 6401327391689448380),
             (b"cse_engine_hash_mod_test_bytes2", 10824100215277000151),
         ] {
-            assert_eq!(code, hash64(&key[..]));
+            assert_eq!(code, hash64(key.as_slice()));
         }
     }
 

--- a/interpreters/src/insert.rs
+++ b/interpreters/src/insert.rs
@@ -204,7 +204,7 @@ impl<'a> TsidBuilder<'a> {
     }
 
     fn finish(self) -> u64 {
-        hash64(self.hash_bytes)
+        hash64(&self.hash_bytes[..])
     }
 }
 

--- a/query_frontend/src/promql/udf.rs
+++ b/query_frontend/src/promql/udf.rs
@@ -152,7 +152,7 @@ impl UUIDBuilder {
     }
 
     fn finish(self) -> u64 {
-        hash64(&self.buf)
+        hash64(&self.buf[..])
     }
 }
 

--- a/table_engine/Cargo.toml
+++ b/table_engine/Cargo.toml
@@ -48,3 +48,6 @@ smallvec = { workspace = true }
 snafu = { workspace = true }
 tokio = { workspace = true }
 trace_metric = { workspace = true }
+
+[dev-dependencies]
+common_types = { workspace = true, features = ["test"] }

--- a/table_engine/src/partition/rule/df_adapter/mod.rs
+++ b/table_engine/src/partition/rule/df_adapter/mod.rs
@@ -74,10 +74,9 @@ impl DfPartitionRuleAdapter {
 
 #[cfg(test)]
 mod tests {
-    use bytes_ext::BytesMut;
     use common_types::{
         column_schema,
-        datum::{Datum, DatumKind},
+        datum::{Datum, DatumKind, DatumView},
         row::RowGroupBuilder,
         schema::{Builder, Schema, TSID_COLUMN},
         string::StringBytes,
@@ -121,9 +120,8 @@ mod tests {
             Datum::String(StringBytes::from("test")),
             Datum::UInt64(42),
         ];
-        let partition_key_refs = partition_keys.iter().collect::<Vec<_>>();
-        let mut buf = BytesMut::new();
-        let expected = compute_partition(&partition_key_refs, partition_num, &mut buf);
+        let partition_key_refs = partition_keys.iter().map(DatumView::from);
+        let expected = compute_partition(partition_key_refs, partition_num);
 
         assert_eq!(partitions[0], expected);
 
@@ -239,12 +237,11 @@ mod tests {
 
         // Expected
         let partition_keys_1 = test_datums[0].clone();
-        let partition_key_refs_1 = partition_keys_1.iter().collect::<Vec<_>>();
+        let partition_key_refs_1 = partition_keys_1.iter().map(DatumView::from);
         let partition_keys_2 = test_datums[1].clone();
-        let partition_key_refs_2 = partition_keys_2.iter().collect::<Vec<_>>();
-        let mut buf = BytesMut::new();
-        let expected_1 = compute_partition(&partition_key_refs_1, partition_num, &mut buf);
-        let expected_2 = compute_partition(&partition_key_refs_2, partition_num, &mut buf);
+        let partition_key_refs_2 = partition_keys_2.iter().map(DatumView::from);
+        let expected_1 = compute_partition(partition_key_refs_1, partition_num);
+        let expected_2 = compute_partition(partition_key_refs_2, partition_num);
         let expecteds = vec![expected_1, expected_2];
 
         assert_eq!(partitions, expecteds);

--- a/table_engine/src/partition/rule/df_adapter/mod.rs
+++ b/table_engine/src/partition/rule/df_adapter/mod.rs
@@ -76,7 +76,7 @@ impl DfPartitionRuleAdapter {
 mod tests {
     use common_types::{
         column_schema,
-        datum::{Datum, DatumKind, DatumView},
+        datum::{Datum, DatumKind},
         row::RowGroupBuilder,
         schema::{Builder, Schema, TSID_COLUMN},
         string::StringBytes,
@@ -120,7 +120,7 @@ mod tests {
             Datum::String(StringBytes::from("test")),
             Datum::UInt64(42),
         ];
-        let partition_key_refs = partition_keys.iter().map(DatumView::from);
+        let partition_key_refs = partition_keys.iter().map(Datum::as_view);
         let expected = compute_partition(partition_key_refs, partition_num);
 
         assert_eq!(partitions[0], expected);
@@ -237,9 +237,9 @@ mod tests {
 
         // Expected
         let partition_keys_1 = test_datums[0].clone();
-        let partition_key_refs_1 = partition_keys_1.iter().map(DatumView::from);
+        let partition_key_refs_1 = partition_keys_1.iter().map(Datum::as_view);
         let partition_keys_2 = test_datums[1].clone();
-        let partition_key_refs_2 = partition_keys_2.iter().map(DatumView::from);
+        let partition_key_refs_2 = partition_keys_2.iter().map(Datum::as_view);
         let expected_1 = compute_partition(partition_key_refs_1, partition_num);
         let expected_2 = compute_partition(partition_key_refs_2, partition_num);
         let expecteds = vec![expected_1, expected_2];

--- a/table_engine/src/partition/rule/key.rs
+++ b/table_engine/src/partition/rule/key.rs
@@ -315,6 +315,13 @@ where
     /// This implementation will fill the whole buf as much as possible, and the
     /// only scenario where the buf is not fully filled is that the serialized
     /// bytes from the `self.key_views` are exhausted.
+    ///
+    /// NOTE: The best way is to fill the `buf` key after key rather than fill
+    /// the `buf`. And an example can illustrate the reason for this way, saying
+    /// there are two `key_views`s, ['a', 'bc'], and ['ab', 'c'], in the way to
+    /// fill the buf as much as possible, the two `key_views`s will output the
+    /// same hash result, while the best way can generate different results.
+    /// However, here the best way is not chose for compatibility.
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let mut total_n_bytes = 0;
         loop {

--- a/table_engine/src/partition/rule/key.rs
+++ b/table_engine/src/partition/rule/key.rs
@@ -20,7 +20,7 @@ use common_types::{
     datum::DatumView,
     row::{Row, RowGroup},
 };
-use hash_ext::hash64_over_read;
+use hash_ext::hash64;
 use itertools::Itertools;
 use log::{debug, error};
 use snafu::OptionExt;
@@ -340,7 +340,7 @@ pub(crate) fn compute_partition<'a>(
     partition_num: usize,
 ) -> usize {
     let reader = PartitionKeysReadAdapter::new(partition_keys);
-    (hash64_over_read(reader) as usize) % partition_num
+    (hash64(reader) as usize) % partition_num
 }
 
 #[cfg(test)]
@@ -384,7 +384,7 @@ mod tests {
         buf.put_slice(&datums[2].to_bytes());
         buf.put_slice(&datums[3].to_bytes());
         buf.put_slice(&datums[4].to_bytes());
-        let expected = (hash64(&buf) % (partition_num as u64)) as usize;
+        let expected = (hash64(&buf[..]) % (partition_num as u64)) as usize;
 
         assert_eq!(actual, expected);
     }


### PR DESCRIPTION
## Rationale
The previous implementation of computing partition key is coarse, leading to poor performance.

## Detailed Changes
Refactor the implementation of computing partition key, and the most of memory allocation is avoided.

## Test Plan
Existing unit tests.