### PR TITLE
refactor: add request id in context

### DIFF
--- a/proxy/src/context.rs
+++ b/proxy/src/context.rs
@@ -16,6 +16,7 @@
 
 use std::time::Duration;
 
+use common_types::request_id::RequestId;
 use macros::define_result;
 use snafu::{ensure, Backtrace, Snafu};
 
@@ -42,15 +43,16 @@ define_result!(Error);
 /// Context for request, may contains
 /// 1. Request context and options
 /// 2. Info from http headers
+#[derive(Debug)]
 pub struct RequestContext {
     /// Catalog of the request
     pub catalog: String,
     /// Schema of request
     pub schema: String,
-    /// Enable partition table_access flag
-    pub enable_partition_table_access: bool,
     /// Request timeout
     pub timeout: Option<Duration>,
+    /// Request id
+    pub request_id: RequestId,
 }
 
 impl RequestContext {
@@ -63,7 +65,6 @@ impl RequestContext {
 pub struct Builder {
     catalog: String,
     schema: String,
-    enable_partition_table_access: bool,
     timeout: Option<Duration>,
 }
 
@@ -75,11 +76,6 @@ impl Builder {
 
     pub fn schema(mut self, schema: String) -> Self {
         self.schema = schema;
-        self
-    }
-
-    pub fn enable_partition_table_access(mut self, enable_partition_table_access: bool) -> Self {
-        self.enable_partition_table_access = enable_partition_table_access;
         self
     }
 
@@ -95,8 +91,8 @@ impl Builder {
         Ok(RequestContext {
             catalog: self.catalog,
             schema: self.schema,
-            enable_partition_table_access: self.enable_partition_table_access,
             timeout: self.timeout,
+            request_id: RequestId::next_id(),
         })
     }
 }

--- a/proxy/src/grpc/prom_query.rs
+++ b/proxy/src/grpc/prom_query.rs
@@ -26,7 +26,6 @@ use ceresdbproto::{
 use common_types::{
     datum::DatumKind,
     record_batch::RecordBatch,
-    request_id::RequestId,
     schema::{RecordSchema, TSID_COLUMN},
 };
 use generic_error::BoxError;
@@ -76,7 +75,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         ctx: Context,
         req: PrometheusQueryRequest,
     ) -> Result<PrometheusQueryResponse> {
-        let request_id = RequestId::next_id();
+        let request_id = ctx.request_id;
         let begin_instant = Instant::now();
         let deadline = ctx.timeout.map(|t| begin_instant + t);
         let req_ctx = req.context.context(ErrNoCause {

--- a/proxy/src/grpc/sql_query.rs
+++ b/proxy/src/grpc/sql_query.rs
@@ -57,7 +57,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         self.hotspot_recorder.inc_sql_query_reqs(&req).await;
         match self.handle_sql_query_internal(&ctx, &req).await {
             Err(e) => {
-                error!("Failed to handle sql query, ctx:{ctx:?}, req:{req:?}, err:{e}");
+                error!("Failed to handle sql query, ctx:{ctx:?}, err:{e}");
 
                 GRPC_HANDLER_COUNTER_VEC.query_failed.inc();
                 SqlQueryResponse {

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -85,12 +85,11 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
             }),
             table_requests: write_table_requests,
         };
-        let ctx = ProxyContext {
-            runtime: self.engine_runtimes.write_runtime.clone(),
-            timeout: ctx.timeout,
-            enable_partition_table_access: false,
-            forwarded_from: None,
-        };
+        let ctx = ProxyContext::new(
+            self.engine_runtimes.write_runtime.clone(),
+            ctx.timeout,
+            None,
+        );
 
         match self.handle_write_internal(ctx, table_request).await {
             Ok(result) => {

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -164,7 +164,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
             .await?;
 
         let cost = begin_instant.saturating_elapsed().as_millis();
-        info!("Handle prom remote query sucess, ctx:{ctx:?}, cost:{cost}ms");
+        info!("Handle prom remote query successfully, ctx:{ctx:?}, cost:{cost}ms");
 
         convert_query_result(metric, timestamp_col_name, field_col_name, output)
     }

--- a/proxy/src/http/sql.rs
+++ b/proxy/src/http/sql.rs
@@ -51,7 +51,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         req: Request,
     ) -> Result<Output> {
         let schema = &ctx.schema;
-        let ctx = Context::new(self.engine_runtimes.read_runtime.clone(), ctx.timeout, None);
+        let ctx = Context::new(ctx.timeout, None);
 
         match self
             .handle_sql(&ctx, schema, &req.query, true)

--- a/proxy/src/http/sql.rs
+++ b/proxy/src/http/sql.rs
@@ -26,6 +26,7 @@ use common_types::{
 use generic_error::BoxError;
 use http::StatusCode;
 use interpreters::interpreter::Output;
+use log::error;
 use query_engine::{
     executor::{Executor as QueryExecutor, RecordBatchVec},
     physical_planner::PhysicalPlanner,
@@ -49,14 +50,16 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         ctx: &RequestContext,
         req: Request,
     ) -> Result<Output> {
-        let context = Context {
-            timeout: ctx.timeout,
-            runtime: self.engine_runtimes.read_runtime.clone(),
-            enable_partition_table_access: true,
-            forwarded_from: None,
-        };
+        let schema = &ctx.schema;
+        let ctx = Context::new(self.engine_runtimes.read_runtime.clone(), ctx.timeout, None);
 
-        match self.handle_sql(context, &ctx.schema, &req.query).await? {
+        match self
+            .handle_sql(&ctx, schema, &req.query, true)
+            .await
+            .map_err(|e| {
+                error!("Handle sql query failed, ctx:{ctx:?}, req:{req:?}, err:{e}");
+                e
+            })? {
             SqlResponse::Forwarded(resp) => convert_sql_response_to_output(resp),
             SqlResponse::Local(output) => Ok(output),
         }

--- a/proxy/src/influxdb/mod.rs
+++ b/proxy/src/influxdb/mod.rs
@@ -80,12 +80,11 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
             }),
             table_requests: write_table_requests,
         };
-        let proxy_context = Context {
-            timeout: ctx.timeout,
-            runtime: self.engine_runtimes.write_runtime.clone(),
-            enable_partition_table_access: false,
-            forwarded_from: None,
-        };
+        let proxy_context = Context::new(
+            self.engine_runtimes.write_runtime.clone(),
+            ctx.timeout,
+            None,
+        );
 
         match self
             .handle_write_internal(proxy_context, table_request)

--- a/proxy/src/influxdb/mod.rs
+++ b/proxy/src/influxdb/mod.rs
@@ -23,7 +23,6 @@ use std::time::Instant;
 use ceresdbproto::storage::{
     RequestContext as GrpcRequestContext, WriteRequest as GrpcWriteRequest,
 };
-use common_types::request_id::RequestId;
 use generic_error::BoxError;
 use http::StatusCode;
 use interpreters::interpreter::Output;
@@ -80,11 +79,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
             }),
             table_requests: write_table_requests,
         };
-        let proxy_context = Context::new(
-            self.engine_runtimes.write_runtime.clone(),
-            ctx.timeout,
-            None,
-        );
+        let proxy_context = Context::new(ctx.timeout, None);
 
         match self
             .handle_write_internal(proxy_context, table_request)
@@ -125,7 +120,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         ctx: RequestContext,
         req: InfluxqlRequest,
     ) -> Result<Output> {
-        let request_id = RequestId::next_id();
+        let request_id = ctx.request_id;
         let begin_instant = Instant::now();
         let deadline = ctx.timeout.map(|t| begin_instant + t);
 

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -39,6 +39,7 @@ mod write;
 pub const FORWARDED_FROM: &str = "forwarded-from";
 
 use std::{
+    fmt,
     ops::Bound,
     sync::Arc,
     time::{Duration, Instant},
@@ -556,8 +557,33 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
 
 #[derive(Clone)]
 pub struct Context {
-    pub timeout: Option<Duration>,
+    pub request_id: RequestId,
     pub runtime: Arc<Runtime>,
-    pub enable_partition_table_access: bool,
+    pub timeout: Option<Duration>,
     pub forwarded_from: Option<String>,
+}
+
+impl Context {
+    pub fn new(
+        runtime: Arc<Runtime>,
+        timeout: Option<Duration>,
+        forwarded_from: Option<String>,
+    ) -> Self {
+        Self {
+            runtime,
+            timeout,
+            forwarded_from,
+            request_id: RequestId::next_id(),
+        }
+    }
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Context")
+            .field("id", &self.request_id)
+            .field("timeout", &self.timeout)
+            .field("forwarded_from", &self.forwarded_from)
+            .finish()
+    }
 }

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -39,7 +39,6 @@ mod write;
 pub const FORWARDED_FROM: &str = "forwarded-from";
 
 use std::{
-    fmt,
     ops::Bound,
     sync::Arc,
     time::{Duration, Instant},
@@ -73,7 +72,6 @@ use log::{error, info};
 use query_engine::{executor::Executor as QueryExecutor, physical_planner::PhysicalPlanner};
 use query_frontend::plan::Plan;
 use router::{endpoint::Endpoint, Router};
-use runtime::Runtime;
 use snafu::{OptionExt, ResultExt};
 use table_engine::{
     engine::{EngineRuntimes, TableState},
@@ -555,35 +553,19 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Context {
-    pub request_id: RequestId,
-    pub runtime: Arc<Runtime>,
-    pub timeout: Option<Duration>,
-    pub forwarded_from: Option<String>,
+    request_id: RequestId,
+    timeout: Option<Duration>,
+    forwarded_from: Option<String>,
 }
 
 impl Context {
-    pub fn new(
-        runtime: Arc<Runtime>,
-        timeout: Option<Duration>,
-        forwarded_from: Option<String>,
-    ) -> Self {
+    pub fn new(timeout: Option<Duration>, forwarded_from: Option<String>) -> Self {
         Self {
-            runtime,
+            request_id: RequestId::next_id(),
             timeout,
             forwarded_from,
-            request_id: RequestId::next_id(),
         }
-    }
-}
-
-impl fmt::Debug for Context {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Context")
-            .field("id", &self.request_id)
-            .field("timeout", &self.timeout)
-            .field("forwarded_from", &self.forwarded_from)
-            .finish()
     }
 }

--- a/proxy/src/opentsdb/mod.rs
+++ b/proxy/src/opentsdb/mod.rs
@@ -56,12 +56,11 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
             }),
             table_requests: write_table_requests,
         };
-        let proxy_context = Context {
-            timeout: ctx.timeout,
-            runtime: self.engine_runtimes.write_runtime.clone(),
-            enable_partition_table_access: false,
-            forwarded_from: None,
-        };
+        let proxy_context = Context::new(
+            self.engine_runtimes.write_runtime.clone(),
+            ctx.timeout,
+            None,
+        );
 
         match self
             .handle_write_internal(proxy_context, table_request)

--- a/proxy/src/opentsdb/mod.rs
+++ b/proxy/src/opentsdb/mod.rs
@@ -56,11 +56,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
             }),
             table_requests: write_table_requests,
         };
-        let proxy_context = Context::new(
-            self.engine_runtimes.write_runtime.clone(),
-            ctx.timeout,
-            None,
-        );
+        let proxy_context = Context::new(ctx.timeout, None);
 
         match self
             .handle_write_internal(proxy_context, table_request)

--- a/proxy/src/read.rs
+++ b/proxy/src/read.rs
@@ -73,6 +73,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
     pub(crate) async fn fetch_sql_query_output(
         &self,
         ctx: &Context,
+        // TODO: maybe we can put params below input a new ReadRequest struct.
         schema: &str,
         sql: &str,
         enable_partition_table_access: bool,
@@ -82,7 +83,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         let deadline = ctx.timeout.map(|t| begin_instant + t);
         let catalog = self.instance.catalog_manager.default_catalog_name();
 
-        info!("Handle sql query begin, catalog:{catalog}, schema:{schema}, ctx:{ctx:?}, sql:{sql}");
+        info!("Handle sql query begin, catalog:{catalog}, schema:{schema}, deadline:{deadline:?}, ctx:{ctx:?}, sql:{sql}");
 
         let instance = &self.instance;
         // TODO(yingwen): Privilege check, cannot access data of other tenant

--- a/proxy/src/read.rs
+++ b/proxy/src/read.rs
@@ -160,7 +160,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         })?;
 
         let cost = begin_instant.saturating_elapsed();
-        info!("Handle sql query success, catalog:{catalog}, schema:{schema}, cost:{cost:?}, ctx:{ctx:?}");
+        info!("Handle sql query successfully, catalog:{catalog}, schema:{schema}, cost:{cost:?}, ctx:{ctx:?}");
 
         match &output {
             Output::AffectedRows(_) => Ok(output),

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -103,8 +103,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         ctx: Context,
         req: WriteRequest,
     ) -> Result<WriteResponse> {
-        let request_id = RequestId::next_id();
-
+        let request_id = ctx.request_id;
         let write_context = req.context.clone().context(ErrNoCause {
             msg: "Missing context",
             code: StatusCode::BAD_REQUEST,
@@ -138,8 +137,7 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Proxy<Q, P> {
         ctx: Context,
         req: WriteRequest,
     ) -> Result<WriteResponse> {
-        let request_id = RequestId::next_id();
-
+        let request_id = ctx.request_id;
         let write_context = req.context.clone().context(ErrNoCause {
             msg: "Missing context",
             code: StatusCode::BAD_REQUEST,

--- a/server/src/http.rs
+++ b/server/src/http.rs
@@ -638,7 +638,6 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> Service<Q, P> {
                             .catalog(catalog.unwrap_or(default_catalog))
                             .schema(schema)
                             .timeout(timeout)
-                            .enable_partition_table_access(true)
                             .build()
                             .context(CreateContext)
                             .map_err(reject::custom)

--- a/server/src/mysql/worker.rs
+++ b/server/src/mysql/worker.rs
@@ -147,7 +147,6 @@ where
         RequestContext::builder()
             .catalog(default_catalog)
             .schema(default_schema)
-            .enable_partition_table_access(false)
             .timeout(self.timeout)
             .build()
             .context(CreateContext)

--- a/server/src/postgresql/handler.rs
+++ b/server/src/postgresql/handler.rs
@@ -84,7 +84,6 @@ impl<Q: QueryExecutor + 'static, P: PhysicalPlanner> PostgresqlHandler<Q, P> {
         RequestContext::builder()
             .catalog(default_catalog)
             .schema(default_schema)
-            .enable_partition_table_access(false)
             .timeout(self.timeout)
             .build()
             .context(CreateContext)


### PR DESCRIPTION
## Rationale
Currently when query failed, the error log doesn't contain request id, this makes it's very hard to tell how long the error query takes.

## Detailed Changes
- Add `request_id` in context, and print this ctx when query failed.
- Remove `enable_partition_table_access`, `runtime` from context to avoid unnecessary clone.
- Remove unnecessary param's move, change to reference.
## Test Plan
