### PR TITLE
test: add integration test for distinct

### DIFF
--- a/integration_tests/cases/common/function/aggregate.result
+++ b/integration_tests/cases/common/function/aggregate.result
@@ -91,6 +91,13 @@ COUNT(02_function_aggregate_table1.arch),
 Int64(4),
 
 
+SELECT distinct(`arch`) FROM `02_function_aggregate_table1`;
+
+arch,
+String("x86-64"),
+String("arm64"),
+
+
 SELECT count(distinct(`arch`)) FROM `02_function_aggregate_table1`;
 
 COUNT(DISTINCT 02_function_aggregate_table1.arch),

--- a/integration_tests/cases/common/function/aggregate.sql
+++ b/integration_tests/cases/common/function/aggregate.sql
@@ -53,6 +53,8 @@ VALUES
 
 SELECT count(`arch`) FROM `02_function_aggregate_table1`;
 
+SELECT distinct(`arch`) FROM `02_function_aggregate_table1`;
+
 SELECT count(distinct(`arch`)) FROM `02_function_aggregate_table1`;
 
 DROP TABLE `02_function_aggregate_table1`;


### PR DESCRIPTION
## Rationale
One of our user report follow errors:

```
{"code":500,"message":"Failed to handle request, err:Rpc error, code:500, message:Failed to execute plan, sql:select  distinct(`app_id`)   from visit where `period` <= 1692147800000 and `period` >= 1692147600000 , err:Internal error, msg:Failed to execute interpreter, err:Failed to execute select, err:Failed to execute logical plan, err:Failed to do physical optimization, err:DataFusion Failed to optimize physical plan, err:Internal error: Unsupported logical plan: Distinct should be replaced to Aggregate. This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker."}
```

This bug is already fix in main, so add this to ensure it won't break any more.
## Detailed Changes


## Test Plan
