### PR TITLE
fix: add order by for integration test case

### DIFF
--- a/integration_tests/cases/common/function/aggregate.result
+++ b/integration_tests/cases/common/function/aggregate.result
@@ -91,7 +91,7 @@ COUNT(02_function_aggregate_table1.arch),
 Int64(4),
 
 
-SELECT distinct(`arch`) FROM `02_function_aggregate_table1`;
+SELECT distinct(`arch`) FROM `02_function_aggregate_table1` ORDER BY `arch` DESC;
 
 arch,
 String("x86-64"),

--- a/integration_tests/cases/common/function/aggregate.sql
+++ b/integration_tests/cases/common/function/aggregate.sql
@@ -53,7 +53,7 @@ VALUES
 
 SELECT count(`arch`) FROM `02_function_aggregate_table1`;
 
-SELECT distinct(`arch`) FROM `02_function_aggregate_table1`;
+SELECT distinct(`arch`) FROM `02_function_aggregate_table1` ORDER BY `arch` DESC;
 
 SELECT count(distinct(`arch`)) FROM `02_function_aggregate_table1`;
 


### PR DESCRIPTION
## Rationale
Currently, on the main branch, the integration test has failed resulting from a sql without the order by clause.

## Detailed Changes
Add order by clause for the wrong case.

## Test Plan
By the CI.