### PR TITLE
feat: implement compression encoding for columar bytes values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,6 +1548,7 @@ dependencies = [
  "common_types",
  "macros",
  "snafu 0.6.10",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,9 +1546,9 @@ version = "1.2.6-alpha"
 dependencies = [
  "bytes_ext",
  "common_types",
+ "lz4_flex",
  "macros",
  "snafu 0.6.10",
- "zstd",
 ]
 
 [[package]]
@@ -3725,6 +3725,15 @@ checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ futures = "0.3"
 generic_error = { path = "components/generic_error" }
 hash_ext = { path = "components/hash_ext" }
 hex = "0.4.3"
+lz4_flex = { version = "0.11", default-features = false, features = ["frame"] }
 lazy_static = "1.4.0"
 log = "0.4"
 logger = { path = "components/logger" }

--- a/components/bytes_ext/src/lib.rs
+++ b/components/bytes_ext/src/lib.rs
@@ -182,6 +182,7 @@ where
     }
 }
 
+/// The wrapper on the [`BufMut`] for implementing [`std::io::Write`].
 pub struct WriterOnBufMut<'a, B: BufMut> {
     pub buf: &'a mut B,
 }

--- a/components/bytes_ext/src/lib.rs
+++ b/components/bytes_ext/src/lib.rs
@@ -182,6 +182,24 @@ where
     }
 }
 
+pub struct WriterOnBufMut<'a, B: BufMut> {
+    pub buf: &'a mut B,
+}
+
+impl<'a, B> std::io::Write for WriterOnBufMut<'a, B>
+where
+    B: BufMut,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buf.put_slice(buf);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/components/bytes_ext/src/lib.rs
+++ b/components/bytes_ext/src/lib.rs
@@ -201,6 +201,7 @@ where
         Ok(())
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -30,4 +30,4 @@ bytes_ext = { workspace = true }
 common_types = { workspace = true, features = ["test"] }
 macros = { workspace = true }
 snafu = { workspace = true }
-
+zstd = { workspace = true }

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -28,6 +28,6 @@ workspace = true
 # In alphabetical order
 bytes_ext = { workspace = true }
 common_types = { workspace = true, features = ["test"] }
+lz4_flex = { workspace = true }
 macros = { workspace = true }
 snafu = { workspace = true }
-zstd = { workspace = true }

--- a/components/codec/src/columnar/bytes.rs
+++ b/components/codec/src/columnar/bytes.rs
@@ -12,28 +12,110 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes_ext::{Buf, BufMut, Bytes};
-use snafu::ResultExt;
+use std::io::{Read, Write};
+
+use bytes_ext::{Buf, BufMut, Bytes, WriterOnBufMut};
+use snafu::{ensure, ResultExt};
+use zstd::{Decoder as ZstdStreamDecoder, Encoder as ZstdStreamEncoder};
 
 use crate::{
     columnar::{
+        Compress, DecodeContext, Decompress, InvalidCompression, InvalidVersion, NotEnoughBytes,
         Result, ValuesDecoder, ValuesDecoderImpl, ValuesEncoder, ValuesEncoderImpl, Varint,
     },
     varint,
 };
 
+/// The layout for the string/bytes:
+/// ```plaintext
+/// +-------------+--------------+------------+-----------------------+-----------------+
+/// | version(u8) | length_block | data_block | length_block_len(u32) | compression(u8) |
+/// +-------------+--------------+------------+-----------------------+-----------------+
+/// ```
+///
+/// Currently, the `compression` has two optional values:
+/// - 0: No compression over the data block
+/// - 1: the data block is compressed by ZSTD
+///
+/// And the lengths in the `length block` are encoded in varint.
+/// And the reason to put `length_block_len` and `compression` at the footer is
+/// for friendly decode.
+struct Encoding;
+
+impl Encoding {
+    const COMPRESSION_SIZE: usize = 1;
+    /// If the data block exceeds this threshold, it will be compressed.
+    const COMPRESS_BYTES_THRESHOLD: usize = 256;
+    const LENGTH_BLOCK_LEN_SIZE: usize = 4;
+    const VERSION: u8 = 0;
+    const VERSION_SIZE: usize = 1;
+    const ZSTD_LEVEL: i32 = 3;
+
+    fn decide_compression(data_block_len: usize) -> Compression {
+        if data_block_len > Self::COMPRESS_BYTES_THRESHOLD {
+            Compression::Zstd
+        } else {
+            Compression::NoCompression
+        }
+    }
+
+    fn decode_compression(v: u8) -> Result<Compression> {
+        let version = match v {
+            0 => Compression::NoCompression,
+            1 => Compression::Zstd,
+            _ => InvalidCompression { flag: v }.fail()?,
+        };
+
+        Ok(version)
+    }
+}
+
+/// The compression for [`Encoding`].
+///
+/// It is not allowed to be modified and only allowed to be appended with a new
+/// variant.
+#[derive(Clone, Copy, Default)]
+#[repr(C)]
+enum Compression {
+    #[default]
+    NoCompression = 0,
+    Zstd = 1,
+}
+
 impl<'a> ValuesEncoder<&'a [u8]> for ValuesEncoderImpl {
+    /// The layout can be referred to the docs of [`Encoding`].
     fn encode<B, I>(&self, buf: &mut B, values: I) -> Result<()>
     where
         B: BufMut,
-        I: Iterator<Item = &'a [u8]>,
+        I: Iterator<Item = &'a [u8]> + Clone,
     {
-        for v in values {
-            debug_assert!(v.len() < u32::MAX as usize);
+        // Encode the `version`.
+        buf.put_u8(Encoding::VERSION);
 
-            varint::encode_uvarint(buf, v.len() as u64).context(Varint)?;
-            buf.put_slice(v);
+        // Encode the `length_block`.
+        let mut data_block_len = 0;
+        let mut length_block_len = 0;
+        for v in values.clone() {
+            data_block_len += v.len();
+            let sz = varint::encode_uvarint(buf, v.len() as u64).context(Varint)?;
+            length_block_len += sz;
         }
+        assert!(length_block_len < u32::MAX as usize);
+
+        // Encode the `data_block`.
+        let compression = Encoding::decide_compression(data_block_len);
+        match compression {
+            Compression::NoCompression => {
+                for v in values {
+                    buf.put_slice(v);
+                }
+            }
+            Compression::Zstd => encode_with_compress(buf, values).context(Compress)?,
+        }
+
+        // Encode the `data_block` offset.
+        buf.put_u32(length_block_len as u32);
+        buf.put_u8(compression as u8);
 
         Ok(())
     }
@@ -42,7 +124,9 @@ impl<'a> ValuesEncoder<&'a [u8]> for ValuesEncoderImpl {
     where
         I: Iterator<Item = &'a [u8]>,
     {
-        let mut total_bytes = 0;
+        let mut total_bytes =
+            Encoding::VERSION_SIZE + Encoding::LENGTH_BLOCK_LEN_SIZE + Encoding::COMPRESSION_SIZE;
+
         for v in values {
             // The length of `v` should be ensured to be smaller than [u32::MAX], that is to
             // say, at most 5 bytes will be used when do varint encoding over a u32 number.
@@ -52,19 +136,90 @@ impl<'a> ValuesEncoder<&'a [u8]> for ValuesEncoderImpl {
     }
 }
 
+fn encode_with_compress<'a, B, I>(buf: &mut B, values: I) -> std::io::Result<()>
+where
+    B: BufMut,
+    I: Iterator<Item = &'a [u8]>,
+{
+    let writer = WriterOnBufMut { buf };
+    let mut zstd_enc = ZstdStreamEncoder::new(writer, Encoding::ZSTD_LEVEL)?;
+    for v in values {
+        zstd_enc.write_all(v)?;
+    }
+    zstd_enc.finish()?;
+
+    Ok(())
+}
+
+fn decode_without_compression<B, F>(
+    length_block_buf: &mut B,
+    data_block_buf: &[u8],
+    mut f: F,
+) -> Result<()>
+where
+    B: Buf,
+    F: FnMut(Bytes) -> Result<()>,
+{
+    let mut offset = 0;
+    while length_block_buf.remaining() > 0 {
+        let length = varint::decode_uvarint(length_block_buf).context(Varint)? as usize;
+        let b = Bytes::copy_from_slice(&data_block_buf[offset..offset + length]);
+        f(b)?;
+        offset += length;
+    }
+
+    Ok(())
+}
+
+fn decode_with_compression<F>(
+    mut length_block_buf: &[u8],
+    compressed_data_block_buf: &[u8],
+    reused_buf: &mut Vec<u8>,
+    f: F,
+) -> Result<()>
+where
+    F: FnMut(Bytes) -> Result<()>,
+{
+    let mut decoder = ZstdStreamDecoder::new(compressed_data_block_buf).context(Decompress)?;
+    decoder.read_to_end(reused_buf).context(Decompress)?;
+    decode_without_compression(&mut length_block_buf, &reused_buf[..], f)
+}
+
 impl ValuesDecoder<Bytes> for ValuesDecoderImpl {
-    fn decode<B, F>(&self, buf: &mut B, mut f: F) -> Result<()>
+    /// The layout can be referred to the docs of [`Encoding`].
+    fn decode<B, F>(&self, ctx: DecodeContext<'_>, buf: &mut B, f: F) -> Result<()>
     where
         B: Buf,
         F: FnMut(Bytes) -> Result<()>,
     {
-        while buf.remaining() > 0 {
-            let str_len = varint::decode_uvarint(buf).context(Varint)? as usize;
-            let v = &buf.chunk()[..str_len];
-            f(Bytes::copy_from_slice(v))?;
-            buf.advance(str_len);
-        }
+        let chunk = buf.chunk();
+        let footer_len = Encoding::LENGTH_BLOCK_LEN_SIZE + Encoding::COMPRESSION_SIZE;
+        ensure!(
+            chunk.len() > footer_len + Encoding::VERSION_SIZE,
+            NotEnoughBytes {
+                len: footer_len + Encoding::VERSION_SIZE
+            }
+        );
 
-        Ok(())
+        let version = chunk[0];
+        ensure!(version == Encoding::VERSION, InvalidVersion { version });
+
+        let compression_offset = chunk.len() - Encoding::COMPRESSION_SIZE;
+        let compression = Encoding::decode_compression(chunk[compression_offset])?;
+
+        let length_block_len_offset = chunk.len() - footer_len;
+        let length_block_end = {
+            let mut len_buf = &chunk[length_block_len_offset..compression_offset];
+            len_buf.get_u32() as usize + Encoding::VERSION_SIZE
+        };
+        let mut length_block = &chunk[Encoding::VERSION_SIZE..length_block_end];
+        let data_block = &chunk[length_block_end..length_block_len_offset];
+
+        match compression {
+            Compression::NoCompression => {
+                decode_without_compression(&mut length_block, data_block, f)
+            }
+            Compression::Zstd => decode_with_compression(length_block, data_block, ctx.buf, f),
+        }
     }
 }

--- a/components/codec/src/columnar/float.rs
+++ b/components/codec/src/columnar/float.rs
@@ -14,7 +14,9 @@
 
 use bytes_ext::{Buf, BufMut};
 
-use crate::columnar::{Result, ValuesDecoder, ValuesDecoderImpl, ValuesEncoder, ValuesEncoderImpl};
+use crate::columnar::{
+    DecodeContext, Result, ValuesDecoder, ValuesDecoderImpl, ValuesEncoder, ValuesEncoderImpl,
+};
 
 impl ValuesEncoder<f64> for ValuesEncoderImpl {
     fn encode<B, I>(&self, buf: &mut B, values: I) -> Result<()>
@@ -31,7 +33,7 @@ impl ValuesEncoder<f64> for ValuesEncoderImpl {
 }
 
 impl ValuesDecoder<f64> for ValuesDecoderImpl {
-    fn decode<B, F>(&self, buf: &mut B, mut f: F) -> Result<()>
+    fn decode<B, F>(&self, _ctx: DecodeContext<'_>, buf: &mut B, mut f: F) -> Result<()>
     where
         B: Buf,
         F: FnMut(f64) -> Result<()>,

--- a/components/codec/src/columnar/int.rs
+++ b/components/codec/src/columnar/int.rs
@@ -17,7 +17,8 @@ use snafu::ResultExt;
 
 use crate::{
     columnar::{
-        Result, ValuesDecoder, ValuesDecoderImpl, ValuesEncoder, ValuesEncoderImpl, Varint,
+        DecodeContext, Result, ValuesDecoder, ValuesDecoderImpl, ValuesEncoder, ValuesEncoderImpl,
+        Varint,
     },
     varint,
 };
@@ -40,7 +41,7 @@ impl ValuesEncoder<i32> for ValuesEncoderImpl {
 }
 
 impl ValuesDecoder<i32> for ValuesDecoderImpl {
-    fn decode<B, F>(&self, buf: &mut B, mut f: F) -> Result<()>
+    fn decode<B, F>(&self, _ctx: DecodeContext<'_>, buf: &mut B, mut f: F) -> Result<()>
     where
         B: Buf,
         F: FnMut(i32) -> Result<()>,
@@ -78,7 +79,7 @@ impl ValuesEncoder<i64> for ValuesEncoderImpl {
 }
 
 impl ValuesDecoder<i64> for ValuesDecoderImpl {
-    fn decode<B, F>(&self, buf: &mut B, mut f: F) -> Result<()>
+    fn decode<B, F>(&self, _ctx: DecodeContext<'_>, buf: &mut B, mut f: F) -> Result<()>
     where
         B: Buf,
         F: FnMut(i64) -> Result<()>,
@@ -116,7 +117,7 @@ impl ValuesEncoder<u64> for ValuesEncoderImpl {
 }
 
 impl ValuesDecoder<u64> for ValuesDecoderImpl {
-    fn decode<B, F>(&self, buf: &mut B, mut f: F) -> Result<()>
+    fn decode<B, F>(&self, _ctx: DecodeContext<'_>, buf: &mut B, mut f: F) -> Result<()>
     where
         B: Buf,
         F: FnMut(u64) -> Result<()>,

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -602,6 +602,22 @@ mod tests {
     }
 
     #[test]
+    fn test_massive_string() {
+        let sample_datums = vec![
+            Datum::from("vvvv"),
+            Datum::from("xxxx"),
+            Datum::from("8"),
+            Datum::from("9999"),
+        ];
+        let mut datums = Vec::with_capacity(sample_datums.len() * 100);
+        for _ in 0..100 {
+            datums.append(&mut sample_datums.clone());
+        }
+
+        check_encode_end_decode(10, datums, DatumKind::String);
+    }
+
+    #[test]
     fn test_large_string() {
         let large_string_bytes = vec![
             vec![b'a'; 500],

--- a/components/codec/src/varint.rs
+++ b/components/codec/src/varint.rs
@@ -48,7 +48,7 @@ define_result!(Error);
 //      return PutUvarint(buf, ux)
 // }
 // ```
-pub fn encode_varint<B: SafeBufMut>(buf: &mut B, value: i64) -> Result<()> {
+pub fn encode_varint<B: SafeBufMut>(buf: &mut B, value: i64) -> Result<usize> {
     let mut x = (value as u64) << 1;
     if value < 0 {
         x = !x;
@@ -71,13 +71,15 @@ pub fn encode_varint<B: SafeBufMut>(buf: &mut B, value: i64) -> Result<()> {
 // 	return i + 1
 // }
 // ```
-pub fn encode_uvarint<B: SafeBufMut>(buf: &mut B, mut x: u64) -> Result<()> {
+pub fn encode_uvarint<B: SafeBufMut>(buf: &mut B, mut x: u64) -> Result<usize> {
+    let mut num_bytes = 0;
     while x >= 0x80 {
         buf.try_put_u8(x as u8 | 0x80).context(EncodeVarint)?;
         x >>= 7;
+        num_bytes += 1;
     }
     buf.try_put_u8(x as u8).context(EncodeVarint)?;
-    Ok(())
+    Ok(num_bytes + 1)
 }
 
 // from https://golang.org/src/encoding/binary/varint.go?s=2955:2991#L84


### PR DESCRIPTION
## Rationale
Current encoding of columnar bytes is naive, without any consideration about compression.

## Detailed Changes
Introduce the compression encoding based on a designed threshold for columnar bytes.

## Test Plan
New unit tests.