### PR TITLE
feat: implement compression encoding for columar timestamp values 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "bytes_ext",
  "common_types",
+ "log",
  "lz4_flex",
  "macros",
  "snafu 0.6.10",

--- a/components/codec/Cargo.toml
+++ b/components/codec/Cargo.toml
@@ -28,6 +28,7 @@ workspace = true
 # In alphabetical order
 bytes_ext = { workspace = true }
 common_types = { workspace = true, features = ["test"] }
+log = { workspace = true }
 lz4_flex = { workspace = true }
 macros = { workspace = true }
 snafu = { workspace = true }

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -53,9 +53,9 @@ impl<'a> BufferedReader<'a> {
         let byte = self.get_byte()?;
 
         let bit = if byte & BIT_MASKS[self.bit_idx as usize] == 0 {
-            Bit::Zero
+            Bit(0)
         } else {
-            Bit::One
+            Bit(1)
         };
 
         self.bit_idx += 1;
@@ -105,7 +105,7 @@ impl<'a> BufferedReader<'a> {
 
         while num > 0 {
             self.next_bit()
-                .map(|bit| bits = bits.wrapping_shl(1) | bit.to_u64())?;
+                .map(|bit| bits = bits.wrapping_shl(1) | bit.0 as u64)?;
 
             num -= 1;
         }
@@ -123,23 +123,23 @@ mod tests {
         let bytes = vec![0b01101100, 0b11101001];
         let mut b = BufferedReader::new(&bytes);
 
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
 
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
 
         assert_eq!(b.next_bit().err().unwrap(), Error::Eof);
     }
@@ -155,10 +155,10 @@ mod tests {
 
         // read some individual bits we can test `read_byte` when the position in the
         // byte we are currently reading is non-zero
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
-        assert_eq!(b.next_bit().unwrap(), Bit::One);
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
+        assert_eq!(b.next_bit().unwrap(), Bit(1));
 
         assert_eq!(b.next_byte().unwrap(), 15);
 
@@ -182,7 +182,7 @@ mod tests {
         let bytes = vec![0b01101101, 0b01101101];
         let mut b = BufferedReader::new(&bytes);
 
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
         assert_eq!(b.next_bits(3).unwrap(), 0b110);
         assert_eq!(b.next_byte().unwrap(), 0b11010110);
         assert_eq!(b.next_bits(2).unwrap(), 0b11);

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -1,4 +1,18 @@
-use crate::bits::{Bit, Error, Read};
+// Copyright 2023 The CeresDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::bits::{Bit, Error};
 
 /// BufferedReader
 ///
@@ -25,8 +39,8 @@ impl<'a> BufferedReader<'a> {
     }
 }
 
-impl<'a> Read for BufferedReader<'a> {
-    fn read_bit(&mut self) -> Result<Bit, Error> {
+impl<'a> BufferedReader<'a> {
+    pub fn read_bit(&mut self) -> Result<Bit, Error> {
         if self.pos == 8 {
             self.index += 1;
             self.pos = 0;
@@ -45,7 +59,7 @@ impl<'a> Read for BufferedReader<'a> {
         Ok(bit)
     }
 
-    fn read_byte(&mut self) -> Result<u8, Error> {
+    pub fn read_byte(&mut self) -> Result<u8, Error> {
         if self.pos == 0 {
             self.pos += 8;
             return self.get_byte();
@@ -71,7 +85,7 @@ impl<'a> Read for BufferedReader<'a> {
 
     // example: read_bits(4): read data:u64 0000 0000 0000 000f
     // datastore in low position
-    fn read_bits(&mut self, mut num: u32) -> Result<u64, Error> {
+    pub fn read_bits(&mut self, mut num: u32) -> Result<u64, Error> {
         // can't read more than 64 bits into a u64
         if num > 64 {
             num = 64;
@@ -94,7 +108,8 @@ impl<'a> Read for BufferedReader<'a> {
         Ok(bits)
     }
 
-    fn peak_bits(&mut self, num: u32) -> Result<u64, Error> {
+    #[allow(dead_code)]
+    pub fn peak_bits(&mut self, num: u32) -> Result<u64, Error> {
         // save the current index and pos so we can reset them after calling `read_bits`
         let index = self.index;
         let pos = self.pos;
@@ -110,7 +125,7 @@ impl<'a> Read for BufferedReader<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::bits::{Bit, BufferedReader, Error, Read};
+    use crate::bits::{Bit, BufferedReader, Error};
 
     #[test]
     fn read_bit() {

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -1,0 +1,209 @@
+use crate::bits::{Bit, Error, Read};
+
+/// BufferedReader
+///
+/// BufferedReader encapsulates a buffer of bytes which can be read from.
+#[derive(Debug)]
+pub struct BufferedReader<'a> {
+    bytes: &'a [u8], // internal buffer of bytes
+    index: usize,    // index into bytes
+    pos: u32,        // position in the byte we are currently reading
+}
+
+impl<'a> BufferedReader<'a> {
+    /// new creates a new `BufferedReader` from `bytes`
+    pub fn new(bytes: &'a [u8]) -> Self {
+        BufferedReader {
+            bytes,
+            index: 0,
+            pos: 0,
+        }
+    }
+
+    fn get_byte(&mut self) -> Result<u8, Error> {
+        self.bytes.get(self.index).cloned().ok_or(Error::Eof)
+    }
+}
+
+impl<'a> Read for BufferedReader<'a> {
+    fn read_bit(&mut self) -> Result<Bit, Error> {
+        if self.pos == 8 {
+            self.index += 1;
+            self.pos = 0;
+        }
+
+        let byte = self.get_byte()?;
+
+        let bit = if byte & 1u8.wrapping_shl(7 - self.pos) == 0 {
+            Bit::Zero
+        } else {
+            Bit::One
+        };
+
+        self.pos += 1;
+
+        Ok(bit)
+    }
+
+    fn read_byte(&mut self) -> Result<u8, Error> {
+        if self.pos == 0 {
+            self.pos += 8;
+            return self.get_byte();
+        }
+
+        if self.pos == 8 {
+            self.index += 1;
+            return self.get_byte();
+        }
+
+        let mut byte = 0;
+        let mut b = self.get_byte()?;
+
+        byte |= b.wrapping_shl(self.pos);
+
+        self.index += 1;
+        b = self.get_byte()?;
+
+        byte |= b.wrapping_shr(8 - self.pos);
+
+        Ok(byte)
+    }
+
+    // example: read_bits(4): read data:u64 0000 0000 0000 000f
+    // datastore in low position
+    fn read_bits(&mut self, mut num: u32) -> Result<u64, Error> {
+        // can't read more than 64 bits into a u64
+        if num > 64 {
+            num = 64;
+        }
+
+        let mut bits: u64 = 0;
+        while num >= 8 {
+            let byte = self.read_byte().map(u64::from)?;
+            bits = bits.wrapping_shl(8) | byte;
+            num -= 8;
+        }
+
+        while num > 0 {
+            self.read_bit()
+                .map(|bit| bits = bits.wrapping_shl(1) | bit.to_u64())?;
+
+            num -= 1;
+        }
+
+        Ok(bits)
+    }
+
+    fn peak_bits(&mut self, num: u32) -> Result<u64, Error> {
+        // save the current index and pos so we can reset them after calling `read_bits`
+        let index = self.index;
+        let pos = self.pos;
+
+        let bits = self.read_bits(num)?;
+
+        self.index = index;
+        self.pos = pos;
+
+        Ok(bits)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bits::{Bit, BufferedReader, Error, Read};
+
+    #[test]
+    fn read_bit() {
+        let bytes = vec![0b01101100, 0b11101001];
+        let mut b = BufferedReader::new(&bytes);
+
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+
+        assert_eq!(b.read_bit().err().unwrap(), Error::Eof);
+    }
+
+    #[test]
+    fn read_byte() {
+        let bytes = vec![100, 25, 0, 240, 240];
+        let mut b = BufferedReader::new(&bytes);
+
+        assert_eq!(b.read_byte().unwrap(), 100);
+        assert_eq!(b.read_byte().unwrap(), 25);
+        assert_eq!(b.read_byte().unwrap(), 0);
+
+        // read some individual bits we can test `read_byte` when the position in the
+        // byte we are currently reading is non-zero
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+        assert_eq!(b.read_bit().unwrap(), Bit::One);
+
+        assert_eq!(b.read_byte().unwrap(), 15);
+
+        assert_eq!(b.read_byte().err().unwrap(), Error::Eof);
+    }
+
+    #[test]
+    fn read_bits() {
+        let bytes = vec![0b01010111, 0b00011101, 0b11110101, 0b00010100];
+        let mut b = BufferedReader::new(&bytes);
+
+        assert_eq!(b.read_bits(3).unwrap(), 0b010);
+        assert_eq!(b.read_bits(1).unwrap(), 0b1);
+        assert_eq!(b.read_bits(20).unwrap(), 0b01110001110111110101);
+        assert_eq!(b.read_bits(8).unwrap(), 0b00010100);
+        assert_eq!(b.read_bits(4).err().unwrap(), Error::Eof);
+    }
+
+    #[test]
+    fn read_mixed() {
+        let bytes = vec![0b01101101, 0b01101101];
+        let mut b = BufferedReader::new(&bytes);
+
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bits(3).unwrap(), 0b110);
+        assert_eq!(b.read_byte().unwrap(), 0b11010110);
+        assert_eq!(b.read_bits(2).unwrap(), 0b11);
+        assert_eq!(b.read_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.read_bits(1).unwrap(), 0b1);
+        assert_eq!(b.read_bit().err().unwrap(), Error::Eof);
+    }
+
+    #[test]
+    fn peak_bits() {
+        let bytes = vec![0b01010111, 0b00011101, 0b11110101, 0b00010100];
+        let mut b = BufferedReader::new(&bytes);
+
+        assert_eq!(b.peak_bits(1).unwrap(), 0b0);
+        assert_eq!(b.peak_bits(4).unwrap(), 0b0101);
+        assert_eq!(b.peak_bits(8).unwrap(), 0b01010111);
+        assert_eq!(b.peak_bits(20).unwrap(), 0b01010111000111011111);
+
+        // read some individual bits we can test `peak_bits` when the position in the
+        // byte we are currently reading is non-zero
+        assert_eq!(b.read_bits(12).unwrap(), 0b010101110001);
+
+        assert_eq!(b.peak_bits(1).unwrap(), 0b1);
+        assert_eq!(b.peak_bits(4).unwrap(), 0b1101);
+        assert_eq!(b.peak_bits(8).unwrap(), 0b11011111);
+        assert_eq!(b.peak_bits(20).unwrap(), 0b11011111010100010100);
+
+        assert_eq!(b.peak_bits(22).err().unwrap(), Error::Eof);
+    }
+}

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -186,7 +186,7 @@ mod tests {
         assert_eq!(b.next_bits(3).unwrap(), 0b110);
         assert_eq!(b.next_byte().unwrap(), 0b11010110);
         assert_eq!(b.next_bits(2).unwrap(), 0b11);
-        assert_eq!(b.next_bit().unwrap(), Bit::Zero);
+        assert_eq!(b.next_bit().unwrap(), Bit(0));
         assert_eq!(b.next_bits(1).unwrap(), 0b1);
         assert_eq!(b.next_bit().err().unwrap(), Error::Eof);
     }

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -77,12 +77,18 @@ impl<'a> BufferedReader<'a> {
         }
 
         let mut byte = 0;
-        let mut b = self.get_byte().unwrap();
+        let mut b = match self.get_byte() {
+            None => return None,
+            Some(b) => b,
+        };
 
         byte |= b.wrapping_shl(self.bit_idx);
 
         self.byte_idx += 1;
-        b = self.get_byte().unwrap();
+        b = match self.get_byte() {
+            None => return None,
+            Some(b) => b,
+        };
 
         byte |= b.wrapping_shr(8 - self.bit_idx);
 

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -14,7 +14,7 @@
 
 use crate::bits::{Bit, Error};
 
-const BIT_MASKS: [u8; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
+const BIT_MASKS: [u8; 8] = [128, 64, 32, 16, 8, 4, 2, 1];
 
 /// BufferedReader
 /// BufferedReader encapsulates a buffer of bytes which can be read from.

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -82,7 +82,7 @@ impl<'a> BufferedReader<'a> {
             Some(b) => b,
         };
 
-        byte |= b.wrapping_shl(self.bit_idx);
+        byte |= b << self.bit_idx;
 
         self.byte_idx += 1;
         b = match self.get_byte() {
@@ -90,7 +90,7 @@ impl<'a> BufferedReader<'a> {
             Some(b) => b,
         };
 
-        byte |= b.wrapping_shr(8 - self.bit_idx);
+        byte |= b >> 8 - self.bit_idx;
 
         Some(byte)
     }
@@ -107,13 +107,12 @@ impl<'a> BufferedReader<'a> {
         let mut bits: u64 = 0;
         while num >= 8 {
             let byte = self.next_byte().map(u64::from)?;
-            bits = bits.wrapping_shl(8) | byte;
+            bits = bits << 8 | byte;
             num -= 8;
         }
 
         while num > 0 {
-            self.next_bit()
-                .map(|bit| bits = bits.wrapping_shl(1) | bit.0 as u64)?;
+            self.next_bit().map(|bit| bits = bits << 1 | bit.0 as u64)?;
 
             num -= 1;
         }

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -105,6 +105,7 @@ impl<'a> BufferedReader<'a> {
         assert!(num <= 64);
 
         let mut bits: u64 = 0;
+
         while num >= 8 {
             let byte = self.next_byte().map(u64::from)?;
             bits = bits << 8 | byte;

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::bits::{Bit, Error};
-
-const BIT_MASKS: [u8; 8] = [128, 64, 32, 16, 8, 4, 2, 1];
+use crate::bits::{Bit, Error, BIT_MASKS};
 
 /// BufferedReader
 /// BufferedReader encapsulates a buffer of bytes which can be read from.

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -112,20 +112,6 @@ impl<'a> BufferedReader<'a> {
 
         Ok(bits)
     }
-
-    #[allow(dead_code)]
-    pub fn peak_bits(&mut self, num: u32) -> Result<u64, Error> {
-        // save the current index and pos so we can reset them after calling `read_bits`
-        let index = self.byte_idx;
-        let pos = self.bit_idx;
-
-        let bits = self.next_bits(num)?;
-
-        self.byte_idx = index;
-        self.bit_idx = pos;
-
-        Ok(bits)
-    }
 }
 
 #[cfg(test)]
@@ -203,27 +189,5 @@ mod tests {
         assert_eq!(b.next_bit().unwrap(), Bit::Zero);
         assert_eq!(b.next_bits(1).unwrap(), 0b1);
         assert_eq!(b.next_bit().err().unwrap(), Error::Eof);
-    }
-
-    #[test]
-    fn peak_bits() {
-        let bytes = vec![0b01010111, 0b00011101, 0b11110101, 0b00010100];
-        let mut b = BufferedReader::new(&bytes);
-
-        assert_eq!(b.peak_bits(1).unwrap(), 0b0);
-        assert_eq!(b.peak_bits(4).unwrap(), 0b0101);
-        assert_eq!(b.peak_bits(8).unwrap(), 0b01010111);
-        assert_eq!(b.peak_bits(20).unwrap(), 0b01010111000111011111);
-
-        // read some individual bits we can test `peak_bits` when the position in the
-        // byte we are currently reading is non-zero
-        assert_eq!(b.next_bits(12).unwrap(), 0b010101110001);
-
-        assert_eq!(b.peak_bits(1).unwrap(), 0b1);
-        assert_eq!(b.peak_bits(4).unwrap(), 0b1101);
-        assert_eq!(b.peak_bits(8).unwrap(), 0b11011111);
-        assert_eq!(b.peak_bits(20).unwrap(), 0b11011111010100010100);
-
-        assert_eq!(b.peak_bits(22).err().unwrap(), Error::Eof);
     }
 }

--- a/components/codec/src/bits/buffered_read.rs
+++ b/components/codec/src/bits/buffered_read.rs
@@ -90,7 +90,7 @@ impl<'a> BufferedReader<'a> {
             Some(b) => b,
         };
 
-        byte |= b >> 8 - self.bit_idx;
+        byte |= b >> (8 - self.bit_idx);
 
         Some(byte)
     }

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -1,6 +1,20 @@
+// Copyright 2023 The CeresDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::boxed::Box;
 
-use crate::bits::{Bit, Write};
+use crate::bits::Bit;
 
 /// BufferedWriter
 ///
@@ -12,6 +26,7 @@ pub struct BufferedWriter {
 }
 
 impl BufferedWriter {
+    #[allow(dead_code)]
     /// new creates a new BufferedWriter
     pub fn new() -> Self {
         BufferedWriter {
@@ -29,6 +44,7 @@ impl BufferedWriter {
         }
     }
 
+    #[allow(dead_code)]
     pub fn with_buf(buf: Vec<u8>) -> Self {
         BufferedWriter {
             buf,
@@ -46,8 +62,8 @@ impl BufferedWriter {
     }
 }
 
-impl Write for BufferedWriter {
-    fn write_bit(&mut self, bit: Bit) {
+impl BufferedWriter {
+    pub fn write_bit(&mut self, bit: Bit) {
         if self.pos == 8 {
             self.grow();
             self.pos = 0;
@@ -63,7 +79,7 @@ impl Write for BufferedWriter {
         self.pos += 1;
     }
 
-    fn write_byte(&mut self, byte: u8) {
+    pub fn write_byte(&mut self, byte: u8) {
         if self.pos == 8 {
             self.grow();
 
@@ -83,7 +99,7 @@ impl Write for BufferedWriter {
     }
 
     // example: wtire_bits(4): data(u64 0000 0000 0000 00ff), write data 1111
-    fn write_bits(&mut self, mut bits: u64, mut num: u32) {
+    pub fn write_bits(&mut self, mut bits: u64, mut num: u32) {
         // we should never write more than 64 bits for a u64
         if num > 64 {
             num = 64;
@@ -111,11 +127,12 @@ impl Write for BufferedWriter {
         }
     }
 
-    fn close(self) -> Box<[u8]> {
+    pub fn close(self) -> Box<[u8]> {
         self.buf.into_boxed_slice()
     }
 
-    fn len(&self) -> usize {
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
         self.buf.len()
     }
 }
@@ -123,7 +140,7 @@ impl Write for BufferedWriter {
 #[cfg(test)]
 mod tests {
     use super::BufferedWriter;
-    use crate::bits::{Bit, Write};
+    use crate::bits::Bit;
 
     #[test]
     fn write_bit() {

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -1,0 +1,262 @@
+use std::boxed::Box;
+
+use crate::bits::{Bit, Write};
+
+/// BufferedWriter
+///
+/// BufferedWriter writes bytes to a buffer.
+#[derive(Debug, Default, Clone)]
+pub struct BufferedWriter {
+    buf: Vec<u8>,
+    pos: u32, // position in the last byte in the buffer
+}
+
+impl BufferedWriter {
+    /// new creates a new BufferedWriter
+    pub fn new() -> Self {
+        BufferedWriter {
+            buf: Vec::new(),
+            // set pos to 8 to indicate the buffer has no space presently since it is empty
+            pos: 8,
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        BufferedWriter {
+            buf: Vec::with_capacity(capacity),
+            // set pos to 8 to indicate the buffer has no space presently since it is empty
+            pos: 8,
+        }
+    }
+
+    pub fn with_buf(buf: Vec<u8>) -> Self {
+        BufferedWriter {
+            buf,
+            // set pos to 8 to indicate the buffer has no space presently since it is empty
+            pos: 8,
+        }
+    }
+
+    fn grow(&mut self) {
+        self.buf.push(0);
+    }
+
+    fn last_index(&self) -> usize {
+        self.buf.len() - 1
+    }
+}
+
+impl Write for BufferedWriter {
+    fn write_bit(&mut self, bit: Bit) {
+        if self.pos == 8 {
+            self.grow();
+            self.pos = 0;
+        }
+
+        let i = self.last_index();
+
+        match bit {
+            Bit::Zero => (),
+            Bit::One => self.buf[i] |= 1u8.wrapping_shl(7 - self.pos),
+        };
+
+        self.pos += 1;
+    }
+
+    fn write_byte(&mut self, byte: u8) {
+        if self.pos == 8 {
+            self.grow();
+
+            let i = self.last_index();
+            self.buf[i] = byte;
+            return;
+        }
+
+        let i = self.last_index();
+        let mut b = byte.wrapping_shr(self.pos);
+        self.buf[i] |= b;
+
+        self.grow();
+
+        b = byte.wrapping_shl(8 - self.pos);
+        self.buf[i + 1] |= b;
+    }
+
+    // example: wtire_bits(4): data(u64 0000 0000 0000 00ff), write data 1111
+    fn write_bits(&mut self, mut bits: u64, mut num: u32) {
+        // we should never write more than 64 bits for a u64
+        if num > 64 {
+            num = 64;
+        }
+
+        bits = bits.wrapping_shl(64 - num);
+        while num >= 8 {
+            let byte = bits.wrapping_shr(56);
+            self.write_byte(byte as u8);
+
+            bits = bits.wrapping_shl(8);
+            num -= 8;
+        }
+
+        while num > 0 {
+            let byte = bits.wrapping_shr(63);
+            if byte == 1 {
+                self.write_bit(Bit::One);
+            } else {
+                self.write_bit(Bit::Zero);
+            }
+
+            bits = bits.wrapping_shl(1);
+            num -= 1;
+        }
+    }
+
+    fn close(self) -> Box<[u8]> {
+        self.buf.into_boxed_slice()
+    }
+
+    fn len(&self) -> usize {
+        self.buf.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BufferedWriter;
+    use crate::bits::{Bit, Write};
+
+    #[test]
+    fn write_bit() {
+        let mut b = BufferedWriter::new();
+
+        // 170 = 0b10101010
+        for i in 0..8 {
+            if i % 2 == 0 {
+                b.write_bit(Bit::One);
+                continue;
+            }
+
+            b.write_bit(Bit::Zero);
+        }
+
+        // 146 = 0b10010010
+        for i in 0..8 {
+            if i % 3 == 0 {
+                b.write_bit(Bit::One);
+                continue;
+            }
+
+            b.write_bit(Bit::Zero);
+        }
+
+        // 136 = 010001000
+        for i in 0..8 {
+            if i % 4 == 0 {
+                b.write_bit(Bit::One);
+                continue;
+            }
+
+            b.write_bit(Bit::Zero);
+        }
+
+        assert_eq!(b.buf.len(), 3);
+
+        assert_eq!(b.buf[0], 170);
+        assert_eq!(b.buf[1], 146);
+        assert_eq!(b.buf[2], 136);
+    }
+
+    #[test]
+    fn write_byte() {
+        let mut b = BufferedWriter::new();
+
+        b.write_byte(234);
+        b.write_byte(188);
+        b.write_byte(77);
+
+        assert_eq!(b.buf.len(), 3);
+
+        assert_eq!(b.buf[0], 234);
+        assert_eq!(b.buf[1], 188);
+        assert_eq!(b.buf[2], 77);
+
+        // write some bits so we can test `write_byte` when the last byte is partially
+        // filled
+        b.write_bit(Bit::One);
+        b.write_bit(Bit::One);
+        b.write_bit(Bit::One);
+        b.write_bit(Bit::One);
+        b.write_byte(0b11110000); // 1111 1111 0000
+        b.write_byte(0b00001111); // 1111 1111 0000 0000 1111
+        b.write_byte(0b00001111); // 1111 1111 0000 0000 1111 0000 1111
+
+        assert_eq!(b.buf.len(), 7);
+        assert_eq!(b.buf[3], 255); // 0b11111111 = 255
+        assert_eq!(b.buf[4], 0); // 0b00000000 = 0
+        assert_eq!(b.buf[5], 240); // 0b11110000 = 240
+    }
+
+    #[test]
+    fn write_bits() {
+        let mut b = BufferedWriter::new();
+
+        // 101011
+        b.write_bits(43, 6);
+
+        // 010
+        b.write_bits(2, 3);
+
+        // 1
+        b.write_bits(1, 1);
+
+        // 1010 1100 1110 0011 1101
+        b.write_bits(708157, 20);
+
+        // 11
+        b.write_bits(3, 2);
+
+        assert_eq!(b.buf.len(), 4);
+
+        assert_eq!(b.buf[0], 173); // 0b10101101 = 173
+        assert_eq!(b.buf[1], 107); // 0b01101011 = 107
+        assert_eq!(b.buf[2], 56); // 0b00111000 = 56
+        assert_eq!(b.buf[3], 247); // 0b11110111 = 247
+    }
+
+    #[test]
+    fn write_mixed() {
+        let mut b = BufferedWriter::new();
+
+        // 1010 1010
+        for i in 0..8 {
+            if i % 2 == 0 {
+                b.write_bit(Bit::One);
+                continue;
+            }
+
+            b.write_bit(Bit::Zero);
+        }
+
+        // 0000 1001
+        b.write_byte(9);
+
+        // 1001 1100 1100
+        b.write_bits(2508, 12);
+
+        println!("{:?}", b.buf);
+
+        // 1111
+        for _ in 0..4 {
+            b.write_bit(Bit::One);
+        }
+
+        assert_eq!(b.buf.len(), 4);
+
+        println!("{:?}", b.buf);
+
+        assert_eq!(b.buf[0], 170); // 0b10101010 = 170
+        assert_eq!(b.buf[1], 9); // 0b00001001 = 9
+        assert_eq!(b.buf[2], 156); // 0b10011100 = 156
+        assert_eq!(b.buf[3], 207); // 0b11001111 = 207
+    }
+}

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -92,11 +92,9 @@ impl BufferedWriter {
     // example: wtire_bits(4): data(u64 0000 0000 0000 00ff), write data 1111
     pub fn write_bits(&mut self, mut bits: u64, mut num: u32) {
         // we should never write more than 64 bits for a u64
-        if num > 64 {
-            num = 64;
-        }
+        assert!(num <= 64);
 
-        bits <<= (64 - num);
+        bits <<= 64 - num;
         while num >= 8 {
             let byte = bits >> 56;
             self.write_byte(byte as u8);

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -14,7 +14,7 @@
 
 use std::boxed::Box;
 
-use crate::bits::Bit;
+use crate::bits::{Bit, BIT_MASKS};
 
 /// BufferedWriter
 /// BufferedWriter writes bytes to a buffer.
@@ -64,7 +64,7 @@ impl BufferedWriter {
         let i = self.last_index();
 
         if bit != Bit(0) {
-            self.buf[i] |= 1u8.wrapping_shl(7 - self.pos);
+            self.buf[i] |= BIT_MASKS[self.pos as usize];
         }
 
         self.pos += 1;

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -96,7 +96,7 @@ impl BufferedWriter {
             num = 64;
         }
 
-        bits = bits << (64 - num);
+        bits <<= (64 - num);
         while num >= 8 {
             let byte = bits >> 56;
             self.write_byte(byte as u8);

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -17,7 +17,6 @@ use std::boxed::Box;
 use crate::bits::Bit;
 
 /// BufferedWriter
-///
 /// BufferedWriter writes bytes to a buffer.
 #[derive(Debug, Default, Clone)]
 pub struct BufferedWriter {
@@ -58,6 +57,9 @@ impl BufferedWriter {
     }
 
     fn last_index(&self) -> usize {
+        if self.buf.len() == 0 {
+            return 0;
+        }
         self.buf.len() - 1
     }
 }

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -47,7 +47,7 @@ impl BufferedWriter {
     }
 
     fn last_index(&self) -> usize {
-        if self.buf.len() == 0 {
+        if self.buf.is_empty() {
             return 0;
         }
         self.buf.len() - 1

--- a/components/codec/src/bits/buffered_write.rs
+++ b/components/codec/src/bits/buffered_write.rs
@@ -80,12 +80,12 @@ impl BufferedWriter {
         }
 
         let i = self.last_index();
-        let mut b = byte.wrapping_shr(self.pos);
+        let mut b = byte >> self.pos;
         self.buf[i] |= b;
 
         self.grow();
 
-        b = byte.wrapping_shl(8 - self.pos);
+        b = byte << (8 - self.pos);
         self.buf[i + 1] |= b;
     }
 
@@ -96,24 +96,24 @@ impl BufferedWriter {
             num = 64;
         }
 
-        bits = bits.wrapping_shl(64 - num);
+        bits = bits << (64 - num);
         while num >= 8 {
-            let byte = bits.wrapping_shr(56);
+            let byte = bits >> 56;
             self.write_byte(byte as u8);
 
-            bits = bits.wrapping_shl(8);
+            bits <<= 8;
             num -= 8;
         }
 
         while num > 0 {
-            let byte = bits.wrapping_shr(63);
+            let byte = bits >> 63;
             if byte == 1 {
                 self.write_bit(Bit(1));
             } else {
                 self.write_bit(Bit(0));
             }
 
-            bits = bits.wrapping_shl(1);
+            bits <<= 1;
             num -= 1;
         }
     }

--- a/components/codec/src/bits/mod.rs
+++ b/components/codec/src/bits/mod.rs
@@ -15,22 +15,11 @@
 use std::{error, fmt};
 
 /// Bit
-/// An enum used to represent a single bit, can be either `Zero` or `One`.
+/// An u8 struct used to represent a single bit,
+/// when it is equal to zero, it represents bit zero, otherwise it represents
+/// bit one.
 #[derive(Debug, PartialEq)]
-pub enum Bit {
-    Zero,
-    One,
-}
-
-impl Bit {
-    /// Convert a bit to u64, so `Zero` becomes 0 and `One` becomes 1.
-    pub fn to_u64(&self) -> u64 {
-        match self {
-            Bit::Zero => 0,
-            Bit::One => 1,
-        }
-    }
-}
+pub struct Bit(pub u8);
 
 /// Error
 /// Enum used to represent potential errors when interacting with a stream.

--- a/components/codec/src/bits/mod.rs
+++ b/components/codec/src/bits/mod.rs
@@ -1,0 +1,90 @@
+use std::{error, fmt};
+
+/// Bit
+///
+/// An enum used to represent a single bit, can be either `Zero` or `One`.
+#[derive(Debug, PartialEq)]
+pub enum Bit {
+    Zero,
+    One,
+}
+
+impl Bit {
+    /// Convert a bit to u64, so `Zero` becomes 0 and `One` becomes 1.
+    pub fn to_u64(&self) -> u64 {
+        match self {
+            Bit::Zero => 0,
+            Bit::One => 1,
+        }
+    }
+}
+
+/// Error
+///
+/// Enum used to represent potential errors when interacting with a stream.
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    Eof,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Eof => write!(f, "Encountered the end of the stream"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Eof => "Encountered the end of the stream",
+        }
+    }
+}
+
+/// Read
+///
+/// Read is a trait that encapsulates the functionality required to read from a
+/// stream of bytes.
+pub trait Read {
+    /// Read a single bit from the underlying stream.
+    fn read_bit(&mut self) -> Result<Bit, Error>;
+
+    /// Read a single byte from the underlying stream.
+    fn read_byte(&mut self) -> Result<u8, Error>;
+
+    /// Read `num` bits from the underlying stream.
+    fn read_bits(&mut self, num: u32) -> Result<u64, Error>;
+
+    /// Get the next `num` bits, but do not update place in stream.
+    fn peak_bits(&mut self, num: u32) -> Result<u64, Error>;
+}
+
+/// Write
+///
+/// Write is a trait that encapsulates the functionality required to write a
+/// stream of bytes.
+pub trait Write {
+    // Write a single bit to the underlying stream.
+    fn write_bit(&mut self, bit: Bit);
+
+    // Write a single byte to the underlying stream.
+    fn write_byte(&mut self, byte: u8);
+
+    // Write the bottom `num` bits of `bits` to the underlying stream.
+    fn write_bits(&mut self, bits: u64, num: u32);
+
+    // Close the underlying stream and return a pointer to the array of bytes.
+    fn close(self) -> Box<[u8]>;
+
+    fn len(&self) -> usize;
+}
+
+pub mod buffered_write;
+
+pub use self::buffered_write::BufferedWriter;
+
+pub mod buffered_read;
+
+pub use self::buffered_read::BufferedReader;

--- a/components/codec/src/bits/mod.rs
+++ b/components/codec/src/bits/mod.rs
@@ -14,6 +14,8 @@
 
 use std::{error, fmt};
 
+const BIT_MASKS: [u8; 8] = [128, 64, 32, 16, 8, 4, 2, 1];
+
 /// Bit
 /// An u8 struct used to represent a single bit,
 /// when it is equal to zero, it represents bit zero, otherwise it represents

--- a/components/codec/src/bits/mod.rs
+++ b/components/codec/src/bits/mod.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 The CeresDB Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::{error, fmt};
 
 /// Bit
@@ -41,44 +55,6 @@ impl error::Error for Error {
             Error::Eof => "Encountered the end of the stream",
         }
     }
-}
-
-/// Read
-///
-/// Read is a trait that encapsulates the functionality required to read from a
-/// stream of bytes.
-pub trait Read {
-    /// Read a single bit from the underlying stream.
-    fn read_bit(&mut self) -> Result<Bit, Error>;
-
-    /// Read a single byte from the underlying stream.
-    fn read_byte(&mut self) -> Result<u8, Error>;
-
-    /// Read `num` bits from the underlying stream.
-    fn read_bits(&mut self, num: u32) -> Result<u64, Error>;
-
-    /// Get the next `num` bits, but do not update place in stream.
-    fn peak_bits(&mut self, num: u32) -> Result<u64, Error>;
-}
-
-/// Write
-///
-/// Write is a trait that encapsulates the functionality required to write a
-/// stream of bytes.
-pub trait Write {
-    // Write a single bit to the underlying stream.
-    fn write_bit(&mut self, bit: Bit);
-
-    // Write a single byte to the underlying stream.
-    fn write_byte(&mut self, byte: u8);
-
-    // Write the bottom `num` bits of `bits` to the underlying stream.
-    fn write_bits(&mut self, bits: u64, num: u32);
-
-    // Close the underlying stream and return a pointer to the array of bytes.
-    fn close(self) -> Box<[u8]>;
-
-    fn len(&self) -> usize;
 }
 
 pub mod buffered_write;

--- a/components/codec/src/bits/mod.rs
+++ b/components/codec/src/bits/mod.rs
@@ -15,7 +15,6 @@
 use std::{error, fmt};
 
 /// Bit
-///
 /// An enum used to represent a single bit, can be either `Zero` or `One`.
 #[derive(Debug, PartialEq)]
 pub enum Bit {
@@ -34,7 +33,6 @@ impl Bit {
 }
 
 /// Error
-///
 /// Enum used to represent potential errors when interacting with a stream.
 #[derive(Debug, PartialEq)]
 pub enum Error {

--- a/components/codec/src/bits/mod.rs
+++ b/components/codec/src/bits/mod.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{error, fmt};
-
 const BIT_MASKS: [u8; 8] = [128, 64, 32, 16, 8, 4, 2, 1];
 
 /// Bit
@@ -22,29 +20,6 @@ const BIT_MASKS: [u8; 8] = [128, 64, 32, 16, 8, 4, 2, 1];
 /// bit one.
 #[derive(Debug, PartialEq)]
 pub struct Bit(pub u8);
-
-/// Error
-/// Enum used to represent potential errors when interacting with a stream.
-#[derive(Debug, PartialEq)]
-pub enum Error {
-    Eof,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Eof => write!(f, "Encountered the end of the stream"),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Eof => "Encountered the end of the stream",
-        }
-    }
-}
 
 pub mod buffered_write;
 

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -88,6 +88,9 @@ pub enum Error {
 
     #[snafu(display("Bytes is not enough, length:{len}.\nBacktrace:\n{backtrace}"))]
     NotEnoughBytes { len: usize, backtrace: Backtrace },
+
+    #[snafu(display("Failed to read encoded data, err:{source}"))]
+    ReadEncode { source: crate::bits::Error },
 }
 
 define_result!(Error);
@@ -744,5 +747,41 @@ mod tests {
             .collect();
 
         check_encode_end_decode(10, datums, DatumKind::String);
+    }
+
+    #[test]
+    fn test_timestamp() {
+        let one_timestamp = vec![Datum::Timestamp(Timestamp::new(1000i64))];
+        check_encode_end_decode(10, one_timestamp, DatumKind::Timestamp);
+
+        let two_timestamp = vec![
+            Datum::Timestamp(Timestamp::new(1000i64)),
+            Datum::Timestamp(Timestamp::new(1050i64)),
+        ];
+        check_encode_end_decode(10, two_timestamp, DatumKind::Timestamp);
+
+        let sample_timestamp = vec![
+            Datum::Timestamp(Timestamp::new(1000i64)),
+            Datum::Timestamp(Timestamp::new(1010i64)),
+            Datum::Timestamp(Timestamp::new(1020i64)),
+            Datum::Timestamp(Timestamp::new(1090i64)),
+        ];
+        check_encode_end_decode(10, sample_timestamp, DatumKind::Timestamp);
+
+        let decreasing_timestamp = vec![
+            Datum::Timestamp(Timestamp::new(1000i64)),
+            Datum::Timestamp(Timestamp::new(950i64)),
+            Datum::Timestamp(Timestamp::new(900i64)),
+        ];
+        check_encode_end_decode(10, decreasing_timestamp, DatumKind::Timestamp);
+
+        let complex_timestamp = vec![
+            Datum::Timestamp(Timestamp::new(1692845701000)),
+            Datum::Timestamp(Timestamp::new(1692845702000)),
+            Datum::Timestamp(Timestamp::new(1692845730000)),
+            Datum::Timestamp(Timestamp::new(1692845760000)),
+            Datum::Timestamp(Timestamp::new(1692845860000)),
+        ];
+        check_encode_end_decode(10, complex_timestamp, DatumKind::Timestamp);
     }
 }

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -793,5 +793,19 @@ mod tests {
             Datum::Timestamp(Timestamp::new(1692845730000)),
         ];
         check_encode_end_decode(10, fallback_two_timestamp, DatumKind::Timestamp);
+
+        let negative_timestamp = vec![
+            Datum::Timestamp(Timestamp::new(-1692845730000)),
+            Datum::Timestamp(Timestamp::new(0)),
+            Datum::Timestamp(Timestamp::new(1692845730000)),
+        ];
+        check_encode_end_decode(10, negative_timestamp, DatumKind::Timestamp);
+
+        let negative_overflow_timestamp = vec![
+            Datum::Timestamp(Timestamp::new(-1692845730000)),
+            Datum::Timestamp(Timestamp::new(1692945730000)),
+            Datum::Timestamp(Timestamp::new(0)),
+        ];
+        check_encode_end_decode(10, negative_overflow_timestamp, DatumKind::Timestamp);
     }
 }

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -802,9 +802,9 @@ mod tests {
         check_encode_end_decode(10, negative_timestamp, DatumKind::Timestamp);
 
         let negative_overflow_timestamp = vec![
-            Datum::Timestamp(Timestamp::new(-1692845730000)),
             Datum::Timestamp(Timestamp::new(1692945730000)),
-            Datum::Timestamp(Timestamp::new(0)),
+            Datum::Timestamp(Timestamp::new(1692945730000)),
+            Datum::Timestamp(Timestamp::new(4692945730000)),
         ];
         check_encode_end_decode(10, negative_overflow_timestamp, DatumKind::Timestamp);
     }

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -89,8 +89,8 @@ pub enum Error {
     #[snafu(display("Bytes is not enough, length:{len}.\nBacktrace:\n{backtrace}"))]
     NotEnoughBytes { len: usize, backtrace: Backtrace },
 
-    #[snafu(display("Failed to read encoded data"))]
-    ReadEncode {},
+    #[snafu(display("Failed to read encoded data.\nBacktrace:\n{backtrace}"))]
+    ReadEncode { backtrace: Backtrace },
 }
 
 define_result!(Error);

--- a/components/codec/src/columnar/timestamp.rs
+++ b/components/codec/src/columnar/timestamp.rs
@@ -11,3 +11,99 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use bytes_ext::{Buf, BufMut, SafeBufMut};
+
+use crate::columnar::{Result, ValuesDecoder, ValuesEncoder};
+
+pub struct TimestampValuesEncoder;
+
+// Encode the timestamp using the delta-of-delta algorithm
+impl ValuesEncoder<i64> for TimestampValuesEncoder {
+    //
+    fn encode<B, I>(&self, buf: &mut B, values: I) -> Result<()>
+    where
+        B: BufMut,
+        I: Iterator<Item = i64>,
+    {
+        // let firstTs = match values.find_or_first() {
+        //     Some(a) => a,
+        //     None() => Err(),
+        // };
+
+        let mut last_ts: i64 = 0;
+        let mut last_delta: i64 = 0;
+        for v in values {
+            let cur_delta = v - last_ts;
+            let delta_of_delta = cur_delta - last_delta;
+            let encode_result = encode_delta_of_delta(delta_of_delta);
+            last_delta = cur_delta;
+        }
+
+        Ok(())
+    }
+
+    fn estimated_encoded_size<I>(&self, values: I) -> usize
+    where
+        I: Iterator<Item = i64>,
+    {
+        let (lower, higher) = values.size_hint();
+        let num = lower.max(higher.unwrap_or_default());
+        num
+    }
+}
+
+const DELTA_MAST_7: i32 = 0x02 << 7;
+
+// TODO: delta_of_delta bigger than i32?
+fn encode_delta_of_delta(dod: i64) -> u32 {
+    // let bit_required = 32 - std::num::NonZeroI32::new(dod -
+    // 1).unwrap().leading_zeros();
+
+    return if dod == 0 {
+        0b0
+    } else if dod >= -63 && dod <= 64 {
+        0b10 << 7 + dod
+    } else if dod >= -255 && dod <= 256 {
+        0b110 << 9 + dod
+    } else if dod >= -2047 && dod <= 2048 {
+        0b1110 << 12 + dod
+    } else {
+        0b1111 << 32 + dod
+    };
+}
+
+// fn compress_encode_results(results: &[i64], buf: &mut B) -> Result<()> {
+//     todo!()
+// }
+
+#[test]
+fn test_delta_of_delta_encode() {
+    assert!(0, encode_delta_of_delta(0));
+    assert!(0, encode_delta_of_delta(10));
+    assert!(0, encode_delta_of_delta(-10));
+    assert!(0, encode_delta_of_delta(64));
+    assert!(0, encode_delta_of_delta(-64));
+    assert!(0, encode_delta_of_delta(256));
+    assert!(0, encode_delta_of_delta(-256));
+    assert!(0, encode_delta_of_delta(2048));
+    assert!(0, encode_delta_of_delta(-2048));
+    assert!(0, encode_delta_of_delta(5000));
+}
+
+#[test]
+fn test_delta_of_delta_decode() {
+    todo!()
+}
+
+pub struct TimestampValuesDecoder;
+
+impl ValuesDecoder<i64> for TimestampValuesDecoder {
+    fn decode<B, F>(&self, buf: &mut B, mut f: F) -> Result<()>
+    where
+        B: Buf,
+        F: FnMut(i64) -> Result<()>,
+    {
+        todo!()
+    }
+}

--- a/components/codec/src/columnar/timestamp.rs
+++ b/components/codec/src/columnar/timestamp.rs
@@ -12,98 +12,268 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes_ext::{Buf, BufMut, SafeBufMut};
+use bytes_ext::{Buf, BufMut};
+use common_types::time::Timestamp;
+use snafu::{ensure, ResultExt};
 
-use crate::columnar::{Result, ValuesDecoder, ValuesEncoder};
+use crate::{
+    bits::{Bit, BufferedReader, BufferedWriter},
+    columnar::{
+        DecodeContext, InvalidVersion, NotEnoughDatums, ReadEncode, Result, ValuesDecoder,
+        ValuesDecoderImpl, ValuesEncoder, ValuesEncoderImpl,
+    },
+};
 
-pub struct TimestampValuesEncoder;
+/// We use delta-of-delta algorithm to compress timestamp, for details, please refer to this paper http://www.vldb.org/pvldb/vol8/p1816-teller.pdf
+/// The layout for the timestamp:
+/// ```plaintext
+/// +--------------+------------------------+-------------------+--------------------------+------------------+------------------+
+/// | version(u8) | first_timestamp(64bits) | control_bit(1bit) | delta_of_delta(1~36bits) | delta_of_delta...| end_mast(36bits) |
+/// +-------------+-------------------------+-------------------+--------------------------+------------------+------------------+
+
+const ENCODE_VERSION: u8 = 1;
+const NUM_BYTES_ENCODE_VERSION_LEN: usize = 1;
+
+/// The max number of the bytes used to store a delta of delta encoding of
+/// first timestamp.
+const NUM_BYTES_OF_FIRST_TS_ENCODE: usize = 8;
+
+/// The max number of the bytes used to store a delta of delta encoding of
+/// dod result.
+const MAX_NUM_BYTES_OF_DOD_ENCODE: usize = 5;
+
+/// END_MARKER is a special bit sequence used to indicate the end of the
+/// stream
+const END_MARKER: u64 = 0b1111_0000_0000_0000_0000_0000_0000_0000_0000;
+/// END_MARKER_LEN is the length, in bits, of END_MARKER
+const NUM_BITS_END_MARKER_LEN: usize = 36;
+const NUM_BYTES_END_MARKER_LEN: usize = 5;
 
 // Encode the timestamp using the delta-of-delta algorithm
-impl ValuesEncoder<i64> for TimestampValuesEncoder {
-    //
-    fn encode<B, I>(&self, buf: &mut B, values: I) -> Result<()>
+struct TimestampEncoder {}
+
+struct TimestampDecoder {}
+
+enum DeltaOfDeltaEncodeMasks {
+    ZeroEncode(),
+    NormalEncode(u8, u8, u8),
+}
+
+impl TimestampEncoder {
+    fn encode_delta_of_delta_masks(dod: i64) -> DeltaOfDeltaEncodeMasks {
+        // max support 2^31/3600/1000/24/2=12 day
+        assert!(dod <= std::i32::MAX as i64);
+        let dod = dod as i32;
+
+        // store the delta of delta using variable length encoding
+        match dod {
+            0 => DeltaOfDeltaEncodeMasks::ZeroEncode(),
+            -63..=64 => DeltaOfDeltaEncodeMasks::NormalEncode(0b10, 2, 7),
+            -255..=256 => DeltaOfDeltaEncodeMasks::NormalEncode(0b110, 3, 9),
+            -2047..=2048 => DeltaOfDeltaEncodeMasks::NormalEncode(0b1110, 4, 12),
+            _ => DeltaOfDeltaEncodeMasks::NormalEncode(0b1111, 4, 32),
+        }
+    }
+
+    pub fn encode<B, I>(buf: &mut B, values: I) -> Result<()>
     where
         B: BufMut,
         I: Iterator<Item = i64>,
     {
-        // let firstTs = match values.find_or_first() {
-        //     Some(a) => a,
-        //     None() => Err(),
-        // };
+        let (lower, higher) = values.size_hint();
+        let num = lower.max(higher.unwrap_or_default());
+        ensure!(
+            num >= 1,
+            NotEnoughDatums {
+                expect: 1usize,
+                found: 0usize
+            }
+        );
 
+        let mut writer = BufferedWriter::with_capacity(0);
+
+        // write version
+        writer.write_bits(
+            ENCODE_VERSION as u64,
+            (8 * NUM_BYTES_ENCODE_VERSION_LEN) as u32,
+        );
+
+        let mut first = true;
+        let mut control_bit_flag = true;
         let mut last_ts: i64 = 0;
         let mut last_delta: i64 = 0;
         for v in values {
+            if first {
+                // store the first timestamp exactly
+                writer.write_bits(v as u64, 64);
+                first = false;
+                last_ts = v;
+                continue;
+            }
+            if !first && control_bit_flag {
+                // remove according to the paper
+                // // write one control bit so we can distinguish a stream which contains only
+                // an initial // timestamp, this assumes the first bit of the
+                // END_MARKER is 1
+                writer.write_bit(Bit::One);
+                control_bit_flag = false;
+            }
             let cur_delta = v - last_ts;
             let delta_of_delta = cur_delta - last_delta;
-            let encode_result = encode_delta_of_delta(delta_of_delta);
+            match TimestampEncoder::encode_delta_of_delta_masks(delta_of_delta) {
+                DeltaOfDeltaEncodeMasks::ZeroEncode() => writer.write_bit(Bit::Zero),
+                DeltaOfDeltaEncodeMasks::NormalEncode(
+                    control_bis,
+                    control_bits_len,
+                    dod_bits_len,
+                ) => {
+                    writer.write_bits(control_bis as u64, control_bits_len as u32);
+                    writer.write_bits(delta_of_delta as u64, dod_bits_len as u32);
+                }
+            };
             last_delta = cur_delta;
+            last_ts = v;
         }
 
+        // write control bit when only the first timestamp exists
+        if control_bit_flag {
+            writer.write_bit(Bit::Zero);
+        }
+        // write end mask
+        if !first {
+            writer.write_bits(END_MARKER, NUM_BITS_END_MARKER_LEN as u32);
+        }
+
+        buf.put_slice(writer.close().as_ref());
         Ok(())
+    }
+}
+
+impl TimestampDecoder {
+    fn encode_delta_of_delta_masks(dod_control_bits_size: &mut i32) -> DeltaOfDeltaEncodeMasks {
+        match dod_control_bits_size {
+            0 => DeltaOfDeltaEncodeMasks::ZeroEncode(),
+            1 => DeltaOfDeltaEncodeMasks::NormalEncode(0b10, 2, 7),
+            2 => DeltaOfDeltaEncodeMasks::NormalEncode(0b110, 3, 9),
+            3 => DeltaOfDeltaEncodeMasks::NormalEncode(0b1110, 4, 12),
+            4 => DeltaOfDeltaEncodeMasks::NormalEncode(0b1111, 4, 32),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn decode<B, F>(buf: &mut B, mut f: F) -> Result<()>
+    where
+        B: Buf,
+        F: FnMut(Timestamp) -> Result<()>,
+    {
+        let mut reader = BufferedReader::new(buf.chunk());
+
+        let version = reader
+            .read_bits((NUM_BYTES_ENCODE_VERSION_LEN * 8) as u32)
+            .context(ReadEncode)? as u8;
+        ensure!(version == ENCODE_VERSION, InvalidVersion { version });
+
+        let first_timestamp = reader.read_bits(64).context(ReadEncode)?;
+        f(Timestamp::new(first_timestamp as i64))?;
+
+        let control_bit = reader.read_bit().context(ReadEncode)?;
+        if control_bit == Bit::Zero {
+            return Ok(());
+        }
+
+        let mut last_delta: u64 = 0;
+        let mut last_timestamp = first_timestamp;
+        loop {
+            let mut dod_control_bits_size = 0;
+            // 0,10,110,1110,1111
+            for _ in 0..4 {
+                let bit = reader.read_bit().context(ReadEncode)?;
+
+                if bit == Bit::One {
+                    dod_control_bits_size += 1;
+                } else {
+                    break;
+                }
+            }
+
+            let dod_masks = Self::encode_delta_of_delta_masks(&mut dod_control_bits_size);
+
+            let dod = match dod_masks {
+                DeltaOfDeltaEncodeMasks::ZeroEncode() => 0,
+                DeltaOfDeltaEncodeMasks::NormalEncode(_, _, dod_bits_len) => {
+                    let mut dod = reader.read_bits(dod_bits_len as u32).context(ReadEncode)?;
+
+                    if dod_bits_len == 32 {
+                        // need to sign extend negative numbers
+                        // negative numbers   -1:ffffffffffffffff -2:fffffffffffffffe
+                        // -63:ffffffffffffffc1 example: 7bit dod=100 0001
+                        // dod:i32=-63. after add mask:dod=ffffffffffffffc1
+                        // add ffff... ahead of dod
+                        // same as ( dod as i32 as u64 )
+                        // if dod > (1 << (32 - 1)) {
+                        //     let mask = u64::max_value() << 32;
+                        //     dod |= mask;
+                        // }
+                        dod as i32 as u64
+                    } else {
+                        // need to sign extend negative numbers
+                        // negative numbers   -1:ffffffffffffffff -2:fffffffffffffffe
+                        // -63:ffffffffffffffc1 example: 7bit dod=100 0001 dod:i32=-63.
+                        // after add mask:dod=ffffffffffffffc1 add ffff... ahead of dod
+                        if dod > (1 << (dod_bits_len - 1)) {
+                            let mask = u64::max_value() << dod_bits_len;
+                            dod |= mask;
+                        }
+                        dod
+                    }
+                }
+            };
+
+            // Reach end mask
+            if dod == 0 && dod_control_bits_size == 4 {
+                return Ok(());
+            }
+
+            let cur_delta = last_delta.wrapping_add(dod);
+            let cur_timestamp = last_timestamp.wrapping_add(cur_delta);
+
+            f(Timestamp::new(cur_timestamp as i64))?;
+
+            last_delta = cur_delta;
+            last_timestamp = cur_timestamp;
+        }
+    }
+}
+
+impl ValuesEncoder<Timestamp> for ValuesEncoderImpl {
+    fn encode<B, I>(&self, buf: &mut B, values: I) -> Result<()>
+    where
+        B: BufMut,
+        I: Iterator<Item = Timestamp>,
+    {
+        TimestampEncoder::encode(buf, values.map(|v| v.as_i64()))
     }
 
     fn estimated_encoded_size<I>(&self, values: I) -> usize
     where
-        I: Iterator<Item = i64>,
+        I: Iterator<Item = Timestamp>,
     {
         let (lower, higher) = values.size_hint();
         let num = lower.max(higher.unwrap_or_default());
-        num
+        NUM_BYTES_ENCODE_VERSION_LEN
+            + NUM_BYTES_OF_FIRST_TS_ENCODE
+            + 1
+            + (num - 1) * MAX_NUM_BYTES_OF_DOD_ENCODE
+            + NUM_BYTES_END_MARKER_LEN
     }
 }
 
-const DELTA_MAST_7: i32 = 0x02 << 7;
-
-// TODO: delta_of_delta bigger than i32?
-fn encode_delta_of_delta(dod: i64) -> u32 {
-    // let bit_required = 32 - std::num::NonZeroI32::new(dod -
-    // 1).unwrap().leading_zeros();
-
-    return if dod == 0 {
-        0b0
-    } else if dod >= -63 && dod <= 64 {
-        0b10 << 7 + dod
-    } else if dod >= -255 && dod <= 256 {
-        0b110 << 9 + dod
-    } else if dod >= -2047 && dod <= 2048 {
-        0b1110 << 12 + dod
-    } else {
-        0b1111 << 32 + dod
-    };
-}
-
-// fn compress_encode_results(results: &[i64], buf: &mut B) -> Result<()> {
-//     todo!()
-// }
-
-#[test]
-fn test_delta_of_delta_encode() {
-    assert!(0, encode_delta_of_delta(0));
-    assert!(0, encode_delta_of_delta(10));
-    assert!(0, encode_delta_of_delta(-10));
-    assert!(0, encode_delta_of_delta(64));
-    assert!(0, encode_delta_of_delta(-64));
-    assert!(0, encode_delta_of_delta(256));
-    assert!(0, encode_delta_of_delta(-256));
-    assert!(0, encode_delta_of_delta(2048));
-    assert!(0, encode_delta_of_delta(-2048));
-    assert!(0, encode_delta_of_delta(5000));
-}
-
-#[test]
-fn test_delta_of_delta_decode() {
-    todo!()
-}
-
-pub struct TimestampValuesDecoder;
-
-impl ValuesDecoder<i64> for TimestampValuesDecoder {
-    fn decode<B, F>(&self, buf: &mut B, mut f: F) -> Result<()>
+impl ValuesDecoder<Timestamp> for ValuesDecoderImpl {
+    fn decode<B, F>(&self, _ctx: DecodeContext<'_>, buf: &mut B, f: F) -> Result<()>
     where
         B: Buf,
-        F: FnMut(i64) -> Result<()>,
+        F: FnMut(Timestamp) -> Result<()>,
     {
-        todo!()
+        TimestampDecoder::decode(buf, f)
     }
 }

--- a/components/codec/src/columnar/timestamp.rs
+++ b/components/codec/src/columnar/timestamp.rs
@@ -115,13 +115,13 @@ impl TimestampEncoder {
                 // // write one control bit so we can distinguish a stream which contains only
                 // an initial // timestamp, this assumes the first bit of the
                 // END_MARKER is 1
-                writer.write_bit(Bit::One);
+                writer.write_bit(Bit(1));
                 control_bit_flag = false;
             }
             let cur_delta = v - last_ts;
             let delta_of_delta = cur_delta - last_delta;
             match TimestampEncoder::encode_delta_of_delta_masks(delta_of_delta) {
-                DeltaOfDeltaEncodeMasks::ZeroEncode() => writer.write_bit(Bit::Zero),
+                DeltaOfDeltaEncodeMasks::ZeroEncode() => writer.write_bit(Bit(0)),
                 DeltaOfDeltaEncodeMasks::NormalEncode(
                     control_bis,
                     control_bits_len,
@@ -137,7 +137,7 @@ impl TimestampEncoder {
 
         // write control bit when only the first timestamp exists
         if control_bit_flag {
-            writer.write_bit(Bit::Zero);
+            writer.write_bit(Bit(0));
         }
         // write end mask
         if !first {
@@ -177,7 +177,7 @@ impl TimestampDecoder {
         f(Timestamp::new(first_timestamp as i64))?;
 
         let control_bit = reader.next_bit().context(ReadEncode)?;
-        if control_bit == Bit::Zero {
+        if control_bit == Bit(0) {
             return Ok(());
         }
 
@@ -189,7 +189,7 @@ impl TimestampDecoder {
             for _ in 0..4 {
                 let bit = reader.next_bit().context(ReadEncode)?;
 
-                if bit == Bit::One {
+                if bit == Bit(1) {
                     dod_control_bits_size += 1;
                 } else {
                     break;

--- a/components/codec/src/columnar/timestamp.rs
+++ b/components/codec/src/columnar/timestamp.rs
@@ -169,11 +169,11 @@ impl TimestampDecoder {
         let mut reader = BufferedReader::new(buf.chunk());
 
         let version = reader
-            .read_bits((NUM_BYTES_ENCODE_VERSION_LEN * 8) as u32)
+            .next_bits((NUM_BYTES_ENCODE_VERSION_LEN * 8) as u32)
             .context(ReadEncode)? as u8;
         ensure!(version == ENCODE_VERSION, InvalidVersion { version });
 
-        let first_timestamp = reader.read_bits(64).context(ReadEncode)?;
+        let first_timestamp = reader.next_bits(64).context(ReadEncode)?;
         f(Timestamp::new(first_timestamp as i64))?;
 
         let control_bit = reader.next_bit().context(ReadEncode)?;
@@ -201,7 +201,7 @@ impl TimestampDecoder {
             let dod = match dod_masks {
                 DeltaOfDeltaEncodeMasks::ZeroEncode() => 0,
                 DeltaOfDeltaEncodeMasks::NormalEncode(_, _, dod_bits_len) => {
-                    let mut dod = reader.read_bits(dod_bits_len as u32).context(ReadEncode)?;
+                    let mut dod = reader.next_bits(dod_bits_len as u32).context(ReadEncode)?;
 
                     if dod_bits_len == 32 {
                         // need to sign extend negative numbers

--- a/components/codec/src/lib.rs
+++ b/components/codec/src/lib.rs
@@ -17,6 +17,7 @@
 // TODO(yingwen): Buf use generic type to avoid cost of vtable call per
 // encode/decode
 
+mod bits;
 pub mod columnar;
 pub mod compact;
 mod consts;


### PR DESCRIPTION
## Rationale
The columnar compression encoding for timestamp is not supported.


## Detailed Changes
Supported compression for the encoding for timestamp.


## Test Plan
New unit tests.