### PR TITLE
feat: support write wal logs in columnar format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "hex",
  "hyperloglog",
  "id_allocator",
+ "itertools 0.10.5",
  "lazy_static",
  "logger",
  "lru 0.7.8",

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -50,6 +50,7 @@ generic_error = { workspace = true }
 hex = { workspace = true }
 hyperloglog = { workspace = true }
 id_allocator = { workspace = true }
+itertools = { workspace = true }
 lazy_static = { workspace = true }
 logger = { workspace = true }
 lru = { workspace = true }

--- a/analytic_engine/src/instance/mod.rs
+++ b/analytic_engine/src/instance/mod.rs
@@ -61,7 +61,7 @@ use crate::{
         metrics::MaybeTableLevelMetrics,
     },
     table::data::{TableDataRef, TableShardInfo},
-    RecoverMode, TableOptions,
+    RecoverMode, TableOptions, WalEncodeConfig,
 };
 
 #[allow(clippy::enum_variant_names)]
@@ -186,6 +186,7 @@ pub struct Instance {
     pub(crate) scan_options: ScanOptions,
     pub(crate) iter_options: Option<IterOptions>,
     pub(crate) recover_mode: RecoverMode,
+    pub(crate) wal_encode: WalEncodeConfig,
 }
 
 impl Instance {

--- a/analytic_engine/src/instance/open.rs
+++ b/analytic_engine/src/instance/open.rs
@@ -146,6 +146,7 @@ impl Instance {
             iter_options,
             scan_options,
             recover_mode: ctx.config.recover_mode,
+            wal_encode: ctx.config.wal_encode,
         });
 
         Ok(instance)

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -137,12 +137,26 @@ pub enum RecoverMode {
     ShardBased,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub enum WalEncodeFormat {
+    RowWise,
+    Columnar,
+}
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WalEncodeConfig {
     /// The threshold of columnar bytes to do compression.
-    pub num_bytes_compress_threshold: usize,
+    pub num_bytes_compress_threshold: ReadableSize,
     /// Encode the data in a columnar layout if it is set.
-    pub enable_columnar_format: bool,
+    pub format: WalEncodeFormat,
+}
+
+impl Default for WalEncodeConfig {
+    fn default() -> Self {
+        Self {
+            num_bytes_compress_threshold: ReadableSize::kb(1),
+            format: WalEncodeFormat::RowWise,
+        }
+    }
 }
 
 impl Default for Config {

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -103,6 +103,8 @@ pub struct Config {
     pub max_bytes_per_write_batch: Option<ReadableSize>,
     /// The interval for sampling the memory usage
     pub mem_usage_sampling_interval: ReadableDuration,
+    /// The config for log in the wal.
+    pub wal_encode: WalEncodeConfig,
 
     /// Wal storage config
     ///
@@ -135,6 +137,14 @@ pub enum RecoverMode {
     ShardBased,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct WalEncodeConfig {
+    /// The threshold of columnar bytes to do compression.
+    pub num_bytes_compress_threshold: usize,
+    /// Encode the data in a columnar layout if it is set.
+    pub enable_columnar_format: bool,
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -163,6 +173,7 @@ impl Default for Config {
             max_retry_flush_limit: 0,
             max_bytes_per_write_batch: None,
             mem_usage_sampling_interval: ReadableDuration::secs(0),
+            wal_encode: WalEncodeConfig::default(),
             wal: StorageConfig::RocksDB(Box::default()),
             remote_engine_client: remote_engine_client::config::Config::default(),
             recover_mode: RecoverMode::TableBased,

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -192,7 +192,7 @@ impl MetaUpdateLogEntryIterator for MetaUpdateReaderImpl {
             let buffer = mem::take(&mut self.buffer);
             self.buffer = self
                 .iter
-                .next_log_entries(decoder, buffer)
+                .next_log_entries(decoder, |_| true, buffer)
                 .await
                 .context(ReadEntry)?;
         }

--- a/analytic_engine/src/manifest/meta_edit.rs
+++ b/analytic_engine/src/manifest/meta_edit.rs
@@ -26,7 +26,7 @@ use macros::define_result;
 use prost::Message;
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::table::TableId;
-use wal::log_batch::{Payload, PayloadDecoder};
+use wal::log_batch::{Payload, PayloadDecodeContext, PayloadDecoder};
 
 use crate::{
     manifest::meta_snapshot::MetaSnapshot,
@@ -408,7 +408,7 @@ impl PayloadDecoder for MetaUpdateDecoder {
     type Error = Error;
     type Target = MetaUpdate;
 
-    fn decode<B: Buf>(&self, buf: &mut B) -> Result<Self::Target> {
+    fn decode<B: Buf>(&self, _ctx: &PayloadDecodeContext, buf: &mut B) -> Result<Self::Target> {
         let meta_update_pb =
             manifest_pb::MetaUpdate::decode(buf.chunk()).context(DecodePayloadPb)?;
         MetaUpdate::try_from(meta_update_pb)

--- a/benchmarks/src/wal_write_bench.rs
+++ b/benchmarks/src/wal_write_bench.rs
@@ -80,7 +80,7 @@ impl WalWriteBench {
             let wal = WalNamespaceImpl::open(
                 MemoryImpl::default(),
                 runtimes.clone(),
-                "ceresedb",
+                "ceresdb",
                 NamespaceConfig::default(),
             )
             .await
@@ -88,8 +88,9 @@ impl WalWriteBench {
 
             let values = self.build_value_vec();
             let wal_encoder = LogBatchEncoder::create(WalLocation::new(1, 1));
+            let payloads = values.iter().map(|v| WritePayload(v));
             let log_batch = wal_encoder
-                .encode_batch::<WritePayload, Vec<u8>>(values.as_slice())
+                .encode_batch(payloads)
                 .expect("should succeed to encode payload batch");
 
             // Write to wal manager

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -1274,6 +1274,13 @@ impl<'a> DatumView<'a> {
         }
     }
 
+    pub fn as_time(&self) -> Option<Timestamp> {
+        match self {
+            DatumView::Time(v) => Some(Timestamp::new(*v)),
+            _ => None,
+        }
+    }
+
     pub fn as_f64(&self) -> Option<f64> {
         match self {
             DatumView::Double(v) => Some(*v),

--- a/common_types/src/datum.rs
+++ b/common_types/src/datum.rs
@@ -521,6 +521,7 @@ impl Datum {
     /// Cast datum to timestamp.
     pub fn as_timestamp(&self) -> Option<Timestamp> {
         match self {
+            Datum::Time(v) => Some(Timestamp::new(*v)),
             Datum::Timestamp(v) => Some(*v),
             _ => None,
         }
@@ -1270,12 +1271,6 @@ impl<'a> DatumView<'a> {
     pub fn as_timestamp(&self) -> Option<Timestamp> {
         match self {
             DatumView::Timestamp(v) => Some(*v),
-            _ => None,
-        }
-    }
-
-    pub fn as_time(&self) -> Option<Timestamp> {
-        match self {
             DatumView::Time(v) => Some(Timestamp::new(*v)),
             _ => None,
         }

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -684,6 +684,23 @@ mod tests {
     }
 
     #[test]
+    fn test_u64() {
+        let datums = vec![
+            Datum::from(10u64),
+            Datum::from(1u64),
+            Datum::from(2u64),
+            Datum::from(18u64),
+            Datum::from(38u64),
+            Datum::from(48u64),
+            Datum::from(80u64),
+            Datum::from(81u64),
+            Datum::from(82u64),
+        ];
+
+        check_encode_end_decode(10, datums, DatumKind::UInt64);
+    }
+
+    #[test]
     fn test_timestamp() {
         let datums = vec![
             Datum::from(Timestamp::new(-10)),

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -117,7 +117,7 @@ trait ValuesEncoder<T> {
 /// The decode context for decoding column.
 pub struct DecodeContext<'a> {
     /// Buffer for reuse during decoding.
-    buf: &'a mut Vec<u8>,
+    pub buf: &'a mut Vec<u8>,
 }
 
 /// The trait bound on the decoders for different types.

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -307,7 +307,7 @@ impl ColumnarEncoder {
                 enc.estimated_encoded_size(datums.clone().filter_map(|v| v.as_date_i32()))
             }
             DatumKind::Time => {
-                enc.estimated_encoded_size(datums.clone().filter_map(|v| v.as_time()))
+                enc.estimated_encoded_size(datums.clone().filter_map(|v| v.as_timestamp()))
             }
         };
 
@@ -342,7 +342,7 @@ impl ColumnarEncoder {
             DatumKind::Int8 => enc.encode(buf, datums.filter_map(|v| v.as_i8())),
             DatumKind::Boolean => enc.encode(buf, datums.filter_map(|v| v.as_bool())),
             DatumKind::Date => enc.encode(buf, datums.filter_map(|v| v.as_date_i32())),
-            DatumKind::Time => enc.encode(buf, datums.filter_map(|v| v.as_time())),
+            DatumKind::Time => enc.encode(buf, datums.filter_map(|v| v.as_timestamp())),
         }
     }
 }

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -613,6 +613,26 @@ mod tests {
     }
 
     #[test]
+    fn test_with_empty_datums() {
+        check_encode_end_decode(1, vec![], DatumKind::Null);
+        check_encode_end_decode(1, vec![], DatumKind::Timestamp);
+        check_encode_end_decode(1, vec![], DatumKind::Double);
+        check_encode_end_decode(1, vec![], DatumKind::Float);
+        check_encode_end_decode(1, vec![], DatumKind::Varbinary);
+        check_encode_end_decode(1, vec![], DatumKind::String);
+        check_encode_end_decode(1, vec![], DatumKind::UInt64);
+        check_encode_end_decode(1, vec![], DatumKind::UInt32);
+        check_encode_end_decode(1, vec![], DatumKind::UInt8);
+        check_encode_end_decode(1, vec![], DatumKind::Int64);
+        check_encode_end_decode(1, vec![], DatumKind::Int32);
+        check_encode_end_decode(1, vec![], DatumKind::Int16);
+        check_encode_end_decode(1, vec![], DatumKind::Int8);
+        check_encode_end_decode(1, vec![], DatumKind::Boolean);
+        check_encode_end_decode(1, vec![], DatumKind::Date);
+        check_encode_end_decode(1, vec![], DatumKind::Time);
+    }
+
+    #[test]
     fn test_i32_with_null() {
         let datums = vec![
             Datum::from(10i32),

--- a/components/codec/src/columnar/number.rs
+++ b/components/codec/src/columnar/number.rs
@@ -118,6 +118,8 @@ impl ValuesEncoder<u64> for ValuesEncoderImpl {
         B: BufMut,
         I: Iterator<Item = u64>,
     {
+        buf.put_u8(VERSION);
+
         for v in values {
             varint::encode_uvarint(buf, v).context(Varint)?;
         }

--- a/components/codec/src/columnar/timestamp.rs
+++ b/components/codec/src/columnar/timestamp.rs
@@ -11,3 +11,94 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use common_types::time::Timestamp;
+use snafu::{ensure, OptionExt, ResultExt};
+
+use super::{DecodeContext, Overflow, Result, ValuesDecoder, ValuesDecoderImpl, Varint};
+use crate::{
+    columnar::{InvalidVersion, ValuesEncoder, ValuesEncoderImpl},
+    consts::MAX_VARINT_BYTES,
+    varint,
+};
+
+/// The layout for the timestamp values:
+/// ```plaintext
+/// +-------------+----------------------+--------+
+/// | version(u8) | first_timestamp(i64) | deltas |
+/// +-------------+----------------------+--------+
+/// ```
+///
+/// This encoding assume the timestamps are have very small differences between
+/// each other, so we just store the deltas from the first timestamp in varint.
+struct Encoding;
+
+impl Encoding {
+    const VERSION: u8 = 0;
+    const VERSION_SIZE: usize = 1;
+}
+
+impl ValuesEncoder<Timestamp> for ValuesEncoderImpl {
+    fn encode<B, I>(&self, buf: &mut B, mut values: I) -> Result<()>
+    where
+        B: bytes_ext::BufMut,
+        I: Iterator<Item = Timestamp> + Clone,
+    {
+        buf.put_u8(Encoding::VERSION);
+
+        let first_ts = match values.next() {
+            Some(v) => v.as_i64(),
+            None => return Ok(()),
+        };
+
+        buf.put_i64(first_ts);
+
+        for value in values {
+            let ts = value.as_i64();
+            let delta = ts.checked_sub(first_ts).with_context(|| Overflow {
+                msg: format!("first timestamp:{ts}, current timestamp:{first_ts}"),
+            })?;
+            varint::encode_varint(buf, delta).context(Varint)?;
+        }
+
+        Ok(())
+    }
+
+    fn estimated_encoded_size<I>(&self, values: I) -> usize
+    where
+        I: Iterator<Item = Timestamp>,
+    {
+        let (lower, higher) = values.size_hint();
+        let num = lower.max(higher.unwrap_or_default());
+        num * MAX_VARINT_BYTES + Encoding::VERSION_SIZE
+    }
+}
+
+impl ValuesDecoder<Timestamp> for ValuesDecoderImpl {
+    fn decode<B, F>(&self, _ctx: DecodeContext<'_>, buf: &mut B, mut f: F) -> Result<()>
+    where
+        B: bytes_ext::Buf,
+        F: FnMut(Timestamp) -> Result<()>,
+    {
+        let version = buf.get_u8();
+
+        ensure!(version == Encoding::VERSION, InvalidVersion { version });
+
+        if buf.remaining() == 0 {
+            return Ok(());
+        }
+
+        let first_ts = buf.get_i64();
+        f(Timestamp::new(first_ts))?;
+
+        while buf.remaining() > 0 {
+            let delta = varint::decode_varint(buf).context(Varint)?;
+            let ts = first_ts.checked_add(delta).with_context(|| Overflow {
+                msg: format!("first timestamp:{first_ts}, delta:{delta}"),
+            })?;
+            f(Timestamp::new(ts))?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/wal/src/lib.rs
+++ b/src/wal/src/lib.rs
@@ -14,6 +14,8 @@
 
 //! Write Ahead Log
 
+#![feature(trait_alias)]
+
 pub mod config;
 pub mod kv_encoder;
 pub mod log_batch;

--- a/src/wal/src/log_batch.rs
+++ b/src/wal/src/log_batch.rs
@@ -107,11 +107,21 @@ impl LogWriteBatch {
     }
 }
 
+/// The context to decode payload.
+#[derive(Debug, Default, Clone)]
+pub struct PayloadDecodeContext {
+    pub table_id: TableId,
+}
+
 pub trait PayloadDecoder: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
     type Target: Send + Sync;
     /// Decode `Target` from the `bytes`.
-    fn decode<B: Buf>(&self, buf: &mut B) -> Result<Self::Target, Self::Error>;
+    fn decode<B: Buf>(
+        &self,
+        ctx: &PayloadDecodeContext,
+        buf: &mut B,
+    ) -> Result<Self::Target, Self::Error>;
 }
 
 pub struct MemoryPayloadDecoder;
@@ -120,7 +130,11 @@ impl PayloadDecoder for MemoryPayloadDecoder {
     type Error = Error;
     type Target = MemoryPayload;
 
-    fn decode<B: SafeBuf>(&self, buf: &mut B) -> Result<Self::Target, Self::Error> {
+    fn decode<B: SafeBuf>(
+        &self,
+        _ctx: &PayloadDecodeContext,
+        buf: &mut B,
+    ) -> Result<Self::Target, Self::Error> {
         let val = buf.try_get_u32().expect("should succeed to read u32");
         Ok(MemoryPayload { val })
     }

--- a/src/wal/src/manager.rs
+++ b/src/wal/src/manager.rs
@@ -29,7 +29,7 @@ use snafu::ResultExt;
 
 use crate::{
     config::StorageConfig,
-    log_batch::{LogEntry, LogWriteBatch, PayloadDecoder},
+    log_batch::{LogEntry, LogWriteBatch, PayloadDecodeContext, PayloadDecoder},
     metrics::WAL_WRITE_BYTES_HISTOGRAM,
 };
 
@@ -398,24 +398,36 @@ impl BatchLogIteratorAdapter {
         }
     }
 
-    async fn simulated_async_next<D: PayloadDecoder + Send + 'static>(
+    async fn simulated_async_next<D, F>(
         &mut self,
         decoder: D,
+        filter: F,
         runtime: Arc<Runtime>,
         sync_iter: Box<dyn SyncLogIterator>,
         mut buffer: VecDeque<LogEntry<D::Target>>,
-    ) -> Result<(VecDeque<LogEntry<D::Target>>, Option<LogIterator>)> {
+    ) -> Result<(VecDeque<LogEntry<D::Target>>, Option<LogIterator>)>
+    where
+        D: PayloadDecoder + Send + 'static,
+        F: Fn(TableId) -> bool + Send + 'static,
+    {
         buffer.clear();
 
         let mut iter = sync_iter;
         let batch_size = self.batch_size;
         let (log_entries, iter_opt) = runtime
             .spawn_blocking(move || {
-                for _ in 0..batch_size {
+                while buffer.len() < batch_size {
                     if let Some(raw_log_entry) = iter.next_log_entry()? {
+                        if !filter(raw_log_entry.table_id) {
+                            continue;
+                        }
+
                         let mut raw_payload = raw_log_entry.payload;
+                        let ctx = PayloadDecodeContext {
+                            table_id: raw_log_entry.table_id,
+                        };
                         let payload = decoder
-                            .decode(&mut raw_payload)
+                            .decode(&ctx, &mut raw_payload)
                             .box_err()
                             .context(error::Decoding)?;
                         let log_entry = LogEntry {
@@ -440,20 +452,31 @@ impl BatchLogIteratorAdapter {
         }
     }
 
-    async fn async_next<D: PayloadDecoder + Send + 'static>(
+    async fn async_next<D, F>(
         &mut self,
         decoder: D,
+        filter: F,
         async_iter: Box<dyn AsyncLogIterator>,
         mut buffer: VecDeque<LogEntry<D::Target>>,
-    ) -> Result<(VecDeque<LogEntry<D::Target>>, Option<LogIterator>)> {
+    ) -> Result<(VecDeque<LogEntry<D::Target>>, Option<LogIterator>)>
+    where
+        D: PayloadDecoder + Send + 'static,
+        F: Fn(TableId) -> bool + Send + 'static,
+    {
         buffer.clear();
 
         let mut async_iter = async_iter;
-        for _ in 0..self.batch_size {
+        while buffer.len() < self.batch_size {
             if let Some(raw_log_entry) = async_iter.next_log_entry().await? {
+                if !filter(raw_log_entry.table_id) {
+                    continue;
+                }
                 let mut raw_payload = raw_log_entry.payload;
+                let ctx = PayloadDecodeContext {
+                    table_id: raw_log_entry.table_id,
+                };
                 let payload = decoder
-                    .decode(&mut raw_payload)
+                    .decode(&ctx, &mut raw_payload)
                     .box_err()
                     .context(error::Decoding)?;
                 let log_entry = LogEntry {
@@ -470,11 +493,21 @@ impl BatchLogIteratorAdapter {
         Ok((buffer, Some(LogIterator::Async(async_iter))))
     }
 
-    pub async fn next_log_entries<D: PayloadDecoder + Send + 'static>(
+    /// Read the next batch of wal logs.
+    ///
+    /// The `filter` will be used to determine whether a log is needed anymore,
+    /// so unnecessary decoding work can be avoided.
+    /// NOTE: the logs will be accepted if the return result of filter is true.
+    pub async fn next_log_entries<D, F>(
         &mut self,
         decoder: D,
+        filter: F,
         buffer: VecDeque<LogEntry<D::Target>>,
-    ) -> Result<VecDeque<LogEntry<D::Target>>> {
+    ) -> Result<VecDeque<LogEntry<D::Target>>>
+    where
+        D: PayloadDecoder + Send + 'static,
+        F: Fn(TableId) -> bool + Send + 'static,
+    {
         if self.iter.is_none() {
             return Ok(VecDeque::new());
         }
@@ -482,10 +515,10 @@ impl BatchLogIteratorAdapter {
         let iter = self.iter.take().unwrap();
         let (log_entries, iter) = match iter {
             LogIterator::Sync { iter, runtime } => {
-                self.simulated_async_next(decoder, runtime, iter, buffer)
+                self.simulated_async_next(decoder, filter, runtime, iter, buffer)
                     .await?
             }
-            LogIterator::Async(iter) => self.async_next(decoder, iter, buffer).await?,
+            LogIterator::Async(iter) => self.async_next(decoder, filter, iter, buffer).await?,
         };
 
         self.iter = iter;
@@ -607,7 +640,7 @@ mod tests {
 
         loop {
             buffer = iter
-                .next_log_entries(MemoryPayloadDecoder, buffer)
+                .next_log_entries(MemoryPayloadDecoder, |_| true, buffer)
                 .await
                 .unwrap();
             for entry in buffer.iter() {
@@ -631,7 +664,7 @@ mod tests {
         let mut buffer = VecDeque::with_capacity(3);
         loop {
             buffer = iter
-                .next_log_entries(MemoryPayloadDecoder, buffer)
+                .next_log_entries(MemoryPayloadDecoder, |_| true, buffer)
                 .await
                 .unwrap();
             for entry in buffer.iter() {

--- a/src/wal/src/manager.rs
+++ b/src/wal/src/manager.rs
@@ -33,6 +33,8 @@ use crate::{
     metrics::WAL_WRITE_BYTES_HISTOGRAM,
 };
 
+pub trait TableFilter = Fn(TableId) -> bool;
+
 pub mod error {
     use generic_error::GenericError;
     use macros::define_result;
@@ -408,7 +410,7 @@ impl BatchLogIteratorAdapter {
     ) -> Result<(VecDeque<LogEntry<D::Target>>, Option<LogIterator>)>
     where
         D: PayloadDecoder + Send + 'static,
-        F: Fn(TableId) -> bool + Send + 'static,
+        F: TableFilter + Send + 'static,
     {
         buffer.clear();
 
@@ -461,7 +463,7 @@ impl BatchLogIteratorAdapter {
     ) -> Result<(VecDeque<LogEntry<D::Target>>, Option<LogIterator>)>
     where
         D: PayloadDecoder + Send + 'static,
-        F: Fn(TableId) -> bool + Send + 'static,
+        F: TableFilter + Send + 'static,
     {
         buffer.clear();
 
@@ -506,7 +508,7 @@ impl BatchLogIteratorAdapter {
     ) -> Result<VecDeque<LogEntry<D::Target>>>
     where
         D: PayloadDecoder + Send + 'static,
-        F: Fn(TableId) -> bool + Send + 'static,
+        F: TableFilter + Send + 'static,
     {
         if self.iter.is_none() {
             return Ok(VecDeque::new());

--- a/src/wal/src/message_queue_impl/region.rs
+++ b/src/wal/src/message_queue_impl/region.rs
@@ -957,7 +957,7 @@ mod tests {
     };
 
     use crate::{
-        log_batch::PayloadDecoder,
+        log_batch::{PayloadDecodeContext, PayloadDecoder},
         manager::{ReadContext, WriteContext},
         message_queue_impl::{encoding::MetaEncoding, test_util::TestContext},
     };
@@ -1033,9 +1033,12 @@ mod tests {
             .unwrap();
         while let Some(log_entry) = msg_iter.next_log_entry().await.unwrap() {
             let mut payload = log_entry.payload;
+            let ctx = PayloadDecodeContext {
+                table_id: log_entry.table_id,
+            };
             let decoded_payload = test_context
                 .test_payload_encoder
-                .decode(&mut payload)
+                .decode(&ctx, &mut payload)
                 .unwrap();
             mixed_decoded_res.push(decoded_payload.val);
         }

--- a/src/wal/src/message_queue_impl/test_util.rs
+++ b/src/wal/src/message_queue_impl/test_util.rs
@@ -71,9 +71,8 @@ impl<Mq: MessageQueue> TestContext<Mq> {
             .map(|(table_id, data)| {
                 let log_batch_encoder =
                     LogBatchEncoder::create(WalLocation::new(region_id, table_id));
-                let log_write_batch = log_batch_encoder
-                    .encode_batch::<MemoryPayload, u32>(&data)
-                    .unwrap();
+                let payloads = data.iter().map(|v| MemoryPayload { val: *v });
+                let log_write_batch = log_batch_encoder.encode_batch(payloads).unwrap();
 
                 (table_id, TestDataOfTable::new(data, log_write_batch))
             })

--- a/src/wal/tests/read_write.rs
+++ b/src/wal/tests/read_write.rs
@@ -1021,11 +1021,11 @@ impl<B: WalBuilder> TestEnv<B> {
         start: u32,
         end: u32,
     ) -> (Vec<MemoryPayload>, LogWriteBatch) {
-        let log_entries = (start..end).collect::<Vec<_>>();
+        let log_entries = start..end;
 
         let log_batch_encoder = LogBatchEncoder::create(location);
         let log_batch = log_batch_encoder
-            .encode_batch::<MemoryPayload, u32>(&log_entries)
+            .encode_batch(log_entries.map(|v| MemoryPayload { val: v }))
             .expect("should succeed to encode payloads");
 
         let payload_batch = self.build_payload_batch(start, end);
@@ -1047,7 +1047,7 @@ impl<B: WalBuilder> TestEnv<B> {
         loop {
             let dec = MemoryPayloadDecoder;
             let log_entries = iter
-                .next_log_entries(dec, VecDeque::new())
+                .next_log_entries(dec, |_| true, VecDeque::new())
                 .await
                 .expect("should succeed to fetch next log entry");
             if log_entries.is_empty() {


### PR DESCRIPTION
## Rationale
After the columnar encoding is supported for wal format, we should adapt such encoding in the wal write procedure.

## Detailed Changes
Adapt the columnar encoding in the wal write procedure. And now, both rowwise and columnar encoding in the wal write procedure are supported, which to use depends on the configuration.

## Test Plan
Existing tests. The compatibility tests have been designed as:
- Write rowwise-encoded wal logs and restart the server to replay it
- Write columnar-encoded wal logs and restart the server to replay it