### PR TITLE
chore: upgrade nightly rust to 1.72

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ env:
   CERESMETA_IMAGE_NAME: ceresdb/ceresmeta-server:latest
   CERESDB_IMAGE_NAME: ceresdb/ceresdb-server:latest
   LOCK_FILE: Cargo.lock
-  RUST_VERSION: nightly-2023-02-02
+  RUST_VERSION: nightly-2023-08-28
 
 jobs:
   style-check:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ env:
   RUSTFLAGS: "-C debuginfo=1"
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
-  RUST_VERSION: nightly-2023-02-02
+  RUST_VERSION: nightly-2023-08-28
 
 jobs:
   coverage:

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -543,7 +543,7 @@ impl TimeWindowPicker {
 
             let (left, _) = Self::get_window_bounds_in_millis(window, ts);
 
-            let bucket_files = buckets.entry(left).or_insert_with(Vec::new);
+            let bucket_files = buckets.entry(left).or_default();
 
             bucket_files.push(f.clone());
 
@@ -813,7 +813,7 @@ mod tests {
 
     #[test]
     fn test_time_window_picker() {
-        let picker_manager = PickerManager::default();
+        let picker_manager = PickerManager;
         let twp = picker_manager.get_picker(CompactionStrategy::Default);
         let mut ctx = PickerContext {
             segment_duration: Duration::from_millis(1000),

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -311,7 +311,7 @@ impl SchedulerImpl {
             space_store,
             runtime: runtime.clone(),
             schedule_interval: config.schedule_interval.0,
-            picker_manager: PickerManager::default(),
+            picker_manager: PickerManager,
             max_ongoing_tasks: config.max_ongoing_tasks,
             max_unflushed_duration: config.max_unflushed_duration.0,
             write_sst_max_buffer_size,

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -407,12 +407,6 @@ impl Instance {
         let shard_id = request.shard_id;
         let mut table_ctxs = Vec::with_capacity(request.table_defs.len());
 
-        // Open tables.
-        struct TableInfo {
-            name: String,
-            id: TableId,
-        }
-
         let mut spaces_of_tables = Vec::with_capacity(request.table_defs.len());
         for table_def in request.table_defs {
             let context = SpaceContext {

--- a/analytic_engine/src/instance/wal_replayer.rs
+++ b/analytic_engine/src/instance/wal_replayer.rs
@@ -217,7 +217,7 @@ impl TableBasedReplay {
         loop {
             // fetch entries to log_entry_buf
             let _timer = PULL_LOGS_DURATION_HISTOGRAM.start_timer();
-            let decoder = WalDecoder::default();
+            let decoder = WalDecoder;
             log_entry_buf = log_iter
                 .next_log_entries(decoder, log_entry_buf)
                 .await
@@ -309,7 +309,7 @@ impl RegionBasedReplay {
         // Split and replay logs.
         loop {
             let _timer = PULL_LOGS_DURATION_HISTOGRAM.start_timer();
-            let decoder = WalDecoder::default();
+            let decoder = WalDecoder;
             log_entry_buf = log_iter
                 .next_log_entries(decoder, log_entry_buf)
                 .await

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -595,8 +595,8 @@ struct ObjectStoreBasedSnapshotStore {
 }
 
 impl ObjectStoreBasedSnapshotStore {
-    const CURRENT_SNAPSHOT_NAME: &str = "current";
-    const SNAPSHOT_PATH_PREFIX: &str = "manifest/snapshot";
+    const CURRENT_SNAPSHOT_NAME: &'static str = "current";
+    const SNAPSHOT_PATH_PREFIX: &'static str = "manifest/snapshot";
 
     pub fn new(space_id: SpaceId, table_id: TableId, store: ObjectStoreRef) -> Self {
         let snapshot_path = Self::snapshot_path(space_id, table_id);

--- a/analytic_engine/src/setup.rs
+++ b/analytic_engine/src/setup.rs
@@ -429,7 +429,7 @@ async fn open_instance(
         manifest_storages,
         wal_manager,
         store_picker,
-        Arc::new(FactoryImpl::default()),
+        Arc::new(FactoryImpl),
     )
     .await
     .context(OpenInstance)?;

--- a/analytic_engine/src/sst/file.rs
+++ b/analytic_engine/src/sst/file.rs
@@ -369,7 +369,7 @@ struct FileHandleSet {
 
 impl FileHandleSet {
     fn latest(&self) -> Option<FileHandle> {
-        if let Some(file) = self.file_map.values().rev().next() {
+        if let Some(file) = self.file_map.values().next_back() {
             return Some(file.clone());
         }
         None

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -778,8 +778,7 @@ mod tests {
 
     impl MockRandomSenders {
         fn start_to_send(&mut self) {
-            while !self.tx_group.is_empty() {
-                let tx = self.tx_group.pop().unwrap();
+            while let Some(tx) = self.tx_group.pop() {
                 let test_data = self.test_datas.pop().unwrap();
                 tokio::spawn(async move {
                     for datum in test_data {

--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -931,9 +931,9 @@ mod tests {
 
     #[test]
     fn test_table_version_sampling() {
-        let memtable = MemTableMocker::default().build();
+        let memtable = MemTableMocker.build();
         test_table_version_sampling_with_memtable(memtable);
-        let memtable = MemTableMocker::default().build_columnar();
+        let memtable = MemTableMocker.build_columnar();
         test_table_version_sampling_with_memtable(memtable);
     }
 
@@ -975,9 +975,9 @@ mod tests {
 
     #[test]
     fn test_table_version_sampling_switch() {
-        let memtable = MemTableMocker::default().build();
+        let memtable = MemTableMocker.build();
         test_table_version_sampling_switch_with_memtable(memtable);
-        let memtable = MemTableMocker::default().build_columnar();
+        let memtable = MemTableMocker.build_columnar();
         test_table_version_sampling_switch_with_memtable(memtable);
     }
 
@@ -1027,7 +1027,7 @@ mod tests {
     fn test_table_version_sampling_freeze() {
         let version = new_table_version();
 
-        let memtable = MemTableMocker::default().build();
+        let memtable = MemTableMocker.build();
         let schema = memtable.schema().clone();
 
         let memtable_id1 = 1;
@@ -1063,7 +1063,7 @@ mod tests {
         assert_eq!(memtable_id1, read_view.sampling_mem.as_ref().unwrap().id);
         assert!(read_view.sampling_mem.unwrap().freezed);
 
-        let memtable = MemTableMocker::default().build();
+        let memtable = MemTableMocker.build();
         let memtable_id2 = 2;
         let mem_state = MemTableState {
             mem: memtable,
@@ -1110,7 +1110,7 @@ mod tests {
     fn test_table_version_sampling_apply_edit() {
         let version = new_table_version();
 
-        let memtable = MemTableMocker::default().build();
+        let memtable = MemTableMocker.build();
 
         let memtable_id1 = 1;
         let sampling_mem = SamplingMemTable::new(memtable, memtable_id1);
@@ -1124,7 +1124,7 @@ mod tests {
             TimeRange::bucket_of(now, table_options::DEFAULT_SEGMENT_DURATION).unwrap();
 
         // Prepare mutable memtable.
-        let memtable = MemTableMocker::default().build();
+        let memtable = MemTableMocker.build();
         let memtable_id2 = 2;
         let mem_state = MemTableState {
             mem: memtable,

--- a/analytic_engine/src/table_options.rs
+++ b/analytic_engine/src/table_options.rs
@@ -427,7 +427,7 @@ impl TableOptions {
                 SEGMENT_DURATION.to_string(),
                 self.segment_duration
                     .map(|v| v.to_string())
-                    .unwrap_or_else(String::new),
+                    .unwrap_or_default(),
             ),
             (UPDATE_MODE.to_string(), self.update_mode.to_string()),
             (ENABLE_TTL.to_string(), self.enable_ttl.to_string()),

--- a/analytic_engine/src/tests/util.rs
+++ b/analytic_engine/src/tests/util.rs
@@ -617,7 +617,7 @@ impl EngineBuildContext for RocksDBEngineBuildContext {
     type WalsOpener = RocksDBWalsOpener;
 
     fn wals_opener(&self) -> Self::WalsOpener {
-        RocksDBWalsOpener::default()
+        RocksDBWalsOpener
     }
 
     fn config(&self) -> Config {

--- a/benchmarks/src/merge_memtable_bench.rs
+++ b/benchmarks/src/merge_memtable_bench.rs
@@ -146,7 +146,7 @@ impl MergeMemTableBench {
         let table_id = self.table_id;
         let sequence = u64::MAX;
         let projected_schema = self.projected_schema.clone();
-        let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
+        let sst_factory: SstFactoryRef = Arc::new(FactoryImpl);
         let iter_options = IterOptions {
             batch_size: self.sst_read_options.num_rows_per_row_group,
         };

--- a/benchmarks/src/merge_sst_bench.rs
+++ b/benchmarks/src/merge_sst_bench.rs
@@ -133,7 +133,7 @@ impl MergeSstBench {
         let table_id = self.table_id;
         let sequence = u64::MAX;
         let projected_schema = self.sst_read_options.projected_schema.clone();
-        let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
+        let sst_factory: SstFactoryRef = Arc::new(FactoryImpl);
         let iter_options = IterOptions {
             batch_size: self.sst_read_options.num_rows_per_row_group,
         };
@@ -189,7 +189,7 @@ impl MergeSstBench {
         let space_id = self.space_id;
         let table_id = self.table_id;
         let projected_schema = self.sst_read_options.projected_schema.clone();
-        let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
+        let sst_factory: SstFactoryRef = Arc::new(FactoryImpl);
 
         let request_id = RequestId::next_id();
         let store_picker: ObjectStorePickerRef = Arc::new(self.store.clone());

--- a/benchmarks/src/sst_tools.rs
+++ b/benchmarks/src/sst_tools.rs
@@ -228,7 +228,7 @@ pub async fn merge_sst(config: MergeSstConfig, runtime: Arc<Runtime>) {
     };
 
     let request_id = RequestId::next_id();
-    let sst_factory: SstFactoryRef = Arc::new(FactoryImpl::default());
+    let sst_factory: SstFactoryRef = Arc::new(FactoryImpl);
     let store_picker: ObjectStorePickerRef = Arc::new(store);
     let projected_schema = ProjectedSchema::no_projection(schema.clone());
     let sst_read_options = SstReadOptions {

--- a/cluster/src/shard_lock_manager.rs
+++ b/cluster/src/shard_lock_manager.rs
@@ -524,7 +524,7 @@ impl ShardLock {
         lease_id: i64,
         expired_at: Instant,
         on_lock_expired: OnExpired,
-        etcd_client: &mut Client,
+        etcd_client: &Client,
         runtime: &RuntimeRef,
     ) -> Result<()>
     where

--- a/cluster/src/topology.rs
+++ b/cluster/src/topology.rs
@@ -118,7 +118,7 @@ impl SchemaTopologies {
 
         self.topologies
             .entry(schema_name.to_string())
-            .or_insert_with(Default::default)
+            .or_default()
             .update_tables(tables);
 
         true

--- a/common_types/src/bitset.rs
+++ b/common_types/src/bitset.rs
@@ -298,7 +298,11 @@ mod tests {
     }
 
     fn iter_set_bools(bools: &[bool]) -> impl Iterator<Item = usize> + '_ {
-        bools.iter().enumerate().filter_map(|(x, y)| y.then(|| x))
+        bools
+            .iter()
+            .enumerate()
+            .filter(|&(_, y)| *y)
+            .map(|(x, _)| x)
     }
 
     #[test]
@@ -347,7 +351,7 @@ mod tests {
     }
 
     fn make_rng() -> StdRng {
-        let seed = OsRng::default().next_u64();
+        let seed = OsRng.next_u64();
         println!("Seed: {seed}");
         StdRng::seed_from_u64(seed)
     }

--- a/common_types/src/column_block.rs
+++ b/common_types/src/column_block.rs
@@ -1033,7 +1033,7 @@ macro_rules! define_column_block_builder {
 
                 /// Append the [DatumView] into the builder, the datum view should have same the data
                 /// type of builder
-                pub fn append_view<'a>(&mut self, datum: DatumView<'a>) -> Result<()> {
+                pub fn append_view(&mut self, datum: DatumView<'_>) -> Result<()> {
                     let given = datum.kind();
                     match self {
                         Self::Null { rows } => match datum {

--- a/common_types/src/column_schema.rs
+++ b/common_types/src/column_schema.rs
@@ -602,7 +602,7 @@ mod tests {
 
     #[test]
     fn test_valid_tag_type() {
-        let invalid_tag_types = vec![DatumKind::Null, DatumKind::Float, DatumKind::Double];
+        let invalid_tag_types = [DatumKind::Null, DatumKind::Float, DatumKind::Double];
 
         for v in &DatumKind::VALUES {
             assert_eq!(
@@ -614,7 +614,7 @@ mod tests {
 
     #[test]
     fn test_valid_dictionary_type() {
-        let valid_dictionary_types = vec![DatumKind::String];
+        let valid_dictionary_types = [DatumKind::String];
 
         for v in &DatumKind::VALUES {
             assert_eq!(

--- a/components/codec/src/columnar/bool.rs
+++ b/components/codec/src/columnar/bool.rs
@@ -99,7 +99,7 @@ impl Encoding {
         }
     }
 
-    fn decode<B, F>(&self, buf: &mut B, f: F) -> Result<()>
+    fn decode<B, F>(&self, buf: &B, f: F) -> Result<()>
     where
         B: Buf,
         F: FnMut(bool) -> Result<()>,

--- a/components/codec/src/columnar/bytes.rs
+++ b/components/codec/src/columnar/bytes.rs
@@ -125,7 +125,7 @@ impl Encoding {
     }
 
     /// The layout can be referred to the docs of [`Encoding`].
-    fn decode<B, F>(&self, ctx: DecodeContext<'_>, buf: &mut B, f: F) -> Result<()>
+    fn decode<B, F>(&self, ctx: DecodeContext<'_>, buf: &B, f: F) -> Result<()>
     where
         B: Buf,
         F: FnMut(Bytes) -> Result<()>,

--- a/components/codec/src/columnar/mod.rs
+++ b/components/codec/src/columnar/mod.rs
@@ -392,7 +392,7 @@ impl ColumnarDecoder {
 impl ColumnarDecoder {
     fn decode_with_nulls<B: Buf>(
         ctx: DecodeContext<'_>,
-        buf: &mut B,
+        buf: &B,
         num_datums: usize,
         datum_kind: DatumKind,
     ) -> Result<Vec<Datum>> {
@@ -570,7 +570,7 @@ mod tests {
 
     #[test]
     fn test_small_int() {
-        let datums = vec![10u32, 1u32, 2u32, 81u32, 82u32];
+        let datums = [10u32, 1u32, 2u32, 81u32, 82u32];
 
         check_encode_end_decode(
             10,

--- a/components/future_ext/src/cancel.rs
+++ b/components/future_ext/src/cancel.rs
@@ -62,7 +62,7 @@ where
     fn drop(&mut self) {
         if !self.done {
             let inner = self.inner.take().unwrap();
-            let handle = self.runtime.spawn(async move { inner.await });
+            let handle = self.runtime.spawn(inner);
             drop(handle);
         }
     }

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -132,7 +132,7 @@ struct Manifest {
 
 impl Manifest {
     const CURRENT_VERSION: usize = 2;
-    const FILE_NAME: &str = "manifest.json";
+    const FILE_NAME: &'static str = "manifest.json";
 
     #[inline]
     fn is_valid(&self, version: usize, page_size: usize) -> bool {
@@ -876,7 +876,7 @@ mod test {
 
         // remove cached values, then get again
         {
-            for range in vec![0..16, 16..32, 32..48, 48..64, 64..80, 80..96, 96..112] {
+            for range in [0..16, 16..32, 32..48, 48..64, 64..80, 80..96, 96..112] {
                 let data_cache = store
                     .inner
                     .cache
@@ -887,7 +887,7 @@ mod test {
                 assert!(test_file_exists(&store.cache_dir, &location, &range));
             }
 
-            for range in vec![16..32, 48..64, 80..96] {
+            for range in [16..32, 48..64, 80..96] {
                 let mut data_cache = store
                     .inner
                     .cache
@@ -1105,7 +1105,7 @@ mod test {
                     .await
                     .unwrap()
             };
-            for range in vec![16..32, 32..48, 48..64, 64..80, 80..96, 96..112] {
+            for range in [16..32, 32..48, 48..64, 64..80, 80..96, 96..112] {
                 let filename = DiskCacheStore::page_cache_name(&location, &range);
                 let cache = store.cache.meta_cache.lock(&filename);
                 assert!(cache.contains(&filename));

--- a/components/object_store/src/obkv/mod.rs
+++ b/components/object_store/src/obkv/mod.rs
@@ -639,7 +639,7 @@ impl<T: TableKv> ObjectStore for ObkvObjectStore<T> {
             }));
         }
 
-        let iter = futures::stream::iter(meta_list.into_iter());
+        let iter = futures::stream::iter(meta_list);
         debug!(
             "ObkvObjectStore list operation, prefix:{path}, cost:{:?}",
             instant.elapsed()
@@ -682,7 +682,7 @@ impl<T: TableKv> ObjectStore for ObkvObjectStore<T> {
             }
         }
 
-        let common_prefixes = Vec::from_iter(common_prefixes.into_iter());
+        let common_prefixes = Vec::from_iter(common_prefixes);
         debug!(
             "ObkvObjectStore list_with_delimiter operation, prefix:{path}, cost:{:?}",
             instant.elapsed()

--- a/components/object_store/src/prefix.rs
+++ b/components/object_store/src/prefix.rs
@@ -348,7 +348,7 @@ mod tests {
 
         let _ = prefix_store.get(&test_filepath).await;
         let _ = prefix_store.get_range(&test_filepath, 0..1).await;
-        let _ = prefix_store.get_ranges(&test_filepath, &[0..2]).await;
+        let _ = prefix_store.get_ranges(&test_filepath, &[0..2; 1]).await;
 
         let meta = prefix_store.head(&test_filepath).await.unwrap();
         assert!(!meta.location.as_ref().starts_with(test_prefix));

--- a/proxy/src/grpc/prom_query.rs
+++ b/proxy/src/grpc/prom_query.rs
@@ -102,21 +102,18 @@ impl Proxy {
                 msg: "Invalid request",
             })?;
 
-        let (plan, column_name) =
-            frontend
-                .promql_expr_to_plan(&mut sql_ctx, expr)
-                .map_err(|e| {
-                    let code = if is_table_not_found_error(&e) {
-                        StatusCode::NOT_FOUND
-                    } else {
-                        StatusCode::INTERNAL_SERVER_ERROR
-                    };
-                    Error::ErrWithCause {
-                        code,
-                        msg: "Failed to create plan".to_string(),
-                        source: Box::new(e),
-                    }
-                })?;
+        let (plan, column_name) = frontend.promql_expr_to_plan(&sql_ctx, expr).map_err(|e| {
+            let code = if is_table_not_found_error(&e) {
+                StatusCode::NOT_FOUND
+            } else {
+                StatusCode::INTERNAL_SERVER_ERROR
+            };
+            Error::ErrWithCause {
+                code,
+                msg: "Failed to create plan".to_string(),
+                source: Box::new(e),
+            }
+        })?;
 
         self.instance
             .limiter

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -133,14 +133,14 @@ impl Proxy {
             function_registry: &*self.instance.function_registry,
         };
         let frontend = Frontend::new(provider);
-        let mut plan_ctx = Context::new(request_id, deadline);
+        let plan_ctx = Context::new(request_id, deadline);
 
         let RemoteQueryPlan {
             plan,
             timestamp_col_name,
             field_col_name,
         } = frontend
-            .prom_remote_query_to_plan(&mut plan_ctx, query.clone())
+            .prom_remote_query_to_plan(&plan_ctx, query.clone())
             .box_err()
             .with_context(|| ErrWithCause {
                 code: StatusCode::BAD_REQUEST,

--- a/proxy/src/influxdb/mod.rs
+++ b/proxy/src/influxdb/mod.rs
@@ -137,10 +137,10 @@ impl Proxy {
             function_registry: &*self.instance.function_registry,
         };
         let frontend = Frontend::new(provider);
-        let mut sql_ctx = SqlContext::new(request_id, deadline);
+        let sql_ctx = SqlContext::new(request_id, deadline);
 
         let mut stmts = frontend
-            .parse_influxql(&mut sql_ctx, &req.query)
+            .parse_influxql(&sql_ctx, &req.query)
             .box_err()
             .with_context(|| ErrWithCause {
                 code: StatusCode::BAD_REQUEST,
@@ -164,7 +164,7 @@ impl Proxy {
         );
 
         let plan = frontend
-            .influxql_stmt_to_plan(&mut sql_ctx, stmts.remove(0))
+            .influxql_stmt_to_plan(&sql_ctx, stmts.remove(0))
             .box_err()
             .with_context(|| ErrWithCause {
                 code: StatusCode::BAD_REQUEST,

--- a/proxy/src/influxdb/types.rs
+++ b/proxy/src/influxdb/types.rs
@@ -383,7 +383,7 @@ impl InfluxqlResultBuilder {
 
         let series = ordered_group_keys
             .into_iter()
-            .zip(self.value_groups.into_iter())
+            .zip(self.value_groups)
             .map(|(group_key, value_group)| {
                 let name = group_key.measurement;
                 let tags = if group_key.group_by_tag_values.is_empty() {

--- a/proxy/src/limiter.rs
+++ b/proxy/src/limiter.rs
@@ -171,17 +171,11 @@ impl Limiter {
     }
 
     pub fn add_write_block_list(&self, block_list: Vec<String>) {
-        self.write_block_list
-            .write()
-            .unwrap()
-            .extend(block_list.into_iter())
+        self.write_block_list.write().unwrap().extend(block_list)
     }
 
     pub fn add_read_block_list(&self, block_list: Vec<String>) {
-        self.read_block_list
-            .write()
-            .unwrap()
-            .extend(block_list.into_iter())
+        self.read_block_list.write().unwrap().extend(block_list)
     }
 
     pub fn set_write_block_list(&self, block_list: Vec<String>) {
@@ -219,7 +213,7 @@ impl Limiter {
     }
 
     pub fn add_block_rules(&self, rules: Vec<BlockRule>) {
-        self.rules.write().unwrap().extend(rules.into_iter());
+        self.rules.write().unwrap().extend(rules);
     }
 
     pub fn remove_block_rules(&self, rules_to_remove: &[BlockRule]) {

--- a/proxy/src/read.rs
+++ b/proxy/src/read.rs
@@ -130,7 +130,7 @@ impl Proxy {
         let plan = frontend
             // TODO(yingwen): Check error, some error may indicate that the sql is invalid. Now we
             // return internal server error in those cases
-            .statement_to_plan(&mut sql_ctx, stmts.remove(0))
+            .statement_to_plan(&sql_ctx, stmts.remove(0))
             .box_err()
             .with_context(|| ErrWithCause {
                 code: StatusCode::INTERNAL_SERVER_ERROR,

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -268,9 +268,9 @@ impl Proxy {
             function_registry: &*self.instance.function_registry,
         };
         let frontend = Frontend::new(provider);
-        let mut ctx = FrontendContext::new(request_id, deadline);
+        let ctx = FrontendContext::new(request_id, deadline);
         let plan = frontend
-            .write_req_to_plan(&mut ctx, schema_config, write_table_req)
+            .write_req_to_plan(&ctx, schema_config, write_table_req)
             .box_err()
             .with_context(|| ErrWithCause {
                 code: StatusCode::INTERNAL_SERVER_ERROR,

--- a/query_engine/src/datafusion_impl/physical_plan_extension/prom_align.rs
+++ b/query_engine/src/datafusion_impl/physical_plan_extension/prom_align.rs
@@ -425,7 +425,7 @@ impl PromAlignReader {
             })?;
         field_array
             .into_iter()
-            .zip(timestamp_array.into_iter())
+            .zip(timestamp_array)
             .map(|(field, timestamp)| {
                 Ok(Sample {
                     value: field.with_context(|| PhysicalPlanNoCause {

--- a/query_frontend/src/container.rs
+++ b/query_frontend/src/container.rs
@@ -142,9 +142,9 @@ impl TableContainer {
     ) {
         self.other_tables
             .entry(catalog)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .entry(schema)
-            .or_insert_with(HashMap::new)
+            .or_default()
             .insert(table, resolved_table);
     }
 

--- a/query_frontend/src/frontend.rs
+++ b/query_frontend/src/frontend.rs
@@ -123,11 +123,7 @@ impl<P> Frontend<P> {
     }
 
     /// Parse the sql and returns the statements
-    pub fn parse_influxql(
-        &self,
-        _ctx: &mut Context,
-        influxql: &str,
-    ) -> Result<Vec<InfluxqlStatement>> {
+    pub fn parse_influxql(&self, _ctx: &Context, influxql: &str) -> Result<Vec<InfluxqlStatement>> {
         match influxql_parser::parse_statements(influxql) {
             Ok(stmts) => Ok(stmts),
             Err(e) => Err(Error::InvalidInfluxql {
@@ -140,7 +136,7 @@ impl<P> Frontend<P> {
 
 impl<P: MetaProvider> Frontend<P> {
     /// Create logical plan for the statement
-    pub fn statement_to_plan(&self, ctx: &mut Context, stmt: Statement) -> Result<Plan> {
+    pub fn statement_to_plan(&self, ctx: &Context, stmt: Statement) -> Result<Plan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
 
         planner.statement_to_plan(stmt).context(CreatePlan)
@@ -149,7 +145,7 @@ impl<P: MetaProvider> Frontend<P> {
     /// Experimental native promql support, not used in production yet.
     pub fn promql_expr_to_plan(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         expr: Expr,
     ) -> Result<(Plan, Arc<ColumnNames>)> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
@@ -160,25 +156,21 @@ impl<P: MetaProvider> Frontend<P> {
     /// Prometheus remote query support
     pub fn prom_remote_query_to_plan(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         query: PromRemoteQuery,
     ) -> Result<RemoteQueryPlan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
         planner.remote_prom_req_to_plan(query).context(CreatePlan)
     }
 
-    pub fn influxql_stmt_to_plan(
-        &self,
-        ctx: &mut Context,
-        stmt: InfluxqlStatement,
-    ) -> Result<Plan> {
+    pub fn influxql_stmt_to_plan(&self, ctx: &Context, stmt: InfluxqlStatement) -> Result<Plan> {
         let planner = Planner::new(&self.provider, ctx.request_id, ctx.read_parallelism);
         planner.influxql_stmt_to_plan(stmt).context(CreatePlan)
     }
 
     pub fn write_req_to_plan(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         schema_config: &SchemaConfig,
         write_table: &WriteTableRequest,
     ) -> Result<Plan> {

--- a/query_frontend/src/lib.rs
+++ b/query_frontend/src/lib.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(once_cell)]
+#![feature(once_cell_try)]
 
 //! SQL frontend
 //!

--- a/remote_engine_client/src/client.rs
+++ b/remote_engine_client/src/client.rs
@@ -187,12 +187,10 @@ impl Client {
             })?;
             let handle = self.io_runtime.spawn(async move {
                 let mut rpc_client = RemoteEngineServiceClient::<Channel>::new(channel);
-                let rpc_result = rpc_client
+                rpc_client
                     .write_batch(Request::new(batch_request_pb))
                     .await
-                    .box_err();
-
-                rpc_result
+                    .box_err()
             });
 
             remote_writes.push(handle);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "nightly-2023-02-02"
+channel = "nightly-2023-08-28"
 components = [ "rustfmt", "clippy" ]

--- a/server/src/mysql/worker.rs
+++ b/server/src/mysql/worker.rs
@@ -38,7 +38,7 @@ where
 {
     pub fn new(proxy: Arc<Proxy>, timeout: Option<Duration>) -> Self {
         Self {
-            generic_hold: PhantomData::default(),
+            generic_hold: PhantomData,
             proxy,
             timeout,
         }

--- a/server/src/postgresql/handler.rs
+++ b/server/src/postgresql/handler.rs
@@ -130,7 +130,7 @@ fn into_pg_reponse<'a>(out: Output) -> PgWireResult<Response<'a>> {
 
             Ok(Response::Query(QueryResponse::new(
                 schema,
-                stream::iter(data_rows.into_iter()),
+                stream::iter(data_rows),
             )))
         }
     }

--- a/table_engine/src/partition/rule/key.rs
+++ b/table_engine/src/partition/rule/key.rs
@@ -52,10 +52,10 @@ impl KeyRule {
     /// Above logics are preparing for implementing something like:
     ///     fa1 && fa2 && fb =  (fa1 && fb) && (fa2 && fb)
     /// Partitions about above expression will be calculated by following steps:
-    ///     + partitions about "(fa1 && fb)" will be calculated first,
-    ///        assume "partitions 1"
-    ///     + partitions about "(fa2 && fb)"  will be calculated after,
-    ///        assume "partitions 2"
+    ///     + partitions about "(fa1 && fb)" will be calculated first, assume
+    ///       "partitions 1"
+    ///     + partitions about "(fa2 && fb)"  will be calculated after, assume
+    ///       "partitions 2"
     ///     + "total partitions" = "partitions 1" intersection "partitions 2"
     fn get_candidate_partition_keys_groups(
         &self,

--- a/tools/src/bin/sst-metadata.rs
+++ b/tools/src/bin/sst-metadata.rs
@@ -216,7 +216,7 @@ async fn run(args: Args) -> Result<()> {
             for i in 0..fields.len() {
                 let column_meta = row_group.column(i);
                 let field_name = fields.get(i).unwrap().get_basic_info().name().to_string();
-                let mut field_stats = field_stats_map
+                let field_stats = field_stats_map
                     .entry(field_name)
                     .or_insert(FieldStatistics::default());
                 field_stats.compressed_size += column_meta.compressed_size();

--- a/wal/src/message_queue_impl/region_context.rs
+++ b/wal/src/message_queue_impl/region_context.rs
@@ -513,10 +513,7 @@ impl RegionContextBuilder {
         debug!("Apply region meta delta, delta:{:?}", delta);
 
         // It is likely that snapshot not exist(e.g. no table has ever flushed).
-        let mut table_meta = self
-            .table_metas
-            .entry(delta.table_id)
-            .or_insert_with(TableMetaInner::default);
+        let table_meta = self.table_metas.entry(delta.table_id).or_default();
 
         table_meta.next_sequence_num = delta.sequence_num + 1;
         table_meta.current_high_watermark = delta.offset + 1;

--- a/wal/src/tests/read_write.rs
+++ b/wal/src/tests/read_write.rs
@@ -34,7 +34,7 @@ static INIT_LOG: Once = Once::new();
 
 #[test]
 fn test_rocksdb_wal() {
-    let builder = RocksWalBuilder::default();
+    let builder = RocksWalBuilder;
 
     test_all(builder, false);
 }


### PR DESCRIPTION
## Rationale
Some ci tools requires 1.72.0 rust, and the the vesion of the rust-toolchain which is used is 1.69.0-nightly.

## Detailed Changes
Upgrade the rust-toolchain to `nightly-2023-08-28`.

## Test Plan
The existing tests.