### PR TITLE
chore: add metrics for meta data cache hit rate

### DIFF
--- a/analytic_engine/src/sst/metrics.rs
+++ b/analytic_engine/src/sst/metrics.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use lazy_static::lazy_static;
-use prometheus::{exponential_buckets, register_histogram, Histogram};
+use prometheus::{exponential_buckets, register_counter, register_histogram, Counter, Histogram};
 
 lazy_static! {
     // Histogram:
@@ -22,5 +22,15 @@ lazy_static! {
         "sst_get_range_length",
         "Histogram for sst get range length",
         exponential_buckets(100.0, 2.0, 5).unwrap()
+    ).unwrap();
+
+    pub static ref META_DATA_CACHE_HIT_COUNTER: Counter = register_counter!(
+        "META_DATA_CACHE_HIT",
+        "The counter for meta data cache hit"
+    ).unwrap();
+
+    pub static ref META_DATA_CACHE_MISS_COUNTER: Counter = register_counter!(
+        "META_DATA_CACHE_MISS",
+        "The counter for meta data cache miss"
     ).unwrap();
 }

--- a/proxy/src/read.rs
+++ b/proxy/src/read.rs
@@ -160,7 +160,7 @@ impl Proxy {
         })?;
 
         let cost = begin_instant.saturating_elapsed();
-        info!("Handle sql query successfully, catalog:{catalog}, schema:{schema}, cost:{cost:?}, ctx:{ctx:?}");
+        info!("Handle sql query successfully, catalog:{catalog}, schema:{schema}, cost:{cost:?}, ctx:{ctx:?}, sql:{sql}");
 
         match &output {
             Output::AffectedRows(_) => Ok(output),


### PR DESCRIPTION
## Rationale
There is no metrics to report the hit rate for the meta data cache.

## Detailed Changes
- Add counter for the meta data cache hit/miss.
- Formalize the logs for the sql query and remote engine service query.

## Test Plan
Existing tests.