### PR TITLE
feat: limit multiple threads fetch the same block simultaneous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "notifier"
+version = "1.2.6-alpha"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +4453,7 @@ dependencies = [
  "log",
  "lru 0.7.8",
  "macros",
+ "notifier",
  "object_store 0.5.6",
  "partitioned_lock",
  "prometheus 0.12.0",
@@ -6267,6 +6275,7 @@ dependencies = [
  "logger",
  "macros",
  "meta_client",
+ "notifier",
  "opensrv-mysql",
  "partition_table_engine",
  "paste 1.0.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "components/macros",
     "components/message_queue",
     "components/metric_ext",
+    "components/notifier",
     "components/object_store",
     "components/panic_ext",
     "components/parquet_ext",
@@ -100,6 +101,7 @@ catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
 ceresdbproto = "1.0.13"
 codec = { path = "components/codec" }
+notifier = { path = "components/notifier" }
 chrono = "0.4"
 clap = "3.0"
 clru = "0.6.1"

--- a/components/notifier/Cargo.toml
+++ b/components/notifier/Cargo.toml
@@ -1,0 +1,28 @@
+# Copyright 2023 The CeresDB Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "notifier"
+
+[package.version]
+workspace = true
+
+[package.authors]
+workspace = true
+
+[package.edition]
+workspace = true
+
+[dependencies]
+tokio = { workspace = true }

--- a/components/notifier/src/lib.rs
+++ b/components/notifier/src/lib.rs
@@ -12,18 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Rpc server
-
-// TODO(yingwen):
-// Borrow some ideas from tikv: https://github.com/tikv/tikv/blob/dc8ce2cf6a8904cb3dad556f71b11bac3531689b/src/server/service/kv.rs#L51
-
-pub mod config;
-mod consts;
-mod error_util;
-mod grpc;
-mod http;
-pub mod local_tables;
-mod metrics;
-mod mysql;
-mod postgresql;
-pub mod server;
+pub mod notifier;

--- a/components/notifier/src/notifier.rs
+++ b/components/notifier/src/notifier.rs
@@ -99,3 +99,29 @@ pub enum RequestResult {
     // There are other requests for this key, just wait for the result.
     Wait,
 }
+
+pub struct ExecutionGuard<F: FnMut()> {
+    f: F,
+    cancelled: bool,
+}
+
+impl<F: FnMut()> ExecutionGuard<F> {
+    pub fn new(f: F) -> Self {
+        Self {
+            f,
+            cancelled: false,
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        self.cancelled = true;
+    }
+}
+
+impl<F: FnMut()> Drop for ExecutionGuard<F> {
+    fn drop(&mut self) {
+        if !self.cancelled {
+            (self.f)()
+        }
+    }
+}

--- a/components/notifier/src/notifier.rs
+++ b/components/notifier/src/notifier.rs
@@ -16,22 +16,20 @@ use std::{collections::HashMap, hash::Hash, sync::RwLock};
 
 use tokio::sync::mpsc::Sender;
 
-type Notifier<T> = Sender<T>;
-
 #[derive(Debug)]
 struct Notifiers<T> {
-    notifiers: RwLock<Vec<Notifier<T>>>,
+    notifiers: RwLock<Vec<T>>,
 }
 
 impl<T> Notifiers<T> {
-    pub fn new(notifier: Notifier<T>) -> Self {
+    pub fn new(notifier: T) -> Self {
         let notifiers = vec![notifier];
         Self {
             notifiers: RwLock::new(notifiers),
         }
     }
 
-    pub fn add_notifier(&self, notifier: Notifier<T>) {
+    pub fn add_notifier(&self, notifier: T) {
         self.notifiers.write().unwrap().push(notifier);
     }
 }
@@ -60,7 +58,7 @@ where
     K: PartialEq + Eq + Hash,
 {
     /// Insert a notifier for the given key.
-    pub fn insert_notifier(&self, key: K, notifier: Notifier<T>) -> RequestResult {
+    pub fn insert_notifier(&self, key: K, notifier: T) -> RequestResult {
         // First try to read the notifiers, if the key exists, add the notifier to the
         // notifiers.
         let notifiers_by_key = self.notifiers_by_key.read().unwrap();
@@ -84,7 +82,7 @@ where
     }
 
     /// Take the notifiers for the given key, and remove the key from the map.
-    pub fn take_notifiers(&self, key: &K) -> Option<Vec<Notifier<T>>> {
+    pub fn take_notifiers(&self, key: &K) -> Option<Vec<T>> {
         self.notifiers_by_key
             .write()
             .unwrap()

--- a/components/notifier/src/notifier.rs
+++ b/components/notifier/src/notifier.rs
@@ -14,8 +14,6 @@
 
 use std::{collections::HashMap, hash::Hash, sync::RwLock};
 
-use tokio::sync::mpsc::Sender;
-
 #[derive(Debug)]
 struct Notifiers<T> {
     notifiers: RwLock<Vec<T>>,

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -38,6 +38,7 @@ lazy_static = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 macros = { workspace = true }
+notifier = { path = "../notifier" }
 partitioned_lock = { workspace = true }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }

--- a/components/object_store/Cargo.toml
+++ b/components/object_store/Cargo.toml
@@ -38,7 +38,7 @@ lazy_static = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
 macros = { workspace = true }
-notifier = { path = "../notifier" }
+notifier = { workspace = true }
 partitioned_lock = { workspace = true }
 prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -978,7 +978,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_fuzz_disk_cache_multi_thread_fetch_same_block() {
+    async fn test_disk_cache_multi_thread_fetch_same_block() {
         let page_size = 16;
         // 51 byte
         let data = b"a b c d e f g h i j k l m n o p q r s t u v w x y z";

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -1043,7 +1043,7 @@ mod test {
             (16..100, "i j k l m n o p q r s t u v w x y za b c d e f g h i j k l m n o p q r s t u v w x y"),
         ];
         let testcases: Vec<(Range<usize>, &str)> =
-            testcases.iter().cycle().take(9).cloned().collect();
+            testcases.iter().cycle().take(testcases.len() * 9).cloned().collect();
 
         let mut tasks = vec![];
         for (input, expected) in testcases {

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -833,12 +833,11 @@ impl ObjectStore for DiskCacheStore {
             }
         }
 
-        let mut missing_ranged_bytes = vec![];
-        let mut rxs = self
+        let mut missing_ranged_bytes = Vec::with_capacity(missing_ranges.len());
+        let rxs = self
             .deduped_fetch_data(location, missing_ranges.clone())
             .await?;
-
-        for rx in rxs.iter_mut() {
+        for rx in rxs {
             let bytes = rx.await.context(ReceiveBytesFromChannel)??;
             missing_ranged_bytes.push(bytes);
         }
@@ -1017,20 +1016,18 @@ mod test {
         let testcases = vec![
             (0..6, "a b c "),
             (0..16, "a b c d e f g h "),
-            // len of aligned ranges will be 2
             (0..17, "a b c d e f g h i"),
             (16..17, "i"),
-            // len of aligned ranges will be 6
             (16..100, "i j k l m n o p q r s t u v w x y za b c d e f g h i j k l m n o p q r s t u v w x y"),
         ];
         let testcases = testcases
             .iter()
             .cycle()
-            .take(testcases.len() * 9)
+            .take(testcases.len() * 100)
             .cloned()
             .collect::<Vec<_>>();
 
-        let mut tasks = vec![];
+        let mut tasks = Vec::with_capacity(testcases.len());
         for (input, _) in &testcases {
             let store = store.clone();
             let location = location.clone();

--- a/components/object_store/src/disk_cache.rs
+++ b/components/object_store/src/disk_cache.rs
@@ -19,7 +19,7 @@
 //! Page is used for reasons below:
 //! - reduce file size in case of there are too many request with small range.
 
-use std::{fmt::Display, mem, ops::Range, sync::Arc};
+use std::{fmt::Display, ops::Range, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
@@ -700,7 +700,7 @@ impl DiskCacheStore {
         for i in rx {
             bytes_vec.push(Self::get_data_from_channel_data(i.await)?);
         }
-        let bytes = mem::replace(&mut bytes_vec[0], Bytes::default());
+        let bytes = std::mem::take(&mut bytes_vec[0]);
         Ok(bytes)
     }
 

--- a/components/object_store/src/metrics.rs
+++ b/components/object_store/src/metrics.rs
@@ -19,7 +19,9 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use lazy_static::lazy_static;
 use log::trace;
-use prometheus::{exponential_buckets, register_histogram_vec, HistogramVec};
+use prometheus::{
+    exponential_buckets, register_histogram_vec, register_int_counter, HistogramVec, IntCounter,
+};
 use prometheus_static_metric::make_static_metric;
 use runtime::Runtime;
 use tokio::io::AsyncWrite;
@@ -73,6 +75,14 @@ lazy_static! {
         &["op"],
         // The max bound value is 64 * 2^24 = 1GB
         exponential_buckets(64.0, 4.0, 12).unwrap()
+    )
+    .unwrap();
+}
+
+lazy_static! {
+    pub static ref DISK_CACHE_DEDUP_COUNT: IntCounter = register_int_counter!(
+        "disk_cache_dedup_counter",
+        "Dedup disk cache fetch request counts"
     )
     .unwrap();
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,7 +48,7 @@ log = { workspace = true }
 logger = { workspace = true }
 macros = { workspace = true }
 meta_client = { workspace = true }
-notifier = { path = "../components/notifier" }
+notifier = { workspace = true }
 opensrv-mysql = "0.1.0"
 partition_table_engine = { workspace = true }
 paste = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -48,6 +48,7 @@ log = { workspace = true }
 logger = { workspace = true }
 macros = { workspace = true }
 meta_client = { workspace = true }
+notifier = { path = "../components/notifier" }
 opensrv-mysql = "0.1.0"
 partition_table_engine = { workspace = true }
 paste = { workspace = true }

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -44,7 +44,10 @@ use proxy::{
 use runtime::{JoinHandle, Runtime};
 use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
 use table_engine::engine::EngineRuntimes;
-use tokio::sync::oneshot::{self, Sender};
+use tokio::sync::{
+    mpsc,
+    oneshot::{self, Sender},
+};
 use tonic::transport::Server;
 
 use crate::grpc::{
@@ -213,7 +216,8 @@ pub struct Builder {
     cluster: Option<ClusterRef>,
     opened_wals: Option<OpenedWals>,
     proxy: Option<Arc<Proxy>>,
-    request_notifiers: Option<Arc<RequestNotifiers<StreamReadReqKey, error::Result<RecordBatch>>>>,
+    request_notifiers:
+        Option<Arc<RequestNotifiers<StreamReadReqKey, mpsc::Sender<error::Result<RecordBatch>>>>>,
     hotspot_recorder: Option<Arc<HotspotRecorder>>,
 }
 

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -33,6 +33,7 @@ use futures::FutureExt;
 use generic_error::GenericError;
 use log::{info, warn};
 use macros::define_result;
+use notifier::notifier::RequestNotifiers;
 use proxy::{
     forward,
     hotspot::HotspotRecorder,
@@ -46,13 +47,10 @@ use table_engine::engine::EngineRuntimes;
 use tokio::sync::oneshot::{self, Sender};
 use tonic::transport::Server;
 
-use crate::{
-    dedup_requests::RequestNotifiers,
-    grpc::{
-        meta_event_service::MetaServiceImpl,
-        remote_engine_service::{error, RemoteEngineServiceImpl, StreamReadReqKey},
-        storage_service::StorageServiceImpl,
-    },
+use crate::grpc::{
+    meta_event_service::MetaServiceImpl,
+    remote_engine_service::{error, RemoteEngineServiceImpl, StreamReadReqKey},
+    storage_service::StorageServiceImpl,
 };
 
 mod meta_event_service;

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -109,7 +109,8 @@ impl<F: FnMut()> Drop for ExecutionGuard<F> {
 pub struct RemoteEngineServiceImpl {
     pub instance: InstanceRef,
     pub runtimes: Arc<EngineRuntimes>,
-    pub request_notifiers: Option<Arc<RequestNotifiers<StreamReadReqKey, Result<RecordBatch>>>>,
+    pub request_notifiers:
+        Option<Arc<RequestNotifiers<StreamReadReqKey, mpsc::Sender<Result<RecordBatch>>>>>,
     pub hotspot_recorder: Arc<HotspotRecorder>,
 }
 
@@ -164,7 +165,9 @@ impl RemoteEngineServiceImpl {
 
     async fn deduped_stream_read_internal(
         &self,
-        request_notifiers: Arc<RequestNotifiers<StreamReadReqKey, Result<RecordBatch>>>,
+        request_notifiers: Arc<
+            RequestNotifiers<StreamReadReqKey, mpsc::Sender<Result<RecordBatch>>>,
+        >,
         request: Request<ReadRequest>,
     ) -> Result<ReceiverStream<Result<RecordBatch>>> {
         let instant = Instant::now();

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -31,6 +31,7 @@ use common_types::record_batch::RecordBatch;
 use futures::stream::{self, BoxStream, FuturesUnordered, StreamExt};
 use generic_error::BoxError;
 use log::{error, info};
+use notifier::notifier::{RequestNotifiers, RequestResult};
 use proxy::{
     hotspot::{HotspotRecorder, Message},
     instance::InstanceRef,
@@ -49,15 +50,11 @@ use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
 use super::metrics::REMOTE_ENGINE_WRITE_BATCH_NUM_ROWS_HISTOGRAM;
-use crate::{
-    dedup_requests::{RequestNotifiers, RequestResult},
-    grpc::{
-        metrics::{
-            REMOTE_ENGINE_GRPC_HANDLER_COUNTER_VEC,
-            REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC,
-        },
-        remote_engine_service::error::{ErrNoCause, ErrWithCause, Result, StatusCode},
+use crate::grpc::{
+    metrics::{
+        REMOTE_ENGINE_GRPC_HANDLER_COUNTER_VEC, REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC,
     },
+    remote_engine_service::error::{ErrNoCause, ErrWithCause, Result, StatusCode},
 };
 
 pub mod error;


### PR DESCRIPTION
## Rationale
The current disk cache may encounter the following scenario: Multiple threads taking the same block from object_store at the same time, To avoid this problem, we maintain a pull queue for each block, so that only one thread will pull the same block at the same time.

## Detailed Changes


## Test Plan
Add new UT `test_disk_cache_multi_thread_fetch_same_block`