### PR TITLE
chore: add meta stable check into integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,7 @@ dependencies = [
  "serde",
  "sqlness",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -28,3 +28,4 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 sqlness = "0.4.3"
 tokio = { workspace = true }
+uuid = { version = "1.3", features = ["v4"] }

--- a/integration_tests/src/database.rs
+++ b/integration_tests/src/database.rs
@@ -19,7 +19,7 @@ use std::{
     fs::File,
     process::{Child, Command},
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -30,6 +30,7 @@ use ceresdb_client::{
 };
 use reqwest::{ClientBuilder, Url};
 use sqlness::{Database, QueryContext};
+use uuid::Timestamp;
 
 const SERVER_GRPC_ENDPOINT_ENV: &str = "CERESDB_SERVER_GRPC_ENDPOINT";
 const SERVER_HTTP_ENDPOINT_ENV: &str = "CERESDB_SERVER_HTTP_ENDPOINT";
@@ -44,6 +45,7 @@ const CERESDB_CONFIG_FILE_0_ENV: &str = "CERESDB_CONFIG_FILE_0";
 const CERESDB_CONFIG_FILE_1_ENV: &str = "CERESDB_CONFIG_FILE_1";
 const CLUSTER_CERESDB_STDOUT_FILE_0_ENV: &str = "CLUSTER_CERESDB_STDOUT_FILE_0";
 const CLUSTER_CERESDB_STDOUT_FILE_1_ENV: &str = "CLUSTER_CERESDB_STDOUT_FILE_1";
+const CLUSTER_CERESDB_HEALTH_CHECK_INTERVAL_SECONDS: usize = 5;
 
 const CERESDB_SERVER_ADDR: &str = "CERESDB_SERVER_ADDR";
 
@@ -63,9 +65,10 @@ impl HttpClient {
     }
 }
 
+#[async_trait]
 pub trait Backend {
     fn start() -> Self;
-    fn wait_for_ready(&self);
+    async fn wait_for_ready(&self);
     fn stop(&mut self);
 }
 
@@ -77,6 +80,10 @@ pub struct CeresDBCluster {
     server0: CeresDBServer,
     server1: CeresDBServer,
     ceresmeta_process: Child,
+
+    /// Used in meta health check
+    db_client: Arc<dyn DbClient>,
+    health_check_sql: String,
 }
 
 impl CeresDBServer {
@@ -97,6 +104,7 @@ impl CeresDBServer {
     }
 }
 
+#[async_trait]
 impl Backend for CeresDBServer {
     fn start() -> Self {
         let config = env::var(CERESDB_CONFIG_FILE_ENV).expect("Cannot parse ceresdb config env");
@@ -105,8 +113,8 @@ impl Backend for CeresDBServer {
         Self::spawn(bin, config, stdout)
     }
 
-    fn wait_for_ready(&self) {
-        std::thread::sleep(Duration::from_secs(5));
+    async fn wait_for_ready(&self) {
+        tokio::time::sleep(Duration::from_secs(10)).await
     }
 
     fn stop(&mut self) {
@@ -114,6 +122,24 @@ impl Backend for CeresDBServer {
     }
 }
 
+impl CeresDBCluster {
+    async fn check_meta_health(&self) -> bool {
+        let query_ctx = RpcContext {
+            database: Some("public".to_string()),
+            timeout: None,
+        };
+
+        let query_req = Request {
+            tables: vec![],
+            sql: self.health_check_sql.clone(),
+        };
+
+        let result = self.db_client.sql_query(&query_ctx, &query_req).await;
+        result.is_ok()
+    }
+}
+
+#[async_trait]
 impl Backend for CeresDBCluster {
     fn start() -> Self {
         let ceresmeta_bin =
@@ -149,16 +175,56 @@ impl Backend for CeresDBCluster {
         let server0 = CeresDBServer::spawn(ceresdb_bin.clone(), ceresdb_config_0, stdout0);
         let server1 = CeresDBServer::spawn(ceresdb_bin, ceresdb_config_1, stdout1);
 
+        // Health check context
+        let endpoint = env::var(SERVER_GRPC_ENDPOINT_ENV).unwrap_or_else(|_| {
+            panic!("Cannot read server endpoint from env {SERVER_GRPC_ENDPOINT_ENV:?}")
+        });
+        let db_client = Builder::new(endpoint, Mode::Proxy).build();
+
+        let health_check_sql = format!(
+            r#"CREATE TABLE `health_check_{}`
+            (`name` string TAG, `value` double NOT NULL, `t` timestamp NOT NULL, TIMESTAMP KEY(t))"#,
+            "asfdasfadsfad"
+        );
+
         Self {
             server0,
             server1,
             ceresmeta_process,
+            db_client,
+            health_check_sql,
         }
     }
 
-    fn wait_for_ready(&self) {
-        println!("wait for cluster service ready...\n");
-        std::thread::sleep(Duration::from_secs(20));
+    async fn wait_for_ready(&self) {
+        println!("wait for cluster service initialized...\n");
+        tokio::time::sleep(Duration::from_secs(
+            20 as u64,
+        ))
+        .await;
+        
+        println!("wait for cluster service stable begin...\n");
+        let mut wait_cnt = 0;
+        let wait_max = 6;
+        loop {
+            if wait_cnt >= wait_max {
+                println!("wait too long for cluster service stable, maybe somethings went wrong...");
+                return;
+            }
+
+            if self.check_meta_health().await {
+                println!("wait cluster service stable finished...\n");
+                return;
+            }
+
+            wait_cnt += 1;
+            let has_waited = wait_cnt * CLUSTER_CERESDB_HEALTH_CHECK_INTERVAL_SECONDS;
+            println!("waiting for cluster service stable, has_waited:{has_waited}s\n");
+            tokio::time::sleep(Duration::from_secs(
+                CLUSTER_CERESDB_HEALTH_CHECK_INTERVAL_SECONDS as u64,
+            ))
+            .await;
+        }
     }
 
     fn stop(&mut self) {
@@ -226,9 +292,9 @@ impl<T: Send + Sync> Database for CeresDB<T> {
 }
 
 impl<T: Backend> CeresDB<T> {
-    pub fn create() -> CeresDB<T> {
+    pub async fn create() -> CeresDB<T> {
         let backend = T::start();
-        backend.wait_for_ready();
+        backend.wait_for_ready().await;
 
         let endpoint = env::var(SERVER_GRPC_ENDPOINT_ENV).unwrap_or_else(|_| {
             panic!("Cannot read server endpoint from env {SERVER_GRPC_ENDPOINT_ENV:?}")

--- a/integration_tests/src/main.rs
+++ b/integration_tests/src/main.rs
@@ -60,8 +60,8 @@ impl EnvController for CeresDBController {
     async fn start(&self, env: &str, _config: Option<&Path>) -> Self::DB {
         println!("start with env {env}");
         let db = match env {
-            "local" => Box::new(CeresDB::<CeresDBServer>::create()) as DbRef,
-            "cluster" => Box::new(CeresDB::<CeresDBCluster>::create()) as DbRef,
+            "local" => Box::new(CeresDB::<CeresDBServer>::create().await) as DbRef,
+            "cluster" => Box::new(CeresDB::<CeresDBCluster>::create().await) as DbRef,
             _ => panic!("invalid env {env}"),
         };
 


### PR DESCRIPTION
## Rationale
Currently, we just left 20s for ceresmeta to do the initialization work in integration test.
However, it will be not enough something... And the test failure will make us so panic...
In this pr, I add a meta stable check to reduce the integration test failure.

## Detailed Changes
Add a meta stable check by keep creating a radom named table utill succeeding(surely, retry max exists).

## Test Plan
Test manually.
