### PR TITLE
fix: lock contention on acquiring the arena stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,9 +197,6 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 [[package]]
 name = "arena"
 version = "1.2.6-alpha"
-dependencies = [
- "parking_lot 0.11.2",
-]
 
 [[package]]
 name = "arrayref"

--- a/components/arena/Cargo.toml
+++ b/components/arena/Cargo.toml
@@ -25,4 +25,3 @@ workspace = true
 workspace = true
 
 [dependencies]
-parking_lot = "0.11.1"

--- a/components/arena/src/mono_inc.rs
+++ b/components/arena/src/mono_inc.rs
@@ -15,10 +15,8 @@
 use std::{
     alloc::{alloc, dealloc, Layout},
     ptr::NonNull,
-    sync::Arc,
+    sync::{Arc, RwLock},
 };
-
-use parking_lot::Mutex;
 
 use crate::arena_trait::{Arena, BasicStats, Collector, CollectorRef};
 
@@ -39,13 +37,13 @@ const DEFAULT_ALIGN: usize = 8;
 /// allocated memory as blocks.
 #[derive(Clone)]
 pub struct MonoIncArena {
-    core: Arc<Mutex<ArenaCore>>,
+    core: Arc<RwLock<ArenaCore>>,
 }
 
 impl MonoIncArena {
     pub fn new(regular_block_size: usize) -> Self {
         Self {
-            core: Arc::new(Mutex::new(ArenaCore::new(
+            core: Arc::new(RwLock::new(ArenaCore::new(
                 regular_block_size,
                 Arc::new(NoopCollector {}),
             ))),
@@ -54,7 +52,7 @@ impl MonoIncArena {
 
     pub fn with_collector(regular_block_size: usize, collector: CollectorRef) -> Self {
         Self {
-            core: Arc::new(Mutex::new(ArenaCore::new(regular_block_size, collector))),
+            core: Arc::new(RwLock::new(ArenaCore::new(regular_block_size, collector))),
         }
     }
 }
@@ -63,15 +61,15 @@ impl Arena for MonoIncArena {
     type Stats = BasicStats;
 
     fn try_alloc(&self, layout: Layout) -> Option<NonNull<u8>> {
-        Some(self.core.lock().alloc(layout))
+        Some(self.core.write().unwrap().alloc(layout))
     }
 
     fn stats(&self) -> Self::Stats {
-        self.core.lock().stats
+        self.core.read().unwrap().stats
     }
 
     fn alloc(&self, layout: Layout) -> NonNull<u8> {
-        self.core.lock().alloc(layout)
+        self.core.write().unwrap().alloc(layout)
     }
 }
 


### PR DESCRIPTION
## Rationale
There is no need to acquire the write lock when fetch arena's stats.

## Detailed Changes
Use `RwLock` instead of `Mutex` to protect the core of the `MonoIncArena` to avoid lock contention.

## Test Plan
Existing tests.