### PR TITLE
refactor: avoid memory allocation during partition write requests

### DIFF
--- a/analytic_engine/src/table/version.rs
+++ b/analytic_engine/src/table/version.rs
@@ -256,7 +256,7 @@ pub type MemTableVec = Vec<MemTableState>;
 struct MemTableView {
     /// The memtable for sampling timestamp to suggest segment duration.
     ///
-    /// This memtable is special and may contains data in differnt segment, so
+    /// This memtable is special and may contains data in different segment, so
     /// can not be moved into immutable memtable set.
     sampling_mem: Option<SamplingMemTable>,
     /// Mutable memtables arranged by its time range.
@@ -399,7 +399,7 @@ impl MutableMemTableSet {
         Self(BTreeMap::new())
     }
 
-    /// Get memtale by timestamp for write
+    /// Get memtable by timestamp for write
     fn memtable_for_write(&self, timestamp: Timestamp) -> Option<&MemTableState> {
         // Find the first memtable whose end time (exclusive) > timestamp
         if let Some((_, memtable)) = self
@@ -607,8 +607,8 @@ impl TableVersion {
 
     /// Switch all mutable memtables
     ///
-    /// Returns the maxium `SequenceNumber` in the mutable memtables needs to be
-    /// freezed.
+    /// Returns the maximum `SequenceNumber` in the mutable memtables needs to
+    /// be freezed.
     pub fn switch_memtables(&self) -> Option<SequenceNumber> {
         self.inner.write().unwrap().memtable_view.switch_memtables()
     }

--- a/components/arena/src/arena_trait.rs
+++ b/components/arena/src/arena_trait.rs
@@ -19,7 +19,7 @@ use std::{alloc::Layout, ptr::NonNull, sync::Arc};
 /// The trait itself provides and enforces no guarantee about alignment. It's
 /// implementation's responsibility to cover.
 ///
-/// All memory-relavent methods (`alloc()` etc.) are not "unsafe". Compare with
+/// All memory-relevant methods (`alloc()` etc.) are not "unsafe". Compare with
 /// "deallocate" which is not included in this trait, allocating is more safer
 /// and not likely to run into UB. However in fact, playing with raw pointer is
 /// always dangerous and needs to be careful for both who implements and uses
@@ -66,7 +66,7 @@ impl BasicStats {
     }
 }
 
-/// Collect memory usage from Arean
+/// Collect memory usage from Arena.
 pub trait Collector {
     /// Called when `bytes` bytes memory is allocated in arena.
     fn on_alloc(&self, bytes: usize);

--- a/components/skiplist/src/list.rs
+++ b/components/skiplist/src/list.rs
@@ -400,7 +400,7 @@ impl<C: KeyComparator, A: Arena<Stats = BasicStats> + Clone> Skiplist<C, A> {
         }
 
         // We always insert from the base level and up. After you add a node in base
-        // leve, we cannot create a node in the level above because it would
+        // level, we cannot create a node in the level above because it would
         // have discovered the node in the base level
         let x: &mut Node = unsafe { &mut *node_ptr };
         for i in 0..=height {

--- a/partition_table_engine/src/partition.rs
+++ b/partition_table_engine/src/partition.rs
@@ -19,7 +19,7 @@ use std::{collections::HashMap, fmt};
 use analytic_engine::{table::support_pushdown, TableOptions};
 use async_trait::async_trait;
 use common_types::{
-    row::{Row, RowGroupBuilder},
+    row::{Row, RowGroup, RowGroupBuilder},
     schema::Schema,
 };
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -27,7 +27,12 @@ use generic_error::BoxError;
 use snafu::ResultExt;
 use table_engine::{
     partition::{
-        format_sub_partition_table_name, rule::df_adapter::DfPartitionRuleAdapter, PartitionInfo,
+        format_sub_partition_table_name,
+        rule::{
+            df_adapter::DfPartitionRuleAdapter, PartitionedRow, PartitionedRowGroup,
+            PartitionedRowsIter,
+        },
+        PartitionInfo,
     },
     remote::{
         model::{
@@ -64,13 +69,23 @@ pub struct TableData {
 pub struct PartitionTableImpl {
     table_data: TableData,
     remote_engine: RemoteEngineRef,
+    partition_rule: DfPartitionRuleAdapter,
 }
 
 impl PartitionTableImpl {
     pub fn new(table_data: TableData, remote_engine: RemoteEngineRef) -> Result<Self> {
+        // Build partition rule.
+        let partition_rule = DfPartitionRuleAdapter::new(
+            table_data.partition_info.clone(),
+            &table_data.table_schema,
+        )
+        .box_err()
+        .context(CreatePartitionRule)?;
+
         Ok(Self {
             table_data,
             remote_engine,
+            partition_rule,
         })
     }
 
@@ -83,6 +98,86 @@ impl PartitionTableImpl {
             schema: self.table_data.schema_name.clone(),
             table: format_sub_partition_table_name(&self.table_data.table_name, &partition_name),
         }
+    }
+
+    async fn write_single_row_group(
+        &self,
+        partition_id: usize,
+        row_group: RowGroup,
+    ) -> Result<usize> {
+        let sub_table_ident = self.get_sub_table_ident(partition_id);
+
+        let request = RemoteWriteRequest {
+            table: sub_table_ident,
+            write_request: WriteRequest { row_group },
+        };
+
+        self.remote_engine
+            .write(request)
+            .await
+            .box_err()
+            .with_context(|| WriteBatch {
+                tables: vec![self.table_data.table_name.clone()],
+            })
+    }
+
+    async fn write_partitioned_row_groups(
+        &self,
+        schema: Schema,
+        partitioned_rows: PartitionedRowsIter,
+    ) -> Result<usize> {
+        let mut split_rows = HashMap::new();
+        for PartitionedRow { partition_idx, row } in partitioned_rows {
+            split_rows
+                .entry(partition_idx)
+                .or_insert_with(Vec::new)
+                .push(row);
+        }
+
+        // Insert split write request through remote engine.
+        let mut request_batch = Vec::with_capacity(split_rows.len());
+        for (partition, rows) in split_rows {
+            let sub_table_ident = self.get_sub_table_ident(partition);
+            let row_group = RowGroupBuilder::with_rows(schema.clone(), rows)
+                .box_err()
+                .with_context(|| Write {
+                    table: sub_table_ident.table.clone(),
+                })?
+                .build();
+
+            let request = RemoteWriteRequest {
+                table: sub_table_ident,
+                write_request: WriteRequest { row_group },
+            };
+            request_batch.push(request);
+        }
+
+        let batch_results = self
+            .remote_engine
+            .write_batch(request_batch)
+            .await
+            .box_err()
+            .with_context(|| WriteBatch {
+                tables: vec![self.table_data.table_name.clone()],
+            })?;
+        let mut total_rows = 0;
+        for batch_result in batch_results {
+            let WriteBatchResult {
+                table_idents,
+                result,
+            } = batch_result;
+
+            let written_rows = result.with_context(|| {
+                let tables = table_idents
+                    .into_iter()
+                    .map(|ident| ident.table)
+                    .collect::<Vec<_>>();
+                WriteBatch { tables }
+            })?;
+            total_rows += written_rows;
+        }
+
+        Ok(total_rows as usize)
     }
 }
 
@@ -137,83 +232,27 @@ impl Table for PartitionTableImpl {
             .with_label_values(&["total"])
             .start_timer();
 
-        // Build partition rule.
-        let df_partition_rule = match self.partition_info() {
-            None => UnexpectedWithMsg {
-                msg: "partition table partition info can't be empty",
-            }
-            .fail()?,
-            Some(partition_info) => {
-                DfPartitionRuleAdapter::new(partition_info, &self.table_data.table_schema)
-                    .box_err()
-                    .context(CreatePartitionRule)?
-            }
-        };
-
         // Split write request.
-        let partitions = {
+        let schema = request.row_group.schema().clone();
+        let partition_rows = {
             let _locate_timer = PARTITION_TABLE_WRITE_DURATION_HISTOGRAM
                 .with_label_values(&["locate"])
                 .start_timer();
-            df_partition_rule
-                .locate_partitions_for_write(&request.row_group)
+            self.partition_rule
+                .locate_partitions_for_write(request.row_group)
                 .box_err()
                 .context(LocatePartitions)?
         };
 
-        let mut split_rows = HashMap::new();
-        let schema = request.row_group.schema().clone();
-        for (partition, row) in partitions.into_iter().zip(request.row_group.into_iter()) {
-            split_rows
-                .entry(partition)
-                .or_insert_with(Vec::new)
-                .push(row);
+        match partition_rows {
+            PartitionedRowGroup::One {
+                partition_idx,
+                row_group,
+            } => self.write_single_row_group(partition_idx, row_group).await,
+            PartitionedRowGroup::Multiple(iter) => {
+                self.write_partitioned_row_groups(schema, iter).await
+            }
         }
-
-        // Insert split write request through remote engine.
-        let mut request_batch = Vec::with_capacity(split_rows.len());
-        for (partition, rows) in split_rows {
-            let sub_table_ident = self.get_sub_table_ident(partition);
-            let row_group = RowGroupBuilder::with_rows(schema.clone(), rows)
-                .box_err()
-                .with_context(|| Write {
-                    table: sub_table_ident.table.clone(),
-                })?
-                .build();
-
-            let request = RemoteWriteRequest {
-                table: sub_table_ident,
-                write_request: WriteRequest { row_group },
-            };
-            request_batch.push(request);
-        }
-
-        let batch_results = self
-            .remote_engine
-            .write_batch(request_batch)
-            .await
-            .box_err()
-            .context(WriteBatch {
-                tables: vec![self.table_data.table_name.clone()],
-            })?;
-        let mut total_rows = 0;
-        for batch_result in batch_results {
-            let WriteBatchResult {
-                table_idents,
-                result,
-            } = batch_result;
-
-            let written_rows = result.with_context(|| {
-                let tables = table_idents
-                    .into_iter()
-                    .map(|ident| ident.table)
-                    .collect::<Vec<_>>();
-                WriteBatch { tables }
-            })?;
-            total_rows += written_rows;
-        }
-
-        Ok(total_rows as usize)
     }
 
     async fn read(&self, _request: ReadRequest) -> Result<SendableRecordBatchStream> {

--- a/partition_table_engine/src/partition.rs
+++ b/partition_table_engine/src/partition.rs
@@ -29,7 +29,7 @@ use table_engine::{
     partition::{
         format_sub_partition_table_name,
         rule::{
-            df_adapter::DfPartitionRuleAdapter, PartitionedRow, PartitionedRowGroup,
+            df_adapter::DfPartitionRuleAdapter, PartitionedRow, PartitionedRows,
             PartitionedRowsIter,
         },
         PartitionInfo,
@@ -127,9 +127,9 @@ impl PartitionTableImpl {
         partitioned_rows: PartitionedRowsIter,
     ) -> Result<usize> {
         let mut split_rows = HashMap::new();
-        for PartitionedRow { partition_idx, row } in partitioned_rows {
+        for PartitionedRow { partition_id, row } in partitioned_rows {
             split_rows
-                .entry(partition_idx)
+                .entry(partition_id)
                 .or_insert_with(Vec::new)
                 .push(row);
         }
@@ -245,11 +245,11 @@ impl Table for PartitionTableImpl {
         };
 
         match partition_rows {
-            PartitionedRowGroup::One {
-                partition_idx,
+            PartitionedRows::One {
+                partition_id,
                 row_group,
-            } => self.write_single_row_group(partition_idx, row_group).await,
-            PartitionedRowGroup::Multiple(iter) => {
+            } => self.write_single_row_group(partition_id, row_group).await,
+            PartitionedRows::Multiple(iter) => {
                 self.write_partitioned_row_groups(schema, iter).await
             }
         }

--- a/partition_table_engine/src/partition.rs
+++ b/partition_table_engine/src/partition.rs
@@ -245,7 +245,7 @@ impl Table for PartitionTableImpl {
         };
 
         match partition_rows {
-            PartitionedRows::One {
+            PartitionedRows::Single {
                 partition_id,
                 row_group,
             } => self.write_single_row_group(partition_id, row_group).await,

--- a/table_engine/src/partition/mod.rs
+++ b/table_engine/src/partition/mod.rs
@@ -72,8 +72,11 @@ pub enum Error {
     ))]
     InvalidPartitionInfoEncodingVersion { version: u8, backtrace: Backtrace },
 
-    #[snafu(display("Partition info could not be empty"))]
-    EmptyPartitionInfo {},
+    #[snafu(display("Partition info could not be empty.\nBacktrace:\n{backtrace}"))]
+    EmptyPartitionInfo { backtrace: Backtrace },
+
+    #[snafu(display("Column in the partition key is not found.\nBacktrace:\n{backtrace}"))]
+    InvalidPartitionKey { backtrace: Backtrace },
 }
 
 define_result!(Error);
@@ -281,7 +284,7 @@ impl TryFrom<ceresdbproto::cluster::PartitionInfo> for PartitionInfo {
                     Ok(Self::Random(random_partition_info))
                 }
             },
-            None => Err(Error::EmptyPartitionInfo {}),
+            None => EmptyPartitionInfo {}.fail(),
         }
     }
 }

--- a/table_engine/src/partition/rule/factory.rs
+++ b/table_engine/src/partition/rule/factory.rs
@@ -21,7 +21,7 @@ use crate::partition::{
     rule::{
         key::{KeyRule, DEFAULT_PARTITION_VERSION},
         random::RandomRule,
-        PartitionRuleRef,
+        PartitionRulePtr,
     },
     BuildPartitionRule, InvalidPartitionKey, KeyPartitionInfo, PartitionInfo, RandomPartitionInfo,
     Result,
@@ -30,7 +30,7 @@ use crate::partition::{
 pub struct PartitionRuleFactory;
 
 impl PartitionRuleFactory {
-    pub fn create(partition_info: PartitionInfo, schema: &Schema) -> Result<PartitionRuleRef> {
+    pub fn create(partition_info: PartitionInfo, schema: &Schema) -> Result<PartitionRulePtr> {
         match partition_info {
             PartitionInfo::Key(key_info) => Self::create_key_rule(key_info, schema),
             PartitionInfo::Random(random_info) => Self::create_random_rule(random_info),
@@ -41,7 +41,7 @@ impl PartitionRuleFactory {
         }
     }
 
-    fn create_key_rule(key_info: KeyPartitionInfo, schema: &Schema) -> Result<PartitionRuleRef> {
+    fn create_key_rule(key_info: KeyPartitionInfo, schema: &Schema) -> Result<PartitionRulePtr> {
         ensure!(
             key_info.version == DEFAULT_PARTITION_VERSION,
             BuildPartitionRule {
@@ -63,7 +63,7 @@ impl PartitionRuleFactory {
         )))
     }
 
-    fn create_random_rule(random_info: RandomPartitionInfo) -> Result<PartitionRuleRef> {
+    fn create_random_rule(random_info: RandomPartitionInfo) -> Result<PartitionRulePtr> {
         Ok(Box::new(RandomRule {
             partition_num: random_info.definitions.len(),
         }))

--- a/table_engine/src/partition/rule/key.rs
+++ b/table_engine/src/partition/rule/key.rs
@@ -25,16 +25,33 @@ use itertools::Itertools;
 use log::{debug, error};
 use snafu::OptionExt;
 
+use super::{PartitionedRow, PartitionedRowGroup};
 use crate::partition::{
-    rule::{filter::PartitionCondition, ColumnWithType, PartitionFilter, PartitionRule},
+    rule::{filter::PartitionCondition, PartitionFilter, PartitionRule},
     Internal, LocateWritePartition, Result,
 };
 
 pub const DEFAULT_PARTITION_VERSION: i32 = 0;
 
 pub struct KeyRule {
-    pub typed_key_columns: Vec<ColumnWithType>,
-    pub partition_num: usize,
+    columns: Vec<String>,
+    name_to_idx: HashMap<String, usize>,
+    partition_num: usize,
+}
+
+impl KeyRule {
+    pub fn new(partition_num: usize, columns: Vec<String>) -> Self {
+        let name_to_idx = columns
+            .iter()
+            .enumerate()
+            .map(|(idx, name)| (name.clone(), idx))
+            .collect();
+        Self {
+            columns,
+            name_to_idx,
+            partition_num,
+        }
+    }
 }
 
 impl KeyRule {
@@ -61,22 +78,17 @@ impl KeyRule {
         &self,
         filters: &[PartitionFilter],
     ) -> Result<Vec<Vec<usize>>> {
-        let column_name_to_idxs = self
-            .typed_key_columns
-            .iter()
-            .enumerate()
-            .map(|(col_idx, typed_col)| (typed_col.column.clone(), col_idx))
-            .collect::<HashMap<_, _>>();
-        let mut filter_by_columns = vec![Vec::new(); self.typed_key_columns.len()];
+        let mut filter_by_columns = vec![Vec::new(); self.columns.len()];
 
         // Group the filters by their columns.
         for (filter_idx, filter) in filters.iter().enumerate() {
-            let col_idx = column_name_to_idxs
+            let col_idx = self
+                .name_to_idx
                 .get(filter.column.as_str())
                 .context(Internal {
                     msg: format!(
                         "column in filters but not in target, column:{}, targets:{:?}",
-                        filter.column, self.typed_key_columns
+                        filter.column, self.columns,
                     ),
                 })?;
 
@@ -90,8 +102,8 @@ impl KeyRule {
             filter_by_columns
         );
 
-        let empty_filter = filter_by_columns.iter().find(|filter| filter.is_empty());
-        if empty_filter.is_some() {
+        let contains_empty_filter = filter_by_columns.iter().any(|filter| filter.is_empty());
+        if contains_empty_filter {
             return Ok(Vec::default());
         }
 
@@ -108,11 +120,15 @@ impl KeyRule {
         Ok(groups)
     }
 
-    fn compute_partition_for_inserted_row(&self, row: &Row, target_column_idxs: &[usize]) -> usize {
+    fn compute_partition_for_inserted_row(
+        row: &Row,
+        partition_num: usize,
+        target_column_idxs: &[usize],
+    ) -> usize {
         let partition_keys = target_column_idxs
             .iter()
             .map(|col_idx| row[*col_idx].as_view());
-        compute_partition(partition_keys, self.partition_num)
+        compute_partition(partition_keys, partition_num)
     }
 
     fn compute_partition_for_keys_group(
@@ -137,35 +153,38 @@ impl KeyRule {
 }
 
 impl PartitionRule for KeyRule {
-    fn columns(&self) -> Vec<String> {
-        self.typed_key_columns
-            .iter()
-            .map(|typed_col| typed_col.column.clone())
-            .collect()
+    fn columns(&self) -> &[String] {
+        &self.columns
     }
 
-    fn locate_partitions_for_write(&self, row_group: &RowGroup) -> Result<Vec<usize>> {
+    fn locate_partitions_for_write(&self, row_group: RowGroup) -> Result<PartitionedRowGroup> {
         // Extract idxs.
         // TODO: we should compare column's related data types in `typed_key_columns`
         // and the ones in `row_group`'s schema.
-        let typed_idxs = self
-            .typed_key_columns
+        let column_index_in_schema = self
+            .columns
             .iter()
-            .map(|typed_col| row_group.schema().index_of(typed_col.column.as_str()))
+            .map(|column| row_group.schema().index_of(column))
             .collect::<Option<Vec<_>>>()
             .context(LocateWritePartition {
                 msg: format!(
                     "not all key columns found in schema when locate partition by key strategy, key columns:{:?}",
-                    self.typed_key_columns
+                    self.columns,
                 ),
             })?;
 
         // Compute partitions.
-        let partitions = row_group
-            .iter()
-            .map(|row| self.compute_partition_for_inserted_row(row, &typed_idxs))
-            .collect();
-        Ok(partitions)
+        let partition_num = self.partition_num;
+        let iter = row_group.into_iter().map(move |row| {
+            let partition_idx = Self::compute_partition_for_inserted_row(
+                &row,
+                partition_num,
+                &column_index_in_schema,
+            );
+            PartitionedRow { partition_idx, row }
+        });
+
+        Ok(PartitionedRowGroup::Multiple(Box::new(iter)))
     }
 
     fn locate_partitions_for_read(&self, filters: &[PartitionFilter]) -> Result<Vec<usize>> {
@@ -357,10 +376,7 @@ pub(crate) fn compute_partition<'a>(
 mod tests {
     use std::{collections::BTreeSet, io::Read};
 
-    use common_types::{
-        datum::{Datum, DatumKind},
-        string::StringBytes,
-    };
+    use common_types::{datum::Datum, string::StringBytes};
 
     use super::*;
 
@@ -402,10 +418,6 @@ mod tests {
     #[test]
     fn test_compute_partition_for_inserted_row_with_empty_string() {
         let partition_num = 161709;
-        let key_rule = KeyRule {
-            typed_key_columns: vec![ColumnWithType::new("col1".to_string(), DatumKind::String)],
-            partition_num,
-        };
 
         let datums = vec![
             Datum::Int32(1),
@@ -417,17 +429,14 @@ mod tests {
         let row = Row::from_datums(datums);
         let defined_idxs = vec![1, 2, 3, 4];
 
-        let partition_id = key_rule.compute_partition_for_inserted_row(&row, &defined_idxs);
+        let partition_id =
+            KeyRule::compute_partition_for_inserted_row(&row, partition_num, &defined_idxs);
         assert_eq!(partition_id, 104979);
     }
 
     #[test]
     fn test_compute_partition_for_inserted_row() {
         let partition_num = 16;
-        let key_rule = KeyRule {
-            typed_key_columns: vec![ColumnWithType::new("col1".to_string(), DatumKind::UInt32)],
-            partition_num,
-        };
 
         let datums = vec![
             Datum::Int32(1),
@@ -440,7 +449,8 @@ mod tests {
         let defined_idxs = vec![1, 2, 3, 4];
 
         // Actual
-        let partition_id = key_rule.compute_partition_for_inserted_row(&row, &defined_idxs);
+        let partition_id =
+            KeyRule::compute_partition_for_inserted_row(&row, partition_num, &defined_idxs);
         assert_eq!(partition_id, 6);
     }
 
@@ -448,14 +458,10 @@ mod tests {
     fn test_get_candidate_partition_keys_groups() {
         // Key rule of keys:[col1, col2, col3]
         let partition_num = 16;
-        let key_rule = KeyRule {
-            typed_key_columns: vec![
-                ColumnWithType::new("col1".to_string(), DatumKind::UInt32),
-                ColumnWithType::new("col2".to_string(), DatumKind::UInt32),
-                ColumnWithType::new("col3".to_string(), DatumKind::UInt32),
-            ],
+        let key_rule = KeyRule::new(
             partition_num,
-        };
+            vec!["col1".to_string(), "col2".to_string(), "col3".to_string()],
+        );
 
         // Filters(related columns: col1, col2, col3, col1, col2)
         let filter1 = PartitionFilter {

--- a/table_engine/src/partition/rule/mod.rs
+++ b/table_engine/src/partition/rule/mod.rs
@@ -25,17 +25,19 @@ use common_types::row::{Row, RowGroup};
 use self::filter::PartitionFilter;
 use crate::partition::Result;
 
-pub enum PartitionedRowGroup {
+/// The partitioned rows of the written requests.
+pub enum PartitionedRows {
     One {
-        partition_idx: usize,
+        partition_id: usize,
         row_group: RowGroup,
     },
     Multiple(PartitionedRowsIter),
 }
 
+/// A row partitioned into a specific partition.
 #[derive(Debug, Clone)]
 pub struct PartitionedRow {
-    pub partition_idx: usize,
+    pub partition_id: usize,
     pub row: Row,
 }
 
@@ -43,12 +45,13 @@ pub type PartitionedRowsIter = Box<dyn Iterator<Item = PartitionedRow> + Send + 
 
 /// Partition rule locate partition
 pub trait PartitionRule: Send + Sync + 'static {
-    fn columns(&self) -> &[String];
+    fn involved_columns(&self) -> &[String];
 
     /// Locate the partition for each row in `row_group`.
     ///
-    /// Len of returned value should be equal to the one of rows in `row group`.
-    fn locate_partitions_for_write(&self, row_group: RowGroup) -> Result<PartitionedRowGroup>;
+    /// The size of returned iterator should be equal to the one of rows in `row
+    /// group`.
+    fn location_partitions_for_write(&self, row_group: RowGroup) -> Result<PartitionedRows>;
 
     /// Locate partitions according to `filters`.
     ///
@@ -64,4 +67,4 @@ pub trait PartitionRule: Send + Sync + 'static {
     fn locate_partitions_for_read(&self, filters: &[PartitionFilter]) -> Result<Vec<usize>>;
 }
 
-pub type PartitionRuleRef = Box<dyn PartitionRule>;
+pub type PartitionRulePtr = Box<dyn PartitionRule>;

--- a/table_engine/src/partition/rule/mod.rs
+++ b/table_engine/src/partition/rule/mod.rs
@@ -27,7 +27,7 @@ use crate::partition::Result;
 
 /// The partitioned rows of the written requests.
 pub enum PartitionedRows {
-    One {
+    Single {
         partition_id: usize,
         row_group: RowGroup,
     },

--- a/table_engine/src/partition/rule/random.rs
+++ b/table_engine/src/partition/rule/random.rs
@@ -38,7 +38,7 @@ impl PartitionRule for RandomRule {
     fn location_partitions_for_write(&self, row_group: RowGroup) -> Result<PartitionedRows> {
         let value: usize = rand::random();
         let partition_id = value % self.partition_num;
-        Ok(PartitionedRows::One {
+        Ok(PartitionedRows::Single {
             partition_id,
             row_group,
         })

--- a/table_engine/src/partition/rule/random.rs
+++ b/table_engine/src/partition/rule/random.rs
@@ -17,21 +17,29 @@
 use common_types::row::RowGroup;
 use itertools::Itertools;
 
+use super::PartitionedRowGroup;
 use crate::partition::{rule::PartitionRule, Result};
 
 pub struct RandomRule {
     pub partition_num: usize,
 }
 
+impl RandomRule {
+    const INVOLVED_COLUMNS: [String; 0] = [];
+}
+
 impl PartitionRule for RandomRule {
-    fn columns(&self) -> Vec<String> {
-        vec![]
+    fn columns(&self) -> &[String] {
+        &Self::INVOLVED_COLUMNS
     }
 
-    fn locate_partitions_for_write(&self, row_group: &RowGroup) -> Result<Vec<usize>> {
+    fn locate_partitions_for_write(&self, row_group: RowGroup) -> Result<PartitionedRowGroup> {
         let value: usize = rand::random();
         let partition_idx = value % self.partition_num;
-        Ok(vec![partition_idx; row_group.num_rows()])
+        Ok(PartitionedRowGroup::One {
+            partition_idx,
+            row_group,
+        })
     }
 
     fn locate_partitions_for_read(

--- a/table_engine/src/partition/rule/random.rs
+++ b/table_engine/src/partition/rule/random.rs
@@ -17,8 +17,10 @@
 use common_types::row::RowGroup;
 use itertools::Itertools;
 
-use super::PartitionedRowGroup;
-use crate::partition::{rule::PartitionRule, Result};
+use crate::partition::{
+    rule::{PartitionRule, PartitionedRows},
+    Result,
+};
 
 pub struct RandomRule {
     pub partition_num: usize,
@@ -29,15 +31,15 @@ impl RandomRule {
 }
 
 impl PartitionRule for RandomRule {
-    fn columns(&self) -> &[String] {
+    fn involved_columns(&self) -> &[String] {
         &Self::INVOLVED_COLUMNS
     }
 
-    fn locate_partitions_for_write(&self, row_group: RowGroup) -> Result<PartitionedRowGroup> {
+    fn location_partitions_for_write(&self, row_group: RowGroup) -> Result<PartitionedRows> {
         let value: usize = rand::random();
-        let partition_idx = value % self.partition_num;
-        Ok(PartitionedRowGroup::One {
-            partition_idx,
+        let partition_id = value % self.partition_num;
+        Ok(PartitionedRows::One {
+            partition_id,
             row_group,
         })
     }


### PR DESCRIPTION
## Rationale
Some memory allocation during partitioning write request can be avoided.

## Detailed Changes
Introduce an enum called `PartitionedRows` as the return type of `PartitionRule.locate_partitions_for_write` to avoid unnecessary memory allocation.

## Test Plan
Existing test.