### PR TITLE
chore: modify `enable_others` default true for happy debugging

### DIFF
--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -94,6 +94,7 @@ use crate::{
 const QUERY_EXPIRED_BUFFER: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(default)]
 pub struct SubTableAccessPerm {
     pub enable_http: bool,
     pub enable_others: bool,
@@ -103,7 +104,7 @@ impl Default for SubTableAccessPerm {
     fn default() -> Self {
         Self {
             enable_http: true,
-            enable_others: false,
+            enable_others: true,
         }
     }
 }


### PR DESCRIPTION
## Rationale
It is too struggle to debug partitioned table because `enable_others` in `sub_table_access_perm` default to false...
When we try to query the specific sub table, we will always be prohibited... It will make us extremely unhappy...

## Detailed Changes
Modify `enable_others` default true.

## Test Plan
Test manually.