### PR TITLE
fix: skip update shard status when create/remove table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 integration_tests/dist_query/dist-query-testing
 integration_tests/dist_query/tsbs
 integration_tests/dist_query/output
+.project

--- a/cluster/src/cluster_impl.rs
+++ b/cluster/src/cluster_impl.rs
@@ -292,7 +292,11 @@ impl Inner {
 
         let shard_id = tables_of_shard.shard_info.id;
         let shard = Arc::new(Shard::new(tables_of_shard));
-        self.shard_set.insert(shard_id, shard.clone());
+
+        info!("Insert shard to shard_set, id:{shard_id}, shard:{shard:?}");
+        if let Some(old_shard) = self.shard_set.insert(shard_id, shard.clone()) {
+            info!("Remove old shard, id:{shard_id}, old:{old_shard:?}");
+        }
 
         Ok(shard)
     }
@@ -302,6 +306,7 @@ impl Inner {
     }
 
     fn close_shard(&self, shard_id: ShardId) -> Result<ShardRef> {
+        info!("Remove shard from shard_set, id:{shard_id}");
         self.shard_set
             .remove(shard_id)
             .with_context(|| ShardNotFound {

--- a/cluster/src/shard_set.rs
+++ b/cluster/src/shard_set.rs
@@ -55,9 +55,9 @@ impl ShardSet {
     }
 
     /// Insert the tables of one shard.
-    pub fn insert(&self, shard_id: ShardId, shard: ShardRef) {
+    pub fn insert(&self, shard_id: ShardId, shard: ShardRef) -> Option<ShardRef> {
         let mut inner = self.inner.write().unwrap();
-        inner.insert(shard_id, shard);
+        inner.insert(shard_id, shard)
     }
 }
 

--- a/cluster/src/shard_set.rs
+++ b/cluster/src/shard_set.rs
@@ -221,6 +221,14 @@ impl ShardData {
         matches!(self.shard_info.status, ShardStatus::Frozen)
     }
 
+    #[inline]
+    fn update_shard_info(&mut self, new_info: ShardInfo) {
+        // TODO: refactor to move status out of ShardInfo
+        self.shard_info.id = new_info.id;
+        self.shard_info.version = new_info.version;
+        self.shard_info.role = new_info.role;
+    }
+
     pub fn try_insert_table(&mut self, updated_info: UpdatedTableInfo) -> Result<()> {
         let UpdatedTableInfo {
             prev_version: prev_shard_version,
@@ -252,7 +260,7 @@ impl ShardData {
         );
 
         // Update tables of shard.
-        self.shard_info = curr_shard;
+        self.update_shard_info(curr_shard);
         self.tables.push(new_table);
 
         Ok(())
@@ -289,7 +297,7 @@ impl ShardData {
             })?;
 
         // Update tables of shard.
-        self.shard_info = curr_shard;
+        self.update_shard_info(curr_shard);
         self.tables.swap_remove(table_idx);
 
         Ok(())

--- a/integration_tests/cases/env/cluster/ddl/partition_table.result
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.result
@@ -2,10 +2,6 @@ DROP TABLE IF EXISTS `partition_table_t`;
 
 affected_rows: 0
 
-DROP TABLE IF EXISTS `__partition_table_t_0`;
-
-Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to execute plan, sql: DROP TABLE IF EXISTS `__partition_table_t_0`;. Caused by: Internal error, msg:Failed to create interpreter, err:Failed to check permission, msg:only can process sub tables in table partition directly when enable partition table access" })
-
 CREATE TABLE `partition_table_t`(
                                     `name`string TAG,
                                     `id` int TAG,
@@ -22,10 +18,6 @@ Table,Create Table,
 String("partition_table_t"),String("CREATE TABLE `partition_table_t` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) PARTITION BY KEY(name) PARTITIONS 4 ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')"),
 
 
-SHOW CREATE TABLE __partition_table_t_0;
-
-Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to execute plan, sql: SHOW CREATE TABLE __partition_table_t_0;. Caused by: Internal error, msg:Failed to create interpreter, err:Failed to check permission, msg:only can process sub tables in table partition directly when enable partition table access" })
-
 INSERT INTO partition_table_t (t, name, value)
 VALUES (1651737067000, "ceresdb0", 100),
        (1651737067000, "ceresdb1", 101),
@@ -40,10 +32,6 @@ VALUES (1651737067000, "ceresdb0", 100),
        (1651737067000, "ceresdb10", 110);
 
 affected_rows: 11
-
-SELECT * from __partition_table_t_0 where name = "ceresdb0";
-
-Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to execute plan, sql: SELECT * from __partition_table_t_0 where name = \"ceresdb0\";. Caused by: Internal error, msg:Failed to create interpreter, err:Failed to check permission, msg:only can process sub tables in table partition directly when enable partition table access" })
 
 SELECT * from partition_table_t where name = "ceresdb0";
 

--- a/integration_tests/cases/env/cluster/ddl/partition_table.sql
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.sql
@@ -1,5 +1,4 @@
 DROP TABLE IF EXISTS `partition_table_t`;
-DROP TABLE IF EXISTS `__partition_table_t_0`;
 
 CREATE TABLE `partition_table_t`(
                                     `name`string TAG,
@@ -10,8 +9,6 @@ CREATE TABLE `partition_table_t`(
 ) PARTITION BY KEY(name) PARTITIONS 4 ENGINE = Analytic with (enable_ttl='false');
 
 SHOW CREATE TABLE partition_table_t;
-
-SHOW CREATE TABLE __partition_table_t_0;
 
 INSERT INTO partition_table_t (t, name, value)
 VALUES (1651737067000, "ceresdb0", 100),
@@ -25,8 +22,6 @@ VALUES (1651737067000, "ceresdb0", 100),
        (1651737067000, "ceresdb8", 108),
        (1651737067000, "ceresdb9", 109),
        (1651737067000, "ceresdb10", 110);
-
-SELECT * from __partition_table_t_0 where name = "ceresdb0";
 
 SELECT * from partition_table_t where name = "ceresdb0";
 

--- a/meta_client/src/meta_impl.rs
+++ b/meta_client/src/meta_impl.rs
@@ -176,7 +176,7 @@ impl MetaClient for MetaClientImpl {
         let mut pb_req = meta_service::GetTablesOfShardsRequest::from(req);
         pb_req.header = Some(self.request_header().into());
 
-        debug!("Meta client try to get tables, req:{:?}", pb_req);
+        info!("Meta client try to get tables, req:{:?}", pb_req);
 
         let pb_resp = self
             .client()
@@ -186,7 +186,7 @@ impl MetaClient for MetaClientImpl {
             .context(FailGetTables)?
             .into_inner();
 
-        debug!("Meta client finish getting tables, resp:{:?}", pb_resp);
+        info!("Meta client finish getting tables, resp:{:?}", pb_resp);
 
         check_response_header(&pb_resp.header)?;
 

--- a/meta_client/src/types.rs
+++ b/meta_client/src/types.rs
@@ -302,7 +302,7 @@ impl From<&meta_service_pb::ShardInfo> for ShardInfo {
             id: pb_shard_info.id,
             role: pb_shard_info.role().into(),
             version: pb_shard_info.version,
-            status: Default::default(),
+            status: ShardStatus::Init,
         }
     }
 }


### PR DESCRIPTION
## Rationale
In one of our deployments, I have one shard change its status from Ready to Init, there is no open/close shards requests between this change, so I add some info log to help investigate this issue.

## Detailed Changes
- Skip update shard status when create/remove table

## Test Plan
TBD