### PR TITLE
fix: add table status to cancel background jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-stream",
  "async-trait",
+ "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
  "ceresdbproto",
@@ -746,6 +747,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
+]
+
+[[package]]
+name = "atomic_enum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6227a8d6fdb862bcb100c4314d0d9579e5cd73fa6df31a2e6f6e1acd3c5f1207"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7574,7 +7586,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ analytic_engine = { path = "analytic_engine" }
 arena = { path = "components/arena" }
 async-stream = "0.3.4"
 async-trait = "0.1.72"
+atomic_enum = "0.2.0"
 base64 = "0.13"
 bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -34,6 +34,7 @@ arena = { workspace = true }
 arrow = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
+atomic_enum = { workspace = true }
 base64 = { workspace = true }
 bytes_ext = { workspace = true }
 ceresdbproto = { workspace = true }

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -569,9 +569,9 @@ impl ScheduleWorker {
 
     async fn handle_table_compaction_request(&self, compact_req: TableCompactionRequest) {
         let table_data = compact_req.table_data.clone();
-        if table_data.is_closed() {
+        if !table_data.allow_compaction() {
             error!(
-                "Table is already closed, unable to do compaction further, table:{}, table_id:{}",
+                "Table status is not ok, unable to compact further, table:{}, table_id:{}",
                 table_data.name, table_data.id
             );
             return;

--- a/analytic_engine/src/compaction/scheduler.rs
+++ b/analytic_engine/src/compaction/scheduler.rs
@@ -569,6 +569,14 @@ impl ScheduleWorker {
 
     async fn handle_table_compaction_request(&self, compact_req: TableCompactionRequest) {
         let table_data = compact_req.table_data.clone();
+        if table_data.is_closed() {
+            error!(
+                "Table is already closed, unable to do compaction further, table:{}, table_id:{}",
+                table_data.name, table_data.id
+            );
+            return;
+        }
+
         let table_options = table_data.table_options();
         let compaction_strategy = table_options.compaction_strategy;
         let picker = self.picker_manager.get_picker(compaction_strategy);

--- a/analytic_engine/src/instance/close.rs
+++ b/analytic_engine/src/instance/close.rs
@@ -79,6 +79,10 @@ impl Closer {
         let removed_table = self.space.remove_table(&request.table_name);
         assert!(removed_table.is_some());
 
+        // Table is already moved out of space, we should close it to stop background
+        // jobs.
+        table_data.set_closed();
+
         info!(
             "table:{}-{} has been removed from the space_id:{}",
             table_data.name, table_data.id, self.space.id

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -725,10 +725,10 @@ impl SpaceStore {
             .await?;
         }
 
-        if table_data.is_closed() {
+        if !table_data.allow_compaction() {
             return Other {
                 msg: format!(
-                    "Table is already closed, unable to do update manifest, table:{}, table_id:{}",
+                    "Table status is not ok, unable to update manifest, table:{}, table_id:{}",
                     table_data.name, table_data.id
                 ),
             }

--- a/analytic_engine/src/instance/flush_compaction.rs
+++ b/analytic_engine/src/instance/flush_compaction.rs
@@ -725,6 +725,16 @@ impl SpaceStore {
             .await?;
         }
 
+        if table_data.is_closed() {
+            return Other {
+                msg: format!(
+                    "Table is already closed, unable to do update manifest, table:{}, table_id:{}",
+                    table_data.name, table_data.id
+                ),
+            }
+            .fail();
+        }
+
         let edit_req = {
             let meta_update = MetaUpdate::VersionEdit(edit_meta.clone());
             MetaEditRequest {

--- a/analytic_engine/src/table/data.rs
+++ b/analytic_engine/src/table/data.rs
@@ -112,7 +112,7 @@ impl TableShardInfo {
 }
 
 /// `atomic_enum` macro will expand method like
-/// ```
+/// ```text
 /// compare_exchange(..) -> Result<TableStatus, TableStatus>
 /// ```
 /// The result type is conflict with outer


### PR DESCRIPTION
## Rationale
Close #1205

## Detailed Changes
- Add `TableStatus::Closed` to donate table is closed, and cancel background jobs, such as compaction.

## Test Plan
