### PR TITLE
fix: wrong text of show create table for partition table

### DIFF
--- a/integration_tests/cases/env/cluster/ddl/partition_table.result
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.result
@@ -103,7 +103,7 @@ affected_rows: 0
 SHOW CREATE TABLE random_partition_table_t;
 
 Table,Create Table,
-String("random_partition_table_t"),String("CREATE TABLE `random_partition_table_t` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) PARTITIONS 4 ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='APPEND', write_buffer_size='33554432')"),
+String("random_partition_table_t"),String("CREATE TABLE `random_partition_table_t` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) PARTITION BY RANDOM PARTITIONS 4 ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='false', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='APPEND', write_buffer_size='33554432')"),
 
 
 INSERT INTO random_partition_table_t (t, name, value)

--- a/interpreters/src/show_create.rs
+++ b/interpreters/src/show_create.rs
@@ -166,7 +166,7 @@ impl ShowCreateInterpreter {
                 }
             }
             PartitionInfo::Random(v) => {
-                format!(" PARTITIONS {}", v.definitions.len())
+                format!(" PARTITION BY RANDOM PARTITIONS {}", v.definitions.len())
             }
         }
     }


### PR DESCRIPTION
## Rationale
The text is wrong of `show create table` for partition table.

## Detailed Changes
Add the missing `PARTITION BY RANDOM` to the output of `show create table`.

## Test Plan
Existing tests.