### PR TITLE
chore: http route directly from meta

### DIFF
--- a/proxy/src/grpc/route.rs
+++ b/proxy/src/grpc/route.rs
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ceresdbproto::storage::{RouteRequest, RouteResponse};
+use ceresdbproto::storage::{RouteRequest as RouteRequestPb, RouteResponse};
+use router::RouteRequest;
 
 use crate::{error, metrics::GRPC_HANDLER_COUNTER_VEC, Context, Proxy};
 
 impl Proxy {
-    pub async fn handle_route(&self, _ctx: Context, req: RouteRequest) -> RouteResponse {
-        let routes = self.route(req).await;
+    pub async fn handle_route(&self, _ctx: Context, req: RouteRequestPb) -> RouteResponse {
+        let request = RouteRequest::new(req, true);
+        let routes = self.route(request).await;
 
         let mut resp = RouteResponse::default();
         match routes {

--- a/proxy/src/http/route.rs
+++ b/proxy/src/http/route.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ceresdbproto::storage::RouteRequest;
-use router::endpoint::Endpoint;
+use ceresdbproto::storage::RouteRequest as RouteRequestPb;
+use router::{endpoint::Endpoint, RouteRequest};
 use serde::Serialize;
 
 use crate::{context::RequestContext, error::Result, Proxy};
@@ -39,14 +39,19 @@ impl Proxy {
             return Ok(RouteResponse { routes: vec![] });
         }
 
-        let route_req = RouteRequest {
+        let req_pb = RouteRequestPb {
             context: Some(ceresdbproto::storage::RequestContext {
                 database: ctx.schema.clone(),
             }),
             tables: vec![table.to_string()],
         };
 
-        let routes = self.route(route_req).await?;
+        let request = RouteRequest {
+            route_with_cache: false,
+            inner: req_pb,
+        };
+
+        let routes = self.route(request).await?;
 
         let routes = routes
             .into_iter()

--- a/proxy/src/lib.rs
+++ b/proxy/src/lib.rs
@@ -53,7 +53,7 @@ use catalog::{
 };
 use ceresdbproto::storage::{
     storage_service_client::StorageServiceClient, PrometheusRemoteQueryRequest,
-    PrometheusRemoteQueryResponse, Route, RouteRequest,
+    PrometheusRemoteQueryResponse, Route,
 };
 use common_types::{request_id::RequestId, table::DEFAULT_SHARD_ID, ENABLE_TTL, TTL};
 use datafusion::{
@@ -70,7 +70,7 @@ use interpreters::{
 };
 use log::{error, info};
 use query_frontend::plan::Plan;
-use router::{endpoint::Endpoint, Router};
+use router::{endpoint::Endpoint, RouteRequest, Router};
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt};
 use table_engine::{

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -22,8 +22,8 @@ use std::{
 
 use bytes::Bytes;
 use ceresdbproto::storage::{
-    storage_service_client::StorageServiceClient, value, RouteRequest, Value, WriteRequest,
-    WriteResponse as WriteResponsePB, WriteSeriesEntry, WriteTableRequest,
+    storage_service_client::StorageServiceClient, value, RouteRequest as RouteRequestPb, Value,
+    WriteRequest, WriteResponse as WriteResponsePB, WriteSeriesEntry, WriteTableRequest,
 };
 use cluster::config::SchemaConfig;
 use common_types::{
@@ -45,7 +45,7 @@ use query_frontend::{
     planner::{build_column_schema, try_get_data_type_from_value},
     provider::CatalogMetaProvider,
 };
-use router::endpoint::Endpoint;
+use router::{endpoint::Endpoint, RouteRequest};
 use snafu::{ensure, OptionExt, ResultExt};
 use table_engine::table::TableRef;
 use tonic::transport::Channel;
@@ -310,13 +310,13 @@ impl Proxy {
 
         // TODO: Make the router can accept an iterator over the tables to avoid the
         // memory allocation here.
-        let route_data = self
-            .router
-            .route(RouteRequest {
-                context: req.context.clone(),
-                tables,
-            })
-            .await?;
+        let req_pb = RouteRequestPb {
+            context: req.context.clone(),
+            tables,
+        };
+        let request = RouteRequest::new(req_pb, true);
+        let route_data = self.router.route(request).await?;
+
         let forwarded_table_routes = route_data
             .into_iter()
             .filter_map(|router| {

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -19,7 +19,7 @@ pub mod rule_based;
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use ceresdbproto::storage::{Route, RouteRequest};
+use ceresdbproto::storage::{Route, RouteRequest as RouteRequestPb};
 pub use cluster_based::ClusterBasedRouter;
 use macros::define_result;
 use meta_client::types::TableInfo;
@@ -77,6 +77,20 @@ pub type RouterRef = Arc<dyn Router + Sync + Send>;
 pub trait Router {
     async fn route(&self, req: RouteRequest) -> Result<Vec<Route>>;
     async fn fetch_table_info(&self, schema: &str, table: &str) -> Result<Option<TableInfo>>;
+}
+
+pub struct RouteRequest {
+    pub route_with_cache: bool,
+    pub inner: RouteRequestPb,
+}
+
+impl RouteRequest {
+    pub fn new(request: RouteRequestPb, route_with_cache: bool) -> Self {
+        Self {
+            route_with_cache,
+            inner: request,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Rationale
We want to know the real endpoint of table through http api, for reaching this we need to get route info from meta directly rather than from cache.

## Detailed Changes
Get route info directy from meta in http api.

## Test Plan
Test manually.