### PR TITLE
feat: rewrite `not in` expr to `in`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "codec",
  "common_types",
  "datafusion",
@@ -1299,7 +1299,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto 1.0.14",
+ "ceresdbproto",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1326,21 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "393f9c4d1afbe096c772e59b169e7932cda7a9da8d2b5c8ca5a8aa40b219569d"
-dependencies = [
- "prost",
- "protoc-bin-vendored",
- "tonic 0.8.3",
- "tonic-build",
- "walkdir",
-]
-
-[[package]]
-name = "ceresdbproto"
-version = "1.0.15"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=031950f#031950fde852d840d877d4788075e8efa3698fbf"
+checksum = "39fca0a20131625263de118b8d09be05ffcc0d0ed6392f75d29e277f36b0d32c"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1523,7 +1511,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1601,7 +1589,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2356,7 +2344,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3906,7 +3894,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4431,7 +4419,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "chrono",
  "clru",
  "crc",
@@ -5309,7 +5297,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -5434,7 +5422,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "cluster",
  "codec",
  "common_types",
@@ -5745,7 +5733,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5874,7 +5862,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "cluster",
  "common_types",
  "generic_error",
@@ -6242,7 +6230,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -6768,7 +6756,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6790,7 +6778,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6990,7 +6978,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "chrono",
  "common_types",
  "macros",
@@ -7640,7 +7628,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.15",
+ "ceresdbproto",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "codec",
  "common_types",
  "datafusion",
@@ -1299,7 +1299,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.14",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1322,6 +1322,18 @@ dependencies = [
  "sqlness",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "ceresdbproto"
+version = "1.0.13"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?branch=feat-column-values#c51ddbbffb762523e972aa3e5add2a3026b049db"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic 0.8.3",
+ "tonic-build",
+ "walkdir",
 ]
 
 [[package]]
@@ -1511,7 +1523,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1589,7 +1601,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2344,7 +2356,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3894,7 +3906,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4419,7 +4431,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "chrono",
  "clru",
  "crc",
@@ -5297,7 +5309,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "clru",
  "cluster",
  "common_types",
@@ -5422,7 +5434,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "cluster",
  "codec",
  "common_types",
@@ -5733,7 +5745,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5862,7 +5874,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "cluster",
  "common_types",
  "generic_error",
@@ -6230,7 +6242,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "clru",
  "cluster",
  "common_types",
@@ -6756,7 +6768,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6778,7 +6790,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6978,7 +6990,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "chrono",
  "common_types",
  "macros",
@@ -7628,7 +7640,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.13",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "codec",
  "common_types",
  "datafusion",
@@ -1326,8 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.13"
-source = "git+https://github.com/CeresDB/ceresdbproto.git?branch=feat-column-values#c51ddbbffb762523e972aa3e5add2a3026b049db"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "393f9c4d1afbe096c772e59b169e7932cda7a9da8d2b5c8ca5a8aa40b219569d"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1338,9 +1339,8 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "393f9c4d1afbe096c772e59b169e7932cda7a9da8d2b5c8ca5a8aa40b219569d"
+version = "1.0.15"
+source = "git+https://github.com/CeresDB/ceresdbproto.git?rev=031950f#031950fde852d840d877d4788075e8efa3698fbf"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1523,7 +1523,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1601,7 +1601,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2356,7 +2356,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3906,7 +3906,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4431,7 +4431,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "chrono",
  "clru",
  "crc",
@@ -5309,7 +5309,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "clru",
  "cluster",
  "common_types",
@@ -5434,7 +5434,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "cluster",
  "codec",
  "common_types",
@@ -5745,7 +5745,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5874,7 +5874,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "cluster",
  "common_types",
  "generic_error",
@@ -6242,7 +6242,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "clru",
  "cluster",
  "common_types",
@@ -6768,7 +6768,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6790,7 +6790,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6990,7 +6990,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "chrono",
  "common_types",
  "macros",
@@ -7640,7 +7640,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.13",
+ "ceresdbproto 1.0.15",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,7 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-# ceresdbproto = "1.0.14"
-ceresdbproto = { git = "https://github.com/CeresDB/ceresdbproto.git", rev = "031950f" }
+ceresdbproto = "1.0.16"
 codec = { path = "components/codec" }
 notifier = { path = "components/notifier" }
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
 # ceresdbproto = "1.0.14"
-ceresdbproto = { git = "https://github.com/CeresDB/ceresdbproto.git", branch = "feat-column-values" }
+ceresdbproto = { git = "https://github.com/CeresDB/ceresdbproto.git", rev = "031950f" }
 codec = { path = "components/codec" }
 notifier = { path = "components/notifier" }
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,8 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = "1.0.14"
+# ceresdbproto = "1.0.14"
+ceresdbproto = { git = "https://github.com/CeresDB/ceresdbproto.git", branch = "feat-column-values" }
 codec = { path = "components/codec" }
 notifier = { path = "components/notifier" }
 chrono = "0.4"

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -724,6 +724,7 @@ mod tests {
             max_sequence: 200,
             schema: build_schema(),
             parquet_filter: Default::default(),
+            column_values: Vec::new(),
         };
 
         SstMetaData::Parquet(Arc::new(parquet_meta_data))

--- a/analytic_engine/src/compaction/picker.rs
+++ b/analytic_engine/src/compaction/picker.rs
@@ -724,7 +724,7 @@ mod tests {
             max_sequence: 200,
             schema: build_schema(),
             parquet_filter: Default::default(),
-            column_values: Vec::new(),
+            column_values: None,
         };
 
         SstMetaData::Parquet(Arc::new(parquet_meta_data))

--- a/analytic_engine/src/sst/meta_data/cache.rs
+++ b/analytic_engine/src/sst/meta_data/cache.rs
@@ -317,6 +317,7 @@ mod tests {
             max_sequence: 1001,
             schema,
             parquet_filter: None,
+            column_values: Vec::new(),
         };
         let store = Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
         write_parquet_file_with_metadata(

--- a/analytic_engine/src/sst/meta_data/cache.rs
+++ b/analytic_engine/src/sst/meta_data/cache.rs
@@ -317,7 +317,7 @@ mod tests {
             max_sequence: 1001,
             schema,
             parquet_filter: None,
-            column_values: Vec::new(),
+            column_values: vec![None; 2],
         };
         let store = Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
         write_parquet_file_with_metadata(

--- a/analytic_engine/src/sst/meta_data/cache.rs
+++ b/analytic_engine/src/sst/meta_data/cache.rs
@@ -317,7 +317,7 @@ mod tests {
             max_sequence: 1001,
             schema,
             parquet_filter: None,
-            column_values: vec![None; 2],
+            column_values: None,
         };
         let store = Arc::new(LocalFileSystem::new_with_prefix(temp_dir.path()).unwrap());
         write_parquet_file_with_metadata(

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -54,6 +54,7 @@ use tokio::sync::{
 };
 use trace_metric::{MetricsCollector, TraceMetricWhenDrop};
 
+use super::meta_data::ColumnValue;
 use crate::{
     prefetchable_stream::{NoopPrefetcher, PrefetchableStream},
     sst::{
@@ -174,6 +175,7 @@ impl<'a> Reader<'a> {
         schema: SchemaRef,
         row_groups: &[RowGroupMetaData],
         parquet_filter: Option<&ParquetFilter>,
+        column_values: &[Option<ColumnValue>],
     ) -> Result<Vec<usize>> {
         let metrics_collector = self
             .metrics
@@ -186,6 +188,7 @@ impl<'a> Reader<'a> {
             parquet_filter,
             self.predicate.exprs(),
             metrics_collector,
+            column_values,
         )?;
 
         Ok(pruner.prune())
@@ -239,11 +242,16 @@ impl<'a> Reader<'a> {
         let row_projector = self.row_projector.as_ref().unwrap();
         let arrow_schema = meta_data.custom().schema.to_arrow_schema_ref();
         // Get target row groups.
-        let target_row_groups = self.prune_row_groups(
-            arrow_schema.clone(),
-            meta_data.parquet().row_groups(),
-            meta_data.custom().parquet_filter.as_ref(),
-        )?;
+        let target_row_groups = {
+            let custom = meta_data.custom();
+
+            self.prune_row_groups(
+                arrow_schema.clone(),
+                meta_data.parquet().row_groups(),
+                custom.parquet_filter.as_ref(),
+                &custom.column_values,
+            )?
+        };
 
         debug!(
             "Reader fetch record batches, path:{}, row_groups total:{}, after prune:{}",

--- a/analytic_engine/src/sst/parquet/async_reader.rs
+++ b/analytic_engine/src/sst/parquet/async_reader.rs
@@ -54,7 +54,7 @@ use tokio::sync::{
 };
 use trace_metric::{MetricsCollector, TraceMetricWhenDrop};
 
-use super::meta_data::ColumnValue;
+use super::meta_data::ColumnValueSet;
 use crate::{
     prefetchable_stream::{NoopPrefetcher, PrefetchableStream},
     sst::{
@@ -175,7 +175,7 @@ impl<'a> Reader<'a> {
         schema: SchemaRef,
         row_groups: &[RowGroupMetaData],
         parquet_filter: Option<&ParquetFilter>,
-        column_values: &[Option<ColumnValue>],
+        column_values: Option<&Vec<Option<ColumnValueSet>>>,
     ) -> Result<Vec<usize>> {
         let metrics_collector = self
             .metrics
@@ -249,7 +249,7 @@ impl<'a> Reader<'a> {
                 arrow_schema.clone(),
                 meta_data.parquet().row_groups(),
                 custom.parquet_filter.as_ref(),
-                &custom.column_values,
+                custom.column_values.as_ref(),
             )?
         };
 

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -355,6 +355,7 @@ pub type ParquetMetaDataRef = Arc<ParquetMetaData>;
 
 impl From<MetaData> for ParquetMetaData {
     fn from(meta: MetaData) -> Self {
+        let num_columns = meta.schema.num_columns();
         Self {
             min_key: meta.min_key,
             max_key: meta.max_key,
@@ -362,7 +363,7 @@ impl From<MetaData> for ParquetMetaData {
             max_sequence: meta.max_sequence,
             schema: meta.schema,
             parquet_filter: None,
-            column_values: Vec::new(),
+            column_values: vec![None; num_columns],
         }
     }
 }
@@ -399,6 +400,7 @@ impl fmt::Debug for ParquetMetaData {
             .field("time_range", &self.time_range)
             .field("max_sequence", &self.max_sequence)
             .field("schema", &self.schema)
+            .field("column_values", &self.column_values)
             .field(
                 "filter_size",
                 &self

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -479,6 +479,20 @@ pub enum ColumnValueSet {
     StringValue(HashSet<String>),
 }
 
+impl ColumnValueSet {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::StringValue(sv) => sv.is_empty(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::StringValue(sv) => sv.len(),
+        }
+    }
+}
+
 impl From<ColumnValueSet> for sst_pb::column_value_set::Value {
     fn from(value: ColumnValueSet) -> Self {
         match value {

--- a/analytic_engine/src/sst/parquet/meta_data.rs
+++ b/analytic_engine/src/sst/parquet/meta_data.rs
@@ -468,7 +468,7 @@ impl TryFrom<sst_pb::ParquetMetaData> for ParquetMetaData {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ColumnValue {
     StringValue(HashSet<String>),
 }

--- a/analytic_engine/src/sst/parquet/row_group_pruner.rs
+++ b/analytic_engine/src/sst/parquet/row_group_pruner.rs
@@ -67,7 +67,7 @@ pub struct RowGroupPruner<'a> {
     schema: &'a SchemaRef,
     row_groups: &'a [RowGroupMetaData],
     parquet_filter: Option<&'a ParquetFilter>,
-    predicates: Cow<'a, Vec<Expr>>,
+    predicates: Cow<'a, [Expr]>,
     metrics: Metrics,
 }
 
@@ -182,7 +182,7 @@ impl<'a> RowGroupPruner<'a> {
         schema: &'a SchemaRef,
         row_groups: &'a [RowGroupMetaData],
         parquet_filter: Option<&'a ParquetFilter>,
-        predicates: &'a Vec<Expr>,
+        predicates: &'a [Expr],
         metrics_collector: Option<MetricsCollector>,
         column_values: Option<&'a Vec<Option<ColumnValueSet>>>,
     ) -> Result<Self> {
@@ -398,6 +398,12 @@ mod tests {
                 // ip = 127.0.0.1
                 col("ip").eq(lit("127.0.0.1")),
                 col("ip").eq(lit("127.0.0.1")),
+            ),
+            // Can't rewrite since host-not-exists is not  in column_values.
+            (
+                // ip != 127.0.0.1
+                col("host-not-exists").not_eq(lit("web1")),
+                col("host-not-exists").not_eq(lit("web1")),
             ),
         ];
         for (input, expected) in testcases {

--- a/analytic_engine/src/sst/parquet/row_group_pruner.rs
+++ b/analytic_engine/src/sst/parquet/row_group_pruner.rs
@@ -204,10 +204,12 @@ impl<'a> RowGroupPruner<'a> {
             .enumerate()
             .map(|(i, f)| (f.name().to_string(), column_values[i].clone()))
             .collect();
+        debug!("Pruner origin predicates:{predicates:?}");
         let predicates = predicates
             .iter()
             .map(|expr| rewrite_expr(expr.clone(), &column_values))
             .collect();
+        debug!("Pruner predicates after rewrite:{predicates:?}, column_values:{column_values:?}");
 
         let metrics = Metrics {
             use_custom_filter: parquet_filter.is_some(),

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -339,6 +339,10 @@ impl RecordBatchGroupWriter {
             if let Some(range) = self.real_time_range {
                 parquet_meta_data.time_range = range;
             }
+            // TODO: when all compaction input SST files already have column_values, we can
+            // merge them from meta_data directly, calculate them here waste CPU
+            // cycles.
+            parquet_meta_data.column_values = self.column_values;
             parquet_meta_data
         };
 

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -103,6 +103,12 @@ impl RecordBatchGroupWriter {
         compression: Compression,
         level: Level,
     ) -> Self {
+        let column_values: Vec<Option<i64>> = meta_data
+            .schema
+            .columns()
+            .iter()
+            .map(|col| if col.is_dictionary { Some(1) } else { None })
+            .collect();
         Self {
             request_id,
             input,

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -248,8 +248,9 @@ impl RecordBatchGroupWriter {
                 match col_values {
                     ColumnValue::StringValue(ss) => {
                         let datum = column_block.datum(row_idx);
-                        let v = datum.as_str().unwrap();
-                        ss.insert(v.to_string());
+                        if let Some(v) = datum.as_str() {
+                            ss.insert(v.to_string());
+                        }
                     }
                 }
             }
@@ -550,6 +551,7 @@ mod tests {
             let sst_file_path = Path::from("data.par");
 
             let schema = build_schema_with_dictionary();
+            let num_column = schema.num_columns();
             let reader_projected_schema = ProjectedSchema::no_projection(schema.clone());
             let mut sst_meta = MetaData {
                 min_key: Bytes::from_static(b"100"),
@@ -655,6 +657,7 @@ mod tests {
                 // sst filter is built insider sst writer, so overwrite to default for
                 // comparison.
                 sst_meta_readback.parquet_filter = Default::default();
+                sst_meta_readback.column_values = vec![None; num_column];
                 // time_range is built insider sst writer, so overwrite it for
                 // comparison.
                 sst_meta.time_range = sst_info.time_range;

--- a/analytic_engine/src/sst/parquet/writer.rs
+++ b/analytic_engine/src/sst/parquet/writer.rs
@@ -47,7 +47,7 @@ use crate::{
     table_options::StorageFormat,
 };
 
-const KEEP_COLUMN_VALUE_THRESHOLD: usize = 100;
+const KEEP_COLUMN_VALUE_THRESHOLD: usize = 20;
 
 /// The implementation of sst based on parquet and object storage.
 #[derive(Debug)]

--- a/integration_tests/cases/env/local/ddl/query-plan.result
+++ b/integration_tests/cases/env/local/ddl/query-plan.result
@@ -40,8 +40,8 @@ String("Plan with Metrics"),String("ScanTable: table=03_dml_select_real_time_ran
 
 
 -- SQLNESS ARG pre_cmd=flush
--- SQLNESS REPLACE duration=\d+.\d*(µ|m) duration=xx
--- SQLNESS REPLACE project_record_batch=\d+.\d*(µ|m) project_record_batch=xx
+-- SQLNESS REPLACE duration=\d+.?\d*(µ|m|n) duration=xx
+-- SQLNESS REPLACE project_record_batch=\d+.?\d*(µ|m|n) project_record_batch=xx
 -- This query should include SST
 explain analyze select t from `03_dml_select_real_time_range`
 where t > 1695348001000;

--- a/integration_tests/cases/env/local/ddl/query-plan.sql
+++ b/integration_tests/cases/env/local/ddl/query-plan.sql
@@ -26,8 +26,8 @@ explain analyze select t from `03_dml_select_real_time_range`
 where t > 1695348002000;
 
 -- SQLNESS ARG pre_cmd=flush
--- SQLNESS REPLACE duration=\d+.\d*(µ|m) duration=xx
--- SQLNESS REPLACE project_record_batch=\d+.\d*(µ|m) project_record_batch=xx
+-- SQLNESS REPLACE duration=\d+.?\d*(µ|m|n) duration=xx
+-- SQLNESS REPLACE project_record_batch=\d+.?\d*(µ|m|n) project_record_batch=xx
 -- This query should include SST
 explain analyze select t from `03_dml_select_real_time_range`
 where t > 1695348001000;

--- a/table_engine/src/predicate.rs
+++ b/table_engine/src/predicate.rs
@@ -81,7 +81,7 @@ impl Predicate {
         }
     }
 
-    pub fn exprs(&self) -> &[Expr] {
+    pub fn exprs(&self) -> &Vec<Expr> {
         &self.exprs
     }
 

--- a/table_engine/src/predicate.rs
+++ b/table_engine/src/predicate.rs
@@ -81,7 +81,7 @@ impl Predicate {
         }
     }
 
-    pub fn exprs(&self) -> &Vec<Expr> {
+    pub fn exprs(&self) -> &[Expr] {
         &self.exprs
     }
 

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -353,6 +353,7 @@ impl From<RemoteExecuteRequest> for ceresdbproto::remote_engine::ExecutePlanRequ
         };
 
         Self {
+            table: None,
             context: Some(pb_context),
             physical_plan: Some(pb_plan),
         }


### PR DESCRIPTION
## Rationale

Current filter is based on bloom-filter like structure, it can give accurate answer if an item doesn't exist in one collection, so by convert `col != value` to `col == value2`, we can fully utilize this feature.

## Detailed Changes
- Save column value to SST metadata when distinct value is less than 20.
- Rewrite not-like expr to its opposite.

## Test Plan
New UT.
