### PR TITLE
feat: support dedup execute physical plan

### DIFF
--- a/query_engine/src/datafusion_impl/task_context.rs
+++ b/query_engine/src/datafusion_impl/task_context.rs
@@ -122,7 +122,7 @@ impl Preprocessor {
             .await
             .box_err()
             .with_context(|| ExecutorWithCause {
-                msg: format!("failed to preprocess remote plan"),
+                msg: Some("failed to preprocess remote plan".to_string()),
             })
     }
 

--- a/server/src/grpc/mod.rs
+++ b/server/src/grpc/mod.rs
@@ -307,6 +307,7 @@ impl Builder {
                     v.enable.then(|| QueryDedup {
                         config: v.clone(),
                         request_notifiers: Arc::new(RequestNotifiers::default()),
+                        physical_plan_notifiers: Arc::new(RequestNotifiers::default()),
                     })
                 })
                 .unwrap_or_default();


### PR DESCRIPTION
## Rationale
Currently, the `execute_physical_plan` of the remote engine service is not supported yet.

## Detailed Changes
Support the dedup the execution of `execute_physical_plan`.

## Test Plan
Manual test.