### PR TITLE
fix: throw error when create a table with a different table id

### DIFF
--- a/catalog/src/schema.rs
+++ b/catalog/src/schema.rs
@@ -157,14 +157,12 @@ pub enum Error {
     },
 
     #[snafu(display(
-        "Invalid table id, msg:{}, table_id:{}.\nBacktrace:\n{}",
-        msg,
-        table_id,
-        backtrace
+        "Different table ids are used for the same table, table_name:{table_name}, expected_table_id:{expected_table_id}, given_table_id:{given_table_id}.\nBacktrace:\n{backtrace}",
     ))]
-    InvalidTableId {
-        msg: &'static str,
-        table_id: TableId,
+    DifferentTableId {
+        table_name: String,
+        expected_table_id: TableId,
+        given_table_id: TableId,
         backtrace: Backtrace,
     },
 

--- a/catalog_impls/src/volatile.rs
+++ b/catalog_impls/src/volatile.rs
@@ -27,8 +27,8 @@ use catalog::{
     manager::{self, Manager},
     schema::{
         self, CatalogMismatch, CreateOptions, CreateTableRequest, CreateTableWithCause,
-        DropOptions, DropTableRequest, DropTableWithCause, NameRef, Schema, SchemaMismatch,
-        SchemaRef,
+        DifferentTableId, DropOptions, DropTableRequest, DropTableWithCause, NameRef, Schema,
+        SchemaMismatch, SchemaRef,
     },
     Catalog, CatalogRef, CreateSchemaWithCause,
 };
@@ -298,6 +298,17 @@ impl Schema for SchemaImpl {
             &request.params.schema_name,
             &request.params.table_name,
         )? {
+            if let Some(given_table_id) = request.table_id {
+                let expected_table_id = table.id();
+                ensure!(
+                    expected_table_id == given_table_id,
+                    DifferentTableId {
+                        table_name: table.name().to_string(),
+                        expected_table_id,
+                        given_table_id,
+                    }
+                );
+            }
             return Ok(table);
         }
 


### PR DESCRIPTION
## Rationale
Currently, the existing table will be returned if create table with an expected table name but a different table id.

## Detailed Changes
Throws an error if the provided table id is different.

## Test Plan
This is fairly simple which doesn't need a test for it.