### PR TITLE
feat: support alter partition table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "codec",
  "common_types",
  "datafusion",
@@ -1298,7 +1298,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1328,6 +1328,18 @@ name = "ceresdbproto"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39fca0a20131625263de118b8d09be05ffcc0d0ed6392f75d29e277f36b0d32c"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic 0.8.3",
+ "tonic-build",
+ "walkdir",
+]
+
+[[package]]
+name = "ceresdbproto"
+version = "1.0.16"
+source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1#a95b6fe9ab988869456eea7f9dbd3154a673b0c1"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1510,7 +1522,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1588,7 +1600,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2343,7 +2355,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3895,7 +3907,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4420,7 +4432,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "chrono",
  "clru",
  "crc",
@@ -5297,7 +5309,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "clru",
  "cluster",
  "common_types",
@@ -5422,7 +5434,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "cluster",
  "codec",
  "common_types",
@@ -5733,7 +5745,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5862,7 +5874,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "cluster",
  "common_types",
  "generic_error",
@@ -6230,7 +6242,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "clru",
  "cluster",
  "common_types",
@@ -6755,7 +6767,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6777,7 +6789,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6980,7 +6992,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "chrono",
  "common_types",
  "macros",
@@ -7630,7 +7642,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "codec",
  "common_types",
  "datafusion",
@@ -1298,7 +1298,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ceresdbproto",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1325,21 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fca0a20131625263de118b8d09be05ffcc0d0ed6392f75d29e277f36b0d32c"
-dependencies = [
- "prost",
- "protoc-bin-vendored",
- "tonic 0.8.3",
- "tonic-build",
- "walkdir",
-]
-
-[[package]]
-name = "ceresdbproto"
-version = "1.0.16"
-source = "git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1#a95b6fe9ab988869456eea7f9dbd3154a673b0c1"
+checksum = "1bb4aa3d3a6b99a22cc2e35cd2cd04d52e825dbcb8f0dd7c7095a0d4e7bdfed1"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1522,7 +1510,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1600,7 +1588,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2355,7 +2343,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3907,7 +3895,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4432,7 +4420,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "chrono",
  "clru",
  "crc",
@@ -5309,7 +5297,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -5434,7 +5422,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "cluster",
  "codec",
  "common_types",
@@ -5745,7 +5733,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5874,7 +5862,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "cluster",
  "common_types",
  "generic_error",
@@ -6242,7 +6230,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -6767,7 +6755,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6789,7 +6777,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6992,7 +6980,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "chrono",
  "common_types",
  "macros",
@@ -7642,7 +7630,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.16 (git+https://github.com/chunshao90/ceresdbproto.git?rev=a95b6fe9ab988869456eea7f9dbd3154a673b0c1)",
+ "ceresdbproto",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = { git = "https://github.com/chunshao90/ceresdbproto.git", rev = "a95b6fe9ab988869456eea7f9dbd3154a673b0c1" }
+ceresdbproto = "1.0.17"
 codec = { path = "components/codec" }
 notifier = { path = "components/notifier" }
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = "1.0.16"
+ceresdbproto = { git = "https://github.com/chunshao90/ceresdbproto.git", rev = "a95b6fe9ab988869456eea7f9dbd3154a673b0c1" }
 codec = { path = "components/codec" }
 notifier = { path = "components/notifier" }
 chrono = "0.4"

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -75,7 +75,7 @@ impl<'a> Alterer<'a> {
         // if the alter schema request is idempotent, we can skip the alter operation.
         if self.validate_before_alter(&request)? {
             info!(
-                "Instance alter schema, idempotent, skip alter, table:{:?}",
+                "Skip alter because of the altered schema is the same as the current, table:{}",
                 self.table_data.name
             );
             return Ok(());
@@ -164,9 +164,8 @@ impl<'a> Alterer<'a> {
 
     // Most validation should be done by catalog module, so we don't do too much
     // duplicate check here, especially the schema compatibility.
-    // Boolean return value indicates whether the alter operation is idempotent.
-    // If it is idempotent, we can skip the alter operation.
-    // true: idempotent, false: not idempotent.
+    // The returned value denotes whether the altered schema is same as the current
+    // one.
     fn validate_before_alter(&self, request: &AlterSchemaRequest) -> Result<bool> {
         ensure!(
             !self.table_data.is_dropped(),

--- a/analytic_engine/src/instance/alter.rs
+++ b/analytic_engine/src/instance/alter.rs
@@ -72,7 +72,14 @@ impl<'a> Alterer<'a> {
         );
 
         // Validate alter schema request.
-        self.validate_before_alter(&request)?;
+        // if the alter schema request is idempotent, we can skip the alter operation.
+        if self.validate_before_alter(&request)? {
+            info!(
+                "Instance alter schema, idempotent, skip alter, table:{:?}",
+                self.table_data.name
+            );
+            return Ok(());
+        }
 
         // Now we can persist and update the schema, since this function is called by
         // write worker, so there is no other concurrent writer altering the
@@ -157,13 +164,20 @@ impl<'a> Alterer<'a> {
 
     // Most validation should be done by catalog module, so we don't do too much
     // duplicate check here, especially the schema compatibility.
-    fn validate_before_alter(&self, request: &AlterSchemaRequest) -> Result<()> {
+    // Boolean return value indicates whether the alter operation is idempotent.
+    // If it is idempotent, we can skip the alter operation.
+    // true: idempotent, false: not idempotent.
+    fn validate_before_alter(&self, request: &AlterSchemaRequest) -> Result<bool> {
         ensure!(
             !self.table_data.is_dropped(),
             AlterDroppedTable {
                 table: &self.table_data.name,
             }
         );
+
+        if self.table_data.schema().columns() == request.schema.columns() {
+            return Ok(true);
+        }
 
         let current_version = self.table_data.schema_version();
         ensure!(
@@ -184,7 +198,7 @@ impl<'a> Alterer<'a> {
             }
         );
 
-        Ok(())
+        Ok(false)
     }
 
     pub async fn alter_options_of_table(

--- a/catalog/src/schema.rs
+++ b/catalog/src/schema.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use common_types::{column_schema::ColumnSchema, table::ShardId};
+use common_types::table::ShardId;
 use generic_error::GenericError;
 use macros::define_result;
 use snafu::{Backtrace, Snafu};
@@ -336,22 +336,6 @@ impl CloseTableRequest {
 pub struct CloseOptions {
     /// Table engine
     pub table_engine: TableEngineRef,
-}
-
-/// Alter table operations.
-#[derive(Debug)]
-pub enum AlterTableOperation {
-    /// Add column operation, the column id in [ColumnSchema] will be ignored.
-    /// Primary key column is not allowed to be added, so all columns will
-    /// be added as normal columns.
-    AddColumn(ColumnSchema),
-}
-
-/// Alter table request.
-#[derive(Debug)]
-pub struct AlterTableRequest {
-    pub table_name: String,
-    pub operations: Vec<AlterTableOperation>,
 }
 
 #[derive(Debug, Clone)]

--- a/integration_tests/cases/env/cluster/ddl/partition_table.result
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.result
@@ -78,6 +78,38 @@ UInt64(9923681778193615344),Timestamp(1651737067000),String("ceresdb8"),Int32(0)
 UInt64(4860320137932382618),Timestamp(1651737067000),String("ceresdb9"),Int32(0),Double(109.0),
 
 
+ALTER TABLE partition_table_t ADD COLUMN (b string);
+
+affected_rows: 0
+
+ALTER TABLE partition_table_t MODIFY SETTING enable_ttl='true';
+
+affected_rows: 0
+
+SHOW CREATE TABLE __partition_table_t_0;
+
+Table,Create Table,
+String("__partition_table_t_0"),String("CREATE TABLE `__partition_table_t_0` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, `b` string, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='2h', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')"),
+
+
+SHOW CREATE TABLE __partition_table_t_1;
+
+Table,Create Table,
+String("__partition_table_t_1"),String("CREATE TABLE `__partition_table_t_1` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, `b` string, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='2h', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')"),
+
+
+SHOW CREATE TABLE __partition_table_t_2;
+
+Table,Create Table,
+String("__partition_table_t_2"),String("CREATE TABLE `__partition_table_t_2` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, `b` string, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')"),
+
+
+SHOW CREATE TABLE __partition_table_t_3;
+
+Table,Create Table,
+String("__partition_table_t_3"),String("CREATE TABLE `__partition_table_t_3` (`tsid` uint64 NOT NULL, `t` timestamp NOT NULL, `name` string TAG, `id` int TAG, `value` double NOT NULL, `b` string, PRIMARY KEY(tsid,t), TIMESTAMP KEY(t)) ENGINE=Analytic WITH(arena_block_size='2097152', compaction_strategy='default', compression='ZSTD', enable_ttl='true', memtable_type='skiplist', num_rows_per_row_group='8192', segment_duration='2h', storage_format='AUTO', ttl='7d', update_mode='OVERWRITE', write_buffer_size='33554432')"),
+
+
 DROP TABLE IF EXISTS `partition_table_t`;
 
 affected_rows: 0

--- a/integration_tests/cases/env/cluster/ddl/partition_table.sql
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.sql
@@ -35,6 +35,18 @@ SELECT * from partition_table_t where name in ("ceresdb0", "ceresdb1", "ceresdb2
 
 SELECT * from partition_table_t where name in ("ceresdb5", "ceresdb6", "ceresdb7","ceresdb8", "ceresdb9", "ceresdb10") order by name;
 
+ALTER TABLE partition_table_t ADD COLUMN (b string);
+
+ALTER TABLE partition_table_t MODIFY SETTING enable_ttl='true';
+
+SHOW CREATE TABLE __partition_table_t_0;
+
+SHOW CREATE TABLE __partition_table_t_1;
+
+SHOW CREATE TABLE __partition_table_t_2;
+
+SHOW CREATE TABLE __partition_table_t_3;
+
 DROP TABLE IF EXISTS `partition_table_t`;
 
 SHOW CREATE TABLE partition_table_t;

--- a/partition_table_engine/src/partition.rs
+++ b/partition_table_engine/src/partition.rs
@@ -352,15 +352,19 @@ impl Table for PartitionTableImpl {
             futures.push(partition);
         }
 
-        let mut rets = Vec::with_capacity(futures.len());
+        let mut result = None;
         while let Some(ret) = futures.next().await {
             if ret.is_err() {
-                error!("alter schema failed, err:{:?}", ret);
-                rets.push(ret.box_err().context(AlterSchema { table: self.name() }));
+                error!("Alter schema failed, err:{:?}", ret);
+                if result.is_none() {
+                    result = Some(ret.box_err().context(AlterSchema { table: self.name() }));
+                }
             }
         }
-        if !rets.is_empty() {
-            rets.remove(0)?;
+
+        // Remove the first error.
+        if let Some(ret) = result {
+            ret?;
         }
 
         // Alter schema of the first partition.
@@ -399,15 +403,19 @@ impl Table for PartitionTableImpl {
             futures.push(partition);
         }
 
-        let mut rets = Vec::with_capacity(futures.len());
+        let mut result = None;
         while let Some(ret) = futures.next().await {
             if ret.is_err() {
-                error!("alter options failed, err:{:?}", ret);
-                rets.push(ret.box_err().context(AlterOptions { table: self.name() }));
+                error!("Alter options failed, err:{:?}", ret);
+                if result.is_none() {
+                    result = Some(ret.box_err().context(AlterOptions { table: self.name() }));
+                }
             }
         }
-        if !rets.is_empty() {
-            rets.remove(0)?;
+
+        // Remove the first error.
+        if let Some(ret) = result {
+            ret?;
         }
 
         // Alter options of the first partition.

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -525,6 +525,8 @@ impl Proxy {
                     success += n;
                 }
                 Err(e) => {
+                    // TODO: remove this logic.
+                    // Refer to https://github.com/CeresDB/ceresdb/issues/1248.
                     if e.error_message().contains("No field named") {
                         self.evict_partition_table(table, catalog_name, &schema_name)
                             .await;

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -38,7 +38,7 @@ use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt}
 use generic_error::BoxError;
 use http::StatusCode;
 use interpreters::interpreter::Output;
-use logger::{debug, error, info};
+use logger::{debug, error, info,warn};
 use query_frontend::{
     frontend::{Context as FrontendContext, Frontend},
     plan::{AlterTableOperation, AlterTablePlan, InsertPlan, Plan},
@@ -481,15 +481,15 @@ impl Proxy {
     ) -> Result<WriteResponse> {
         let begin_instant = Instant::now();
         let deadline = ctx.timeout.map(|t| begin_instant + t);
-        let catalog = self.instance.catalog_manager.default_catalog_name();
+        let catalog_name = self.instance.catalog_manager.default_catalog_name();
         let req_ctx = req.context.context(ErrNoCause {
             msg: "Missing context",
             code: StatusCode::BAD_REQUEST,
         })?;
-        let schema = req_ctx.database;
+        let schema_name = req_ctx.database;
 
         debug!(
-            "Local write begin, catalog:{catalog}, schema:{schema}, request_id:{request_id}, first_table:{:?}, num_tables:{}",
+            "Local write begin, catalog:{catalog_name}, schema:{schema_name}, request_id:{request_id}, first_table:{:?}, num_tables:{}",
             req.table_requests
                 .first()
                 .map(|m| (&m.table, &m.tag_names, &m.field_names)),
@@ -499,8 +499,8 @@ impl Proxy {
         let write_context = WriteContext {
             request_id,
             deadline,
-            catalog: catalog.to_string(),
-            schema: schema.clone(),
+            catalog: catalog_name.to_string(),
+            schema: schema_name.clone(),
             auto_create_table: self.auto_create_table,
         };
 
@@ -510,9 +510,28 @@ impl Proxy {
 
         let mut success = 0;
         for insert_plan in plan_vec {
-            success += self
-                .execute_insert_plan(request_id, catalog, &schema, insert_plan, deadline)
-                .await?;
+            let table = insert_plan.table.clone();
+            match self
+                .execute_insert_plan(
+                    request_id,
+                    catalog_name,
+                    &schema_name,
+                    insert_plan,
+                    deadline,
+                )
+                .await
+            {
+                Ok(n) => {
+                    success += n;
+                }
+                Err(e) => {
+                    if e.error_message().contains("No field named") {
+                        self.evict_partition_table(table, catalog_name, &schema_name)
+                            .await;
+                    }
+                    return Err(e);
+                }
+            }
         }
 
         Ok(WriteResponse {
@@ -579,8 +598,8 @@ impl Proxy {
     async fn execute_insert_plan(
         &self,
         request_id: RequestId,
-        catalog: &str,
-        schema: &str,
+        catalog_name: &str,
+        schema_name: &str,
         insert_plan: InsertPlan,
         deadline: Option<Instant>,
     ) -> Result<usize> {
@@ -591,7 +610,7 @@ impl Proxy {
         );
         let plan = Plan::Insert(insert_plan);
         let output = self
-            .execute_plan(request_id, catalog, schema, plan, deadline)
+            .execute_plan(request_id, catalog_name, schema_name, plan, deadline)
             .await;
         output.and_then(|output| match output {
             Output::AffectedRows(n) => Ok(n),
@@ -663,6 +682,31 @@ impl Proxy {
 
         info!("Add columns success, request_id:{request_id}, table:{table_name}");
         Ok(())
+    }
+
+    async fn evict_partition_table(&self, table: TableRef, catalog_name: &str, schema_name: &str) {
+        if table.partition_info().is_some() {
+            let catalog = self.get_catalog(catalog_name);
+            if catalog.is_err() {
+                return;
+            }
+            let schema = self.get_schema(&catalog.unwrap(), schema_name);
+            if schema.is_err() {
+                return;
+            }
+            let _ = self
+                .drop_partition_table(
+                    schema.unwrap(),
+                    catalog_name.to_string(),
+                    schema_name.to_string(),
+                    table.name().to_string(),
+                )
+                .await
+                .map_err(|e| {
+                    warn!("Failed to drop partition table, err:{:?}", e);
+                    e
+                });
+        }
     }
 }
 

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -38,7 +38,7 @@ use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt}
 use generic_error::BoxError;
 use http::StatusCode;
 use interpreters::interpreter::Output;
-use logger::{debug, error, info,warn};
+use logger::{debug, error, info, warn};
 use query_frontend::{
     frontend::{Context as FrontendContext, Frontend},
     plan::{AlterTableOperation, AlterTablePlan, InsertPlan, Plan},

--- a/remote_engine_client/src/client.rs
+++ b/remote_engine_client/src/client.rs
@@ -32,7 +32,7 @@ use ceresdbproto::{
 use common_types::{record_batch::RecordBatch, schema::RecordSchema};
 use futures::{Stream, StreamExt};
 use generic_error::BoxError;
-use logger::info;
+use logger::{error, info};
 use router::RouterRef;
 use runtime::Runtime;
 use snafu::{ensure, OptionExt, ResultExt};
@@ -278,8 +278,13 @@ impl Client {
                 }
             });
 
-            if resp.is_err() {
-                result = resp;
+            if let Err(e) = resp {
+                error!(
+                    "Failed to alter schema to remote engine, table:{:?}, err:{}",
+                    table_ident, e
+                );
+
+                result = Err(e);
 
                 // If occurred error, we simply evict the corresponding channel now.
                 // TODO: evict according to the type of error.
@@ -325,8 +330,13 @@ impl Client {
                 }
             });
 
-            if resp.is_err() {
-                result = resp;
+            if let Err(e) = resp {
+                error!(
+                    "Failed to alter options to remote engine, table:{:?}, err:{}",
+                    table_ident, e
+                );
+
+                result = Err(e);
 
                 // If occurred error, we simply evict the corresponding channel now.
                 // TODO: evict according to the type of error.

--- a/remote_engine_client/src/client.rs
+++ b/remote_engine_client/src/client.rs
@@ -257,6 +257,7 @@ impl Client {
 
         let mut result = Ok(());
         // Alter schema to remote engine with retry.
+        // TODO: Define a macro to reuse the retry logic.
         for i in 0..(self.max_retry + 1) {
             let resp = rpc_client
                 .alter_table_schema(Request::new(request_pb.clone()))
@@ -280,7 +281,10 @@ impl Client {
             });
 
             if let Err(e) = resp {
-                error!("Failed to alter schema to remote engine, table:{table_ident:?}, err:{e}");
+                error!(
+                    "Failed to alter schema to remote engine,
+        table:{table_ident:?}, err:{e}"
+                );
 
                 result = Err(e);
 

--- a/remote_engine_client/src/config.rs
+++ b/remote_engine_client/src/config.rs
@@ -14,8 +14,6 @@
 
 //! Config for [Client]
 
-use std::str::FromStr;
-
 use arrow_ext::ipc::CompressOptions;
 use serde::{Deserialize, Serialize};
 use time_ext::ReadableDuration;
@@ -39,17 +37,17 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            connect_timeout: ReadableDuration::from_str("3s").unwrap(),
+            connect_timeout: ReadableDuration::secs(3),
             channel_pool_max_size_per_partition: 16,
             channel_pool_partition_num: 16,
-            channel_keep_alive_interval: ReadableDuration::from_str("600s").unwrap(),
-            channel_keep_alive_timeout: ReadableDuration::from_str("3s").unwrap(),
+            channel_keep_alive_interval: ReadableDuration::secs(600),
+            channel_keep_alive_timeout: ReadableDuration::secs(3),
             channel_keep_alive_while_idle: true,
             route_cache_max_size_per_partition: 16,
             route_cache_partition_num: 16,
             compression: CompressOptions::default(),
             max_retry: 5,
-            retry_interval: ReadableDuration::from_str("5s").unwrap(),
+            retry_interval: ReadableDuration::secs(5),
         }
     }
 }

--- a/remote_engine_client/src/config.rs
+++ b/remote_engine_client/src/config.rs
@@ -32,6 +32,8 @@ pub struct Config {
     pub route_cache_max_size_per_partition: usize,
     pub route_cache_partition_num: usize,
     pub compression: CompressOptions,
+    pub max_retry: usize,
+    pub retry_interval: ReadableDuration,
 }
 
 impl Default for Config {
@@ -46,6 +48,8 @@ impl Default for Config {
             route_cache_max_size_per_partition: 16,
             route_cache_partition_num: 16,
             compression: CompressOptions::default(),
+            max_retry: 5,
+            retry_interval: ReadableDuration::from_str("5s").unwrap(),
         }
     }
 }

--- a/remote_engine_client/src/lib.rs
+++ b/remote_engine_client/src/lib.rs
@@ -41,8 +41,8 @@ use table_engine::{
     remote::{
         self,
         model::{
-            ExecutePlanRequest, GetTableInfoRequest, ReadRequest, TableInfo, WriteBatchResult,
-            WriteRequest,
+            AlterTableOptionsRequest, AlterTableSchemaRequest, ExecutePlanRequest,
+            GetTableInfoRequest, ReadRequest, TableInfo, WriteBatchResult, WriteRequest,
         },
         RemoteEngine,
     },
@@ -158,6 +158,22 @@ impl RemoteEngine for RemoteEngineImpl {
     ) -> remote::Result<Vec<WriteBatchResult>> {
         self.client
             .write_batch(requests)
+            .await
+            .box_err()
+            .context(remote::Write)
+    }
+
+    async fn alter_table_schema(&self, request: AlterTableSchemaRequest) -> remote::Result<()> {
+        self.client
+            .alter_table_schema(request)
+            .await
+            .box_err()
+            .context(remote::Write)
+    }
+
+    async fn alter_table_options(&self, request: AlterTableOptionsRequest) -> remote::Result<()> {
+        self.client
+            .alter_table_options(request)
             .await
             .box_err()
             .context(remote::Write)

--- a/remote_engine_client/src/lib.rs
+++ b/remote_engine_client/src/lib.rs
@@ -168,7 +168,7 @@ impl RemoteEngine for RemoteEngineImpl {
             .alter_table_schema(request)
             .await
             .box_err()
-            .context(remote::Write)
+            .context(remote::AlterSchema)
     }
 
     async fn alter_table_options(&self, request: AlterTableOptionsRequest) -> remote::Result<()> {
@@ -176,7 +176,7 @@ impl RemoteEngine for RemoteEngineImpl {
             .alter_table_options(request)
             .await
             .box_err()
-            .context(remote::Write)
+            .context(remote::AlterOptions)
     }
 
     async fn get_table_info(&self, request: GetTableInfoRequest) -> remote::Result<TableInfo> {

--- a/server/src/grpc/metrics.rs
+++ b/server/src/grpc/metrics.rs
@@ -42,6 +42,8 @@ make_auto_flush_static_metric! {
         get_table_info,
         write_batch,
         execute_physical_plan,
+        alter_table_schema,
+        alter_table_options,
     }
 
     pub struct RemoteEngineGrpcHandlerDurationHistogramVec: LocalHistogram {

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -28,7 +28,8 @@ use catalog::{manager::ManagerRef, schema::SchemaRef};
 use ceresdbproto::{
     remote_engine::{
         execute_plan_request, read_response::Output::Arrow,
-        remote_engine_service_server::RemoteEngineService, row_group, ExecContext,
+        remote_engine_service_server::RemoteEngineService, row_group, AlterTableOptionsRequest,
+        AlterTableOptionsResponse, AlterTableSchemaRequest, AlterTableSchemaResponse, ExecContext,
         ExecutePlanRequest, GetTableInfoRequest, GetTableInfoResponse, ReadRequest, ReadResponse,
         WriteBatchRequest, WriteRequest, WriteResponse,
     },
@@ -56,7 +57,7 @@ use table_engine::{
     predicate::PredicateRef,
     remote::model::{self, TableIdentifier},
     stream::{PartitionedStreams, SendableRecordBatchStream},
-    table::TableRef,
+    table::{AlterSchemaRequest, TableRef},
 };
 use time_ext::InstantExt;
 use tokio::sync::mpsc::{self, Sender};
@@ -654,6 +655,70 @@ impl RemoteEngineServiceImpl {
         ))
     }
 
+    async fn alter_table_schema_internal(
+        &self,
+        request: Request<AlterTableSchemaRequest>,
+    ) -> std::result::Result<Response<AlterTableSchemaResponse>, Status> {
+        let begin_instant = Instant::now();
+        let ctx = self.handler_ctx();
+        let handle = self.runtimes.read_runtime.spawn(async move {
+            let request = request.into_inner();
+            handle_alter_table_schema(ctx, request).await
+        });
+
+        let res = handle.await.box_err().context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: "fail to join task",
+        });
+
+        let mut resp = AlterTableSchemaResponse::default();
+        match res {
+            Ok(Ok(_)) => {
+                resp.header = Some(error::build_ok_header());
+            }
+            Ok(Err(e)) | Err(e) => {
+                resp.header = Some(error::build_err_header(e));
+            }
+        };
+
+        REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC
+            .get_table_info
+            .observe(begin_instant.saturating_elapsed().as_secs_f64());
+        Ok(Response::new(resp))
+    }
+
+    async fn alter_table_options_internal(
+        &self,
+        request: Request<AlterTableOptionsRequest>,
+    ) -> std::result::Result<Response<AlterTableOptionsResponse>, Status> {
+        let begin_instant = Instant::now();
+        let ctx = self.handler_ctx();
+        let handle = self.runtimes.read_runtime.spawn(async move {
+            let request = request.into_inner();
+            handle_alter_table_options(ctx, request).await
+        });
+
+        let res = handle.await.box_err().context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: "fail to join task",
+        });
+
+        let mut resp = AlterTableOptionsResponse::default();
+        match res {
+            Ok(Ok(_)) => {
+                resp.header = Some(error::build_ok_header());
+            }
+            Ok(Err(e)) | Err(e) => {
+                resp.header = Some(error::build_err_header(e));
+            }
+        };
+
+        REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC
+            .get_table_info
+            .observe(begin_instant.saturating_elapsed().as_secs_f64());
+        Ok(Response::new(resp))
+    }
+
     fn handler_ctx(&self) -> HandlerContext {
         HandlerContext {
             catalog_manager: self.instance.catalog_manager.clone(),
@@ -739,6 +804,20 @@ impl RemoteEngineService for RemoteEngineServiceImpl {
         };
 
         record_stream_to_response_stream!(record_stream_result, ExecutePhysicalPlanStream)
+    }
+
+    async fn alter_table_schema(
+        &self,
+        request: Request<AlterTableSchemaRequest>,
+    ) -> std::result::Result<Response<AlterTableSchemaResponse>, Status> {
+        self.alter_table_schema_internal(request).await
+    }
+
+    async fn alter_table_options(
+        &self,
+        request: Request<AlterTableOptionsRequest>,
+    ) -> std::result::Result<Response<AlterTableOptionsResponse>, Status> {
+        self.alter_table_options_internal(request).await
     }
 }
 
@@ -1001,6 +1080,83 @@ async fn handle_execute_plan(
             code: StatusCode::Internal,
             msg: "failed to execute remote plan",
         })
+}
+
+async fn handle_alter_table_schema(
+    ctx: HandlerContext,
+    request: AlterTableSchemaRequest,
+) -> Result<()> {
+    let request: table_engine::remote::model::AlterTableSchemaRequest =
+        request.try_into().box_err().context(ErrWithCause {
+            code: StatusCode::BadRequest,
+            msg: "fail to convert alter table schema",
+        })?;
+
+    let schema = find_schema_by_identifier(&ctx, &request.table_ident)?;
+    let table = schema
+        .table_by_name(&request.table_ident.table)
+        .box_err()
+        .context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: format!("fail to get table, table:{}", request.table_ident.table),
+        })?
+        .context(ErrNoCause {
+            code: StatusCode::NotFound,
+            msg: format!("table is not found, table:{}", request.table_ident.table),
+        })?;
+
+    table
+        .alter_schema(AlterSchemaRequest {
+            schema: request.table_schema,
+            pre_schema_version: request.pre_schema_version,
+        })
+        .await
+        .box_err()
+        .context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: format!(
+                "fail to alter table schema, table:{}",
+                request.table_ident.table
+            ),
+        })?;
+    Ok(())
+}
+
+async fn handle_alter_table_options(
+    ctx: HandlerContext,
+    request: AlterTableOptionsRequest,
+) -> Result<()> {
+    let request: table_engine::remote::model::AlterTableOptionsRequest =
+        request.try_into().box_err().context(ErrWithCause {
+            code: StatusCode::BadRequest,
+            msg: "fail to convert alter table schema",
+        })?;
+
+    let schema = find_schema_by_identifier(&ctx, &request.table_ident)?;
+    let table = schema
+        .table_by_name(&request.table_ident.table)
+        .box_err()
+        .context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: format!("fail to get table, table:{}", request.table_ident.table),
+        })?
+        .context(ErrNoCause {
+            code: StatusCode::NotFound,
+            msg: format!("table is not found, table:{}", request.table_ident.table),
+        })?;
+
+    table
+        .alter_options(request.options)
+        .await
+        .box_err()
+        .context(ErrWithCause {
+            code: StatusCode::Internal,
+            msg: format!(
+                "fail to alter table options, table:{}",
+                request.table_ident.table
+            ),
+        })?;
+    Ok(())
 }
 
 fn check_and_extract_plan(

--- a/server/src/grpc/remote_engine_service/mod.rs
+++ b/server/src/grpc/remote_engine_service/mod.rs
@@ -682,7 +682,7 @@ impl RemoteEngineServiceImpl {
         };
 
         REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC
-            .get_table_info
+            .alter_table_schema
             .observe(begin_instant.saturating_elapsed().as_secs_f64());
         Ok(Response::new(resp))
     }
@@ -714,7 +714,7 @@ impl RemoteEngineServiceImpl {
         };
 
         REMOTE_ENGINE_GRPC_HANDLER_DURATION_HISTOGRAM_VEC
-            .get_table_info
+            .alter_table_options
             .observe(begin_instant.saturating_elapsed().as_secs_f64());
         Ok(Response::new(resp))
     }
@@ -1129,7 +1129,7 @@ async fn handle_alter_table_options(
     let request: table_engine::remote::model::AlterTableOptionsRequest =
         request.try_into().box_err().context(ErrWithCause {
             code: StatusCode::BadRequest,
-            msg: "fail to convert alter table schema",
+            msg: "fail to convert alter table options",
         })?;
 
     let schema = find_schema_by_identifier(&ctx, &request.table_ident)?;

--- a/table_engine/src/memory.rs
+++ b/table_engine/src/memory.rs
@@ -41,7 +41,10 @@ use crate::{
     },
     remote::{
         self,
-        model::{self, ExecutePlanRequest, GetTableInfoRequest, WriteBatchResult},
+        model::{
+            self, AlterTableOptionsRequest, AlterTableSchemaRequest, ExecutePlanRequest,
+            GetTableInfoRequest, WriteBatchResult,
+        },
         RemoteEngine,
     },
     stream::{
@@ -358,6 +361,14 @@ impl RemoteEngine for MockRemoteEngine {
         &self,
         _requests: Vec<remote::model::WriteRequest>,
     ) -> remote::Result<Vec<WriteBatchResult>> {
+        unimplemented!()
+    }
+
+    async fn alter_table_schema(&self, _requests: AlterTableSchemaRequest) -> remote::Result<()> {
+        unimplemented!()
+    }
+
+    async fn alter_table_options(&self, _requests: AlterTableOptionsRequest) -> remote::Result<()> {
         unimplemented!()
     }
 

--- a/table_engine/src/remote/mod.rs
+++ b/table_engine/src/remote/mod.rs
@@ -25,7 +25,10 @@ use model::{ReadRequest, WriteRequest};
 use snafu::Snafu;
 
 use crate::{
-    remote::model::{ExecutePlanRequest, GetTableInfoRequest, TableInfo, WriteBatchResult},
+    remote::model::{
+        AlterTableOptionsRequest, AlterTableSchemaRequest, ExecutePlanRequest, GetTableInfoRequest,
+        TableInfo, WriteBatchResult,
+    },
     stream::SendableRecordBatchStream,
 };
 
@@ -37,6 +40,12 @@ pub enum Error {
 
     #[snafu(display("Failed to write to remote, err:{}", source))]
     Write { source: GenericError },
+
+    #[snafu(display("Failed to alter schema, err:{}", source))]
+    AlterSchema { source: GenericError },
+
+    #[snafu(display("Failed to alter options, err:{}", source))]
+    AlterOptions { source: GenericError },
 
     #[snafu(display("Failed to get table info from remote, err:{}", source))]
     GetTableInfo { source: GenericError },
@@ -57,6 +66,10 @@ pub trait RemoteEngine: fmt::Debug + Send + Sync {
     async fn write(&self, request: WriteRequest) -> Result<usize>;
 
     async fn write_batch(&self, requests: Vec<WriteRequest>) -> Result<Vec<WriteBatchResult>>;
+
+    async fn alter_table_schema(&self, request: AlterTableSchemaRequest) -> Result<()>;
+
+    async fn alter_table_options(&self, request: AlterTableOptionsRequest) -> Result<()>;
 
     async fn get_table_info(&self, request: GetTableInfoRequest) -> Result<TableInfo>;
 

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -247,6 +247,7 @@ pub struct WriteBatchResult {
     pub result: GenericResult<u64>,
 }
 
+#[derive(Debug)]
 pub struct AlterTableSchemaRequest {
     pub table_ident: TableIdentifier,
     pub table_schema: Schema,
@@ -285,6 +286,7 @@ impl From<AlterTableSchemaRequest> for ceresdbproto::remote_engine::AlterTableSc
     }
 }
 
+#[derive(Debug)]
 pub struct AlterTableOptionsRequest {
     pub table_ident: TableIdentifier,
     pub options: HashMap<String, String>,

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -27,7 +27,7 @@ use common_types::{
         contiguous::{ContiguousRow, ContiguousRowReader, ContiguousRowWriter},
         Row, RowGroup, RowGroupBuilder,
     },
-    schema::{IndexInWriterSchema, RecordSchema, Schema},
+    schema::{IndexInWriterSchema, RecordSchema, Schema, Version},
 };
 use generic_error::{BoxError, GenericError, GenericResult};
 use macros::define_result;
@@ -245,6 +245,73 @@ impl WriteRequest {
 pub struct WriteBatchResult {
     pub table_idents: Vec<TableIdentifier>,
     pub result: GenericResult<u64>,
+}
+
+pub struct AlterTableSchemaRequest {
+    pub table_ident: TableIdentifier,
+    pub table_schema: Schema,
+    /// Previous schema version before alteration.
+    pub pre_schema_version: Version,
+}
+
+impl TryFrom<ceresdbproto::remote_engine::AlterTableSchemaRequest> for AlterTableSchemaRequest {
+    type Error = Error;
+
+    fn try_from(value: remote_engine::AlterTableSchemaRequest) -> Result<Self> {
+        let table = value.table.context(EmptyTableIdentifier)?.into();
+        let table_schema = value
+            .table_schema
+            .context(EmptyTableSchema)?
+            .try_into()
+            .box_err()
+            .context(ConvertTableSchema)?;
+        Ok(Self {
+            table_ident: table,
+            table_schema,
+            pre_schema_version: value.pre_schema_version,
+        })
+    }
+}
+
+impl From<AlterTableSchemaRequest> for ceresdbproto::remote_engine::AlterTableSchemaRequest {
+    fn from(value: AlterTableSchemaRequest) -> Self {
+        let table = value.table_ident.into();
+        let table_schema = (&value.table_schema).into();
+        Self {
+            table: Some(table),
+            table_schema: Some(table_schema),
+            pre_schema_version: value.pre_schema_version,
+        }
+    }
+}
+
+pub struct AlterTableOptionsRequest {
+    pub table_ident: TableIdentifier,
+    pub options: HashMap<String, String>,
+}
+
+impl TryFrom<ceresdbproto::remote_engine::AlterTableOptionsRequest> for AlterTableOptionsRequest {
+    type Error = Error;
+
+    fn try_from(value: remote_engine::AlterTableOptionsRequest) -> Result<Self> {
+        let table = value.table.context(EmptyTableIdentifier)?.into();
+        let options = value.options;
+        Ok(Self {
+            table_ident: table,
+            options,
+        })
+    }
+}
+
+impl From<AlterTableOptionsRequest> for ceresdbproto::remote_engine::AlterTableOptionsRequest {
+    fn from(value: AlterTableOptionsRequest) -> Self {
+        let table = value.table_ident.into();
+        let options = value.options;
+        Self {
+            table: Some(table),
+            options,
+        }
+    }
 }
 
 pub struct GetTableInfoRequest {

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -474,7 +474,7 @@ impl TryFrom<ceresdbproto::remote_engine::TableReadRequest> for ReadRequest {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AlterSchemaRequest {
     /// The new schema.
     pub schema: Schema,

--- a/table_engine/src/table.rs
+++ b/table_engine/src/table.rs
@@ -474,7 +474,7 @@ impl TryFrom<ceresdbproto::remote_engine::TableReadRequest> for ReadRequest {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct AlterSchemaRequest {
     /// The new schema.
     pub schema: Schema,


### PR DESCRIPTION
## Rationale
Support for alter schema on partition table.

## Detailed Changes
* Support for alter schema on partition table.
* Support for alter options on partition table.
* **Notice:** Currently, there is no concurrency control in place. If alter schema operations are performed simultaneously on the same partition table, it may result in schema inconsistency issue. #1247 
* **Notice:** Due to the ability to open partition table on multiple ceresdb nodes, there may be inconsistencies in the schema information maintained in memory. Currently, the approach of cleaning up through errors occurring during writing is relatively rough. #1248 

## Test Plan
Manual test and CI.