### PR TITLE
chore: fix the missing `example.toml` in README-CN

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -73,7 +73,7 @@ cargo build --release
 
 使用下载的代码中提供的默认配置文件，即可启动：
 ```bash
-./target/release/ceresdb-server --config ./docs/example.toml
+./target/release/ceresdb-server --config ./docs/minimal.toml
 ```
 
 ### 进行数据读写


### PR DESCRIPTION
The `example.toml` is missing in the docs folder, the `minimal.toml` is valid.

## Rationale
`example.toml` was renamed into `minimal.toml`

## Detailed Changes
change the README-CN's  content

## Test Plan
