### PR TITLE
feat: support schema validate in remote write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "codec",
  "common_types",
  "datafusion",
@@ -1298,7 +1298,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1328,6 +1328,18 @@ name = "ceresdbproto"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bb4aa3d3a6b99a22cc2e35cd2cd04d52e825dbcb8f0dd7c7095a0d4e7bdfed1"
+dependencies = [
+ "prost",
+ "protoc-bin-vendored",
+ "tonic 0.8.3",
+ "tonic-build",
+ "walkdir",
+]
+
+[[package]]
+name = "ceresdbproto"
+version = "1.0.17"
+source = "git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416#411f4773c84831b3d200d95cf91797f27319b416"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1510,7 +1522,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1588,7 +1600,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2343,7 +2355,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3895,7 +3907,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4420,7 +4432,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "chrono",
  "clru",
  "crc",
@@ -5297,7 +5309,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "clru",
  "cluster",
  "common_types",
@@ -5422,7 +5434,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "cluster",
  "codec",
  "common_types",
@@ -5733,7 +5745,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5862,7 +5874,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "cluster",
  "common_types",
  "generic_error",
@@ -6230,7 +6242,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "clru",
  "cluster",
  "common_types",
@@ -6755,7 +6767,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6777,7 +6789,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6980,7 +6992,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "chrono",
  "common_types",
  "macros",
@@ -7630,7 +7642,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto",
+ "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
  "atomic_enum",
  "base64 0.13.1",
  "bytes_ext",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "codec",
  "common_types",
  "datafusion",
@@ -1298,7 +1298,7 @@ checksum = "8ef195bacb1ca0eb02d6a0562b09852941d01de2b962c7066c922115fab7dcb7"
 dependencies = [
  "arrow 38.0.0",
  "async-trait",
- "ceresdbproto 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ceresdbproto",
  "dashmap 5.4.0",
  "futures 0.3.28",
  "paste 1.0.12",
@@ -1325,21 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "ceresdbproto"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb4aa3d3a6b99a22cc2e35cd2cd04d52e825dbcb8f0dd7c7095a0d4e7bdfed1"
-dependencies = [
- "prost",
- "protoc-bin-vendored",
- "tonic 0.8.3",
- "tonic-build",
- "walkdir",
-]
-
-[[package]]
-name = "ceresdbproto"
-version = "1.0.17"
-source = "git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416#411f4773c84831b3d200d95cf91797f27319b416"
+checksum = "7fc99bdf6e40cee4545ba77eebe28bdf6e40c99595d895a8f3891fc748e57276"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -1522,7 +1510,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "common_types",
  "etcd-client",
  "future_ext",
@@ -1600,7 +1588,7 @@ dependencies = [
  "arrow 43.0.0",
  "arrow_ext",
  "bytes_ext",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "chrono",
  "datafusion",
  "hash_ext",
@@ -2355,7 +2343,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -3907,7 +3895,7 @@ name = "meta_client"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -4432,7 +4420,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "chrono",
  "clru",
  "crc",
@@ -5309,7 +5297,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "catalog",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -5434,7 +5422,7 @@ dependencies = [
  "arrow 43.0.0",
  "async-trait",
  "catalog",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "cluster",
  "codec",
  "common_types",
@@ -5745,7 +5733,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "arrow_ext",
  "async-trait",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "common_types",
  "futures 0.3.28",
  "generic_error",
@@ -5874,7 +5862,7 @@ name = "router"
 version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "cluster",
  "common_types",
  "generic_error",
@@ -6242,7 +6230,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "clru",
  "cluster",
  "common_types",
@@ -6767,7 +6755,7 @@ dependencies = [
  "async-trait",
  "bytes_ext",
  "catalog",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "codec",
  "common_types",
  "futures 0.3.28",
@@ -6789,7 +6777,7 @@ dependencies = [
  "arrow_ext",
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "common_types",
  "datafusion",
  "datafusion-proto",
@@ -6992,7 +6980,7 @@ dependencies = [
 name = "time_ext"
 version = "1.2.6-alpha"
 dependencies = [
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "chrono",
  "common_types",
  "macros",
@@ -7642,7 +7630,7 @@ version = "1.2.6-alpha"
 dependencies = [
  "async-trait",
  "bytes_ext",
- "ceresdbproto 1.0.17 (git+https://github.com/ShiKaiWi/ceresdbproto.git?rev=411f4773c84831b3d200d95cf91797f27319b416)",
+ "ceresdbproto",
  "chrono",
  "codec",
  "common_types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = "1.0.17"
+ceresdbproto = { git = "https://github.com/ShiKaiWi/ceresdbproto.git", rev = "411f4773c84831b3d200d95cf91797f27319b416" }
 codec = { path = "components/codec" }
 notifier = { path = "components/notifier" }
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ bytes = "1"
 bytes_ext = { path = "components/bytes_ext" }
 catalog = { path = "catalog" }
 catalog_impls = { path = "catalog_impls" }
-ceresdbproto = { git = "https://github.com/ShiKaiWi/ceresdbproto.git", rev = "411f4773c84831b3d200d95cf91797f27319b416" }
+ceresdbproto = "1.0.18"
 codec = { path = "components/codec" }
 notifier = { path = "components/notifier" }
 chrono = "0.4"

--- a/common_types/src/column_schema.rs
+++ b/common_types/src/column_schema.rs
@@ -17,7 +17,7 @@
 use std::{collections::HashMap, convert::TryFrom, str::FromStr, sync::Arc};
 
 use arrow::datatypes::{DataType, Field};
-use ceresdbproto::schema as schema_pb;
+use ceresdbproto::{remote_engine::ColumnDesc, schema as schema_pb};
 use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 use sqlparser::ast::Expr;
 
@@ -281,6 +281,25 @@ impl ColumnSchema {
             );
 
             Ok(ReadOp::Exact)
+        }
+    }
+
+    /// Check whether the given `desc` is correct with self.
+    pub fn is_correct_desc(&self, desc: &ColumnDesc) -> bool {
+        if self.id != desc.id {
+            return false;
+        }
+
+        let desc_datum_kind = DatumKind::from(desc.typ());
+        desc_datum_kind == self.data_type
+    }
+}
+
+impl From<&ColumnSchema> for ColumnDesc {
+    fn from(column_schema: &ColumnSchema) -> Self {
+        Self {
+            id: column_schema.id,
+            typ: schema_pb::DataType::from(column_schema.data_type).into(),
         }
     }
 }

--- a/integration_tests/cases/env/cluster/ddl/partition_table.result
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.result
@@ -82,6 +82,10 @@ ALTER TABLE partition_table_t ADD COLUMN (b string);
 
 affected_rows: 0
 
+INSERT INTO partition_table_t (t, id, name, value) VALUES (1651737067000, 10, "ceresdb0", 100);
+
+Failed to execute query, err: Server(ServerError { code: 500, msg: "Failed to execute plan, sql:INSERT INTO partition_table_t (t, id, name, value) VALUES (1651737067000, 10, \"ceresdb0\", 100);. Caused by: Internal error, msg:Failed to execute interpreter, err:Failed to execute insert, err:Failed to write table, err:Failed to write tables in batch, tables:[\"__partition_table_t_1\"], err:Failed to query from table in server, table_idents:[TableIdentifier { catalog: \"ceresdb\", schema: \"public\", table: \"__partition_table_t_1\" }], code:401, msg:failed to decode row group payload. Caused by: Schema mismatch with the write request, msg:expect 6 columns, but got 5." })
+
 ALTER TABLE partition_table_t MODIFY SETTING enable_ttl='true';
 
 affected_rows: 0

--- a/integration_tests/cases/env/cluster/ddl/partition_table.sql
+++ b/integration_tests/cases/env/cluster/ddl/partition_table.sql
@@ -37,6 +37,8 @@ SELECT * from partition_table_t where name in ("ceresdb5", "ceresdb6", "ceresdb7
 
 ALTER TABLE partition_table_t ADD COLUMN (b string);
 
+INSERT INTO partition_table_t (t, id, name, value) VALUES (1651737067000, 10, "ceresdb0", 100);
+
 ALTER TABLE partition_table_t MODIFY SETTING enable_ttl='true';
 
 SHOW CREATE TABLE __partition_table_t_0;

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -280,6 +280,7 @@ fn validate_contiguous_payload_schema(schema: &Schema, column_descs: &[ColumnDes
             }
         );
     }
+
     Ok(())
 }
 

--- a/table_engine/src/remote/model.rs
+++ b/table_engine/src/remote/model.rs
@@ -20,7 +20,9 @@ use std::{
 };
 
 use bytes_ext::{ByteVec, Bytes};
-use ceresdbproto::remote_engine::{self, execute_plan_request, row_group::Rows::Contiguous};
+use ceresdbproto::remote_engine::{
+    self, execute_plan_request, row_group::Rows::Contiguous, ColumnDesc,
+};
 use common_types::{
     request_id::RequestId,
     row::{
@@ -30,8 +32,9 @@ use common_types::{
     schema::{IndexInWriterSchema, RecordSchema, Schema, Version},
 };
 use generic_error::{BoxError, GenericError, GenericResult};
+use itertools::Itertools;
 use macros::define_result;
-use snafu::{Backtrace, OptionExt, ResultExt, Snafu};
+use snafu::{ensure, Backtrace, OptionExt, ResultExt, Snafu};
 
 use crate::{
     partition::PartitionInfo,
@@ -62,6 +65,12 @@ pub enum Error {
 
     #[snafu(display("Empty table schema.\nBacktrace:\n{}", backtrace))]
     EmptyTableSchema { backtrace: Backtrace },
+
+    #[snafu(display(
+        "Schema mismatch with the write request, msg:{msg}.\nBacktrace:\n{}",
+        backtrace
+    ))]
+    SchemaMismatch { msg: String, backtrace: Backtrace },
 
     #[snafu(display("Empty row group.\nBacktrace:\n{}", backtrace))]
     EmptyRowGroup { backtrace: Backtrace },
@@ -184,6 +193,8 @@ impl WriteRequest {
         payload: ceresdbproto::remote_engine::ContiguousRows,
         schema: &Schema,
     ) -> Result<RowGroup> {
+        validate_contiguous_payload_schema(schema, &payload.column_descs)?;
+
         let mut row_group_builder =
             RowGroupBuilder::with_capacity(schema.clone(), payload.encoded_rows.len());
         for encoded_row in payload.encoded_rows {
@@ -222,9 +233,15 @@ impl WriteRequest {
             encoded_rows.push(buf);
         }
 
+        let column_descs = table_schema
+            .columns()
+            .iter()
+            .map(ColumnDesc::from)
+            .collect_vec();
         let contiguous_rows = ceresdbproto::remote_engine::ContiguousRows {
             schema_version: table_schema.version(),
             encoded_rows,
+            column_descs,
         };
         let row_group_pb = ceresdbproto::remote_engine::RowGroup {
             min_timestamp,
@@ -240,6 +257,30 @@ impl WriteRequest {
             row_group: Some(row_group_pb),
         })
     }
+}
+
+/// Validate the provided column descriptions with schema.
+fn validate_contiguous_payload_schema(schema: &Schema, column_descs: &[ColumnDesc]) -> Result<()> {
+    ensure!(
+        schema.num_columns() == column_descs.len(),
+        SchemaMismatch {
+            msg: format!(
+                "expect {} columns, but got {}",
+                schema.num_columns(),
+                column_descs.len(),
+            )
+        }
+    );
+
+    for (expect_column_schema, desc) in schema.columns().iter().zip(column_descs.iter()) {
+        ensure!(
+            expect_column_schema.is_correct_desc(desc),
+            SchemaMismatch {
+                msg: format!("expect column schema:{expect_column_schema:?}, but got {desc:?}")
+            }
+        );
+    }
+    Ok(())
 }
 
 pub struct WriteBatchResult {


### PR DESCRIPTION
## Rationale
The schema must be ensured to be correct during the remote write rpc call. Howerver, such check is missing now.

## Detailed Changes
Introduce schema version check during remote write rpc call.

## Test Plan
Add a new integration test for it.