### PR TITLE
feat: avoid flush when drop table

### DIFF
--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -14,7 +14,7 @@
 
 //! Drop table logic of instance
 
-use common_types::SequenceNumber;
+use common_types::MAX_SEQUENCE_NUMBER;
 use logger::{info, warn};
 use snafu::ResultExt;
 use table_engine::engine::DropTableRequest;
@@ -59,8 +59,9 @@ impl Dropper {
         let table_location = table_data.table_location();
         let wal_location =
             crate::instance::create_wal_location(table_location.id, table_location.shard_info);
-        // Use max to represet delete all WAL.
-        let sequence = SequenceNumber::MAX;
+        // Use max to represent delete all WAL.
+        // TODO: add a method in wal_manager to delete all WAL with same prefix.
+        let sequence = MAX_SEQUENCE_NUMBER;
         self.space_store
             .wal_manager
             .mark_delete_entries_up_to(wal_location, sequence)

--- a/analytic_engine/src/instance/drop.rs
+++ b/analytic_engine/src/instance/drop.rs
@@ -35,6 +35,9 @@ pub(crate) struct Dropper {
 
 impl Dropper {
     /// Drop a table under given space
+    // TODO: Currently we first delete WAL then manifest, if wal is deleted but
+    // manifest failed to delete, it could cause the table in a unknown state, we
+    // should find a better way to deal with this.
     pub async fn drop(&self, request: DropTableRequest) -> Result<bool> {
         info!("Try to drop table, request:{:?}", request);
 

--- a/analytic_engine/src/instance/engine.rs
+++ b/analytic_engine/src/instance/engine.rs
@@ -368,7 +368,6 @@ impl Instance {
         let dropper = Dropper {
             space,
             space_store: self.space_store.clone(),
-            flusher: self.make_flusher(),
         };
 
         dropper.drop(request).await

--- a/analytic_engine/src/memtable/skiplist/mod.rs
+++ b/analytic_engine/src/memtable/skiplist/mod.rs
@@ -49,7 +49,7 @@ struct Metrics {
 }
 
 /// MemTable implementation based on skiplist
-pub struct SkiplistMemTable<A: Arena<Stats = BasicStats> + Clone> {
+pub struct SkiplistMemTable<A> {
     /// Schema of this memtable, is immutable.
     schema: Schema,
     skiplist: Skiplist<BytewiseComparator, A>,
@@ -60,6 +60,16 @@ pub struct SkiplistMemTable<A: Arena<Stats = BasicStats> + Clone> {
     metrics: Metrics,
     min_time: AtomicI64,
     max_time: AtomicI64,
+}
+
+impl<A> Drop for SkiplistMemTable<A> {
+    fn drop(&mut self) {
+        logger::debug!(
+            "Drop memtable, last_seq:{}, schema:{:?}",
+            self.last_sequence.load(atomic::Ordering::Relaxed),
+            self.schema
+        );
+    }
 }
 
 impl<A: Arena<Stats = BasicStats> + Clone> SkiplistMemTable<A> {

--- a/analytic_engine/src/memtable/skiplist/mod.rs
+++ b/analytic_engine/src/memtable/skiplist/mod.rs
@@ -65,7 +65,7 @@ pub struct SkiplistMemTable<A> {
 impl<A> Drop for SkiplistMemTable<A> {
     fn drop(&mut self) {
         logger::debug!(
-            "Drop memtable, last_seq:{}, schema:{:?}",
+            "Drop skiplist memtable, last_seq:{}, schema:{:?}",
             self.last_sequence.load(atomic::Ordering::Relaxed),
             self.schema
         );

--- a/components/skiplist/src/list.rs
+++ b/components/skiplist/src/list.rs
@@ -211,7 +211,7 @@ impl Node {
     }
 }
 
-struct SkiplistCore<A: Arena<Stats = BasicStats>> {
+struct SkiplistCore<A> {
     height: AtomicUsize,
     head: NonNull<Node>,
     arena: A,
@@ -220,7 +220,7 @@ struct SkiplistCore<A: Arena<Stats = BasicStats>> {
 /// FIXME(yingwen): Modify the skiplist to support arena that supports growth,
 /// otherwise it is hard to avoid memory usage not out of the arena capacity
 #[derive(Clone)]
-pub struct Skiplist<C, A: Arena<Stats = BasicStats> + Clone> {
+pub struct Skiplist<C, A> {
     core: Arc<SkiplistCore<A>>,
     c: C,
 }

--- a/wal/src/table_kv_impl/table_unit.rs
+++ b/wal/src/table_kv_impl/table_unit.rs
@@ -479,12 +479,12 @@ impl TableUnit {
                 // may be greater than the `actual last sequence of written logs`.
                 //
                 // Such as following case:
-                //  + Write wal logs failed(last sequence stored in memory will increase when write failed). 
-                //  + Get last sequence from memory(greater then actual last sequence now). 
+                //  + Write wal logs failed(last sequence stored in memory will increase when write failed).
+                //  + Get last sequence from memory(greater then actual last sequence now).
                 //  + Mark the got last sequence as flushed sequence.
                 let actual_next_sequence = sequence + 1;
                 if actual_next_sequence < start_sequence {
-                    warn!("TableKv WAL found start_sequence greater than actual_next_sequence, 
+                    warn!("TableKv WAL found start_sequence greater than actual_next_sequence,
                     start_sequence:{start_sequence}, actual_next_sequence:{actual_next_sequence}, table_id:{table_id}, region_id:{region_id}");
 
                     break;
@@ -994,13 +994,6 @@ impl TableUnitWriter {
         debug!(
             "Try to delete entries, table_id:{}, sequence_num:{}, meta table:{}",
             table_unit_state.table_id, sequence_num, table_unit_meta_table
-        );
-
-        ensure!(
-            sequence_num < common_types::MAX_SEQUENCE_NUMBER,
-            SequenceOverflow {
-                table_id: table_unit_state.table_id,
-            }
         );
 
         let last_sequence = table_unit_state.last_sequence();


### PR DESCRIPTION
## Rationale
When drop a table, flush is unnecessary, and this cause the drop take a long time.

## Detailed Changes
Mark WAL as deleted directly when drop table.

## Test Plan
Manually

