### PR TITLE
chore: delete the configuration related to github cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Check License Header
         uses: korandoru/hawkeye@v3
       - name: Setup Build Environment
@@ -89,6 +93,10 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -115,6 +123,10 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -146,6 +158,10 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -202,6 +218,10 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -229,6 +249,10 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,26 +56,8 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
-      - name: Release Disk Quota
-        run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Check License Header
         uses: korandoru/hawkeye@v3
-      - name: Cache Rust Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
-            debug-${{ runner.os }}-
-            debug-
-      - name: Ensure Disk Quota
-        run: |
-          make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -107,21 +89,6 @@ jobs:
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
-      - name: Release Disk Quota
-        run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
-      - name: Cache Rust Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
-            debug-${{ runner.os }}-
-            debug-
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -145,24 +112,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Cache Rust Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
-            debug-${{ runner.os }}-
-            debug-
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
-      - name: Release Disk Quota
-        run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -191,24 +143,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Cache Rust Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
-            debug-${{ runner.os }}-
-            debug-
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
-      - name: Release Disk Quota
-        run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -262,24 +199,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Cache Rust Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
-            debug-${{ runner.os }}-
-            debug-
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
-      - name: Release Disk Quota
-        run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update
@@ -304,24 +226,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Cache Rust Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            debug-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
-            debug-${{ runner.os }}-
-            debug-
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
-      - name: Release Disk Quota
-        run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Setup Build Environment
         run: |
           sudo apt update

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -43,6 +43,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
       - name: Build Docker image
         run: docker build -t ${IMAGE_NAME} .
       - name: Test the Built Image

--- a/.github/workflows/tsbs.yml
+++ b/.github/workflows/tsbs.yml
@@ -31,6 +31,23 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Release Disk Quota
+        run: |
+          sudo rm -rf /usr/local/lib/android # release about 10 GB
+          sudo rm -rf /usr/share/dotnet # release about 20GB
+      - name: Cache Rust Dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo
+            ./target
+          key: release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
+            release-${{ runner.os }}-
+      - name: Ensure Disk Quota
+        run: |
+          make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update

--- a/.github/workflows/tsbs.yml
+++ b/.github/workflows/tsbs.yml
@@ -31,23 +31,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Release Disk Quota
-        run: |
-          sudo rm -rf /usr/local/lib/android # release about 10 GB
-          sudo rm -rf /usr/share/dotnet # release about 20GB
-      - name: Cache Rust Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}-
-            release-${{ runner.os }}-
-      - name: Ensure Disk Quota
-        run: |
-          make ensure-disk-quota
       - name: Setup Build Environment
         run: |
           sudo apt update


### PR DESCRIPTION
## Rationale
Due to the huge cache of rust before, unit tests often failed due to insufficient capacity. [CI without cache](https://github.com/CeresDB/ceresdb/actions/runs/6492219953/job/17630769103?pr=1259) takes an acceptable time and does not cause failure problems.

https://github.com/CeresDB/ceresdb/pull/1261 show CI always fail in Rust Cache.
The github action's time seems have huge volatile, https://github.com/CeresDB/ceresdb/actions/runs/6517181839/job/17701414760?pr=1259 takes 24 min without cache, some pr have cache even is slower than this action
## Detailed Changes
Delete out the configuration related to github cache

## Test Plan
CI


