### PR TITLE
chore: add metrics to inspect write path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2696,6 +2696,8 @@ name = "future_ext"
 version = "1.2.6-alpha"
 dependencies = [
  "futures 0.3.28",
+ "lazy_static",
+ "prometheus 0.12.0",
  "runtime",
  "tokio",
 ]

--- a/analytic_engine/src/table/metrics.rs
+++ b/analytic_engine/src/table/metrics.rs
@@ -62,6 +62,11 @@ lazy_static! {
         "Read request counter of table"
     )
     .unwrap();
+
+    static ref TABLE_QUEUE_WRITER_CANCEL_COUNTER: IntCounter = register_int_counter!(
+        "table_queue_writer_cancel_counter",
+        "Counter for table queue writer cancel"
+    ).unwrap();
     // End of counters.
 
     // Histograms:
@@ -185,6 +190,8 @@ pub struct Metrics {
     table_write_instance_flush_wait_duration: Histogram,
     table_write_flush_wait_duration: Histogram,
     table_write_execute_duration: Histogram,
+    table_write_queue_waiter_duration: Histogram,
+    table_write_queue_writer_duration: Histogram,
     table_write_total_duration: Histogram,
 }
 
@@ -219,6 +226,10 @@ impl Default for Metrics {
                 .with_label_values(&["wait_flush"]),
             table_write_execute_duration: TABLE_WRITE_DURATION_HISTOGRAM
                 .with_label_values(&["execute"]),
+            table_write_queue_waiter_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["queue_waiter"]),
+            table_write_queue_writer_duration: TABLE_WRITE_DURATION_HISTOGRAM
+                .with_label_values(&["queue_writer"]),
             table_write_total_duration: TABLE_WRITE_DURATION_HISTOGRAM
                 .with_label_values(&["total"]),
         }
@@ -338,6 +349,16 @@ impl Metrics {
     #[inline]
     pub fn start_table_write_encode_timer(&self) -> HistogramTimer {
         self.table_write_encode_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_queue_waiter_timer(&self) -> HistogramTimer {
+        self.table_write_queue_waiter_duration.start_timer()
+    }
+
+    #[inline]
+    pub fn start_table_write_queue_writer_timer(&self) -> HistogramTimer {
+        self.table_write_queue_writer_duration.start_timer()
     }
 
     #[inline]

--- a/analytic_engine/src/table/metrics.rs
+++ b/analytic_engine/src/table/metrics.rs
@@ -62,11 +62,6 @@ lazy_static! {
         "Read request counter of table"
     )
     .unwrap();
-
-    static ref TABLE_QUEUE_WRITER_CANCEL_COUNTER: IntCounter = register_int_counter!(
-        "table_queue_writer_cancel_counter",
-        "Counter for table queue writer cancel"
-    ).unwrap();
     // End of counters.
 
     // Histograms:

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -321,9 +321,8 @@ impl TableImpl {
                     .start_table_write_queue_waiter_timer();
                 // The request is successfully pushed into the queue, and just wait for the
                 // write result.
-                let waiter_fut = async move { rx.await };
                 match CancellationSafeFuture::new(
-                    waiter_fut,
+                    rx,
                     "pending_queue_waiter".to_string(),
                     self.instance.write_runtime().clone(),
                 )

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -315,12 +315,17 @@ impl TableImpl {
                 }
             }
             QueueResult::Waiter(rx) => {
+                // The request is successfully pushed into the queue, and just wait for the
+                // write result.
                 let _timer = self
                     .table_data
                     .metrics
                     .start_table_write_queue_waiter_timer();
-                // The request is successfully pushed into the queue, and just wait for the
-                // write result.
+
+                // We have ever observed that `rx` is closed in production but it is impossible
+                // in theory(especially after warping actual write by
+                // `CancellationSafeFuture`)... So we also warp `rx` by
+                // `CancellationSafeFuture` for not just retrying but better observing.
                 match CancellationSafeFuture::new(
                     rx,
                     "pending_queue_waiter".to_string(),

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -305,7 +305,7 @@ impl TableImpl {
 
                 match CancellationSafeFuture::new(
                     Self::write_requests(write_requests),
-                    "pending_queue_writer".to_string(),
+                    "pending_queue_writer",
                     self.instance.write_runtime().clone(),
                 )
                 .await
@@ -328,7 +328,7 @@ impl TableImpl {
                 // `CancellationSafeFuture` for not just retrying but better observing.
                 match CancellationSafeFuture::new(
                     rx,
-                    "pending_queue_waiter".to_string(),
+                    "pending_queue_waiter",
                     self.instance.write_runtime().clone(),
                 )
                 .await

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -324,7 +324,7 @@ impl TableImpl {
 
                 // We have ever observed that `rx` is closed in production but it is impossible
                 // in theory(especially after warping actual write by
-                // `CancellationSafeFuture`)... So we also warp `rx` by
+                // `CancellationSafeFuture`). So we also warp `rx` by
                 // `CancellationSafeFuture` for not just retrying but better observing.
                 match CancellationSafeFuture::new(
                     rx,

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -288,6 +288,8 @@ impl TableImpl {
 
         match queue_res {
             QueueResult::First => {
+                let _timer = self.table_data.metrics.start_table_write_queue_writer_timer();
+                
                 // This is the first request in the queue, and we should
                 // take responsibilities for merging and writing the
                 // requests in the queue.
@@ -309,6 +311,7 @@ impl TableImpl {
                 }
             }
             QueueResult::Waiter(rx) => {
+                let _timer = self.table_data.metrics.start_table_write_queue_waiter_timer();
                 // The request is successfully pushed into the queue, and just wait for the
                 // write result.
                 match rx.await {

--- a/components/future_ext/Cargo.toml
+++ b/components/future_ext/Cargo.toml
@@ -26,5 +26,7 @@ workspace = true
 
 [dependencies]
 futures = { workspace = true }
+lazy_static = { workspace = true }
+prometheus = { workspace = true }
 runtime = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/components/future_ext/src/cancel.rs
+++ b/components/future_ext/src/cancel.rs
@@ -167,7 +167,7 @@ mod tests {
                 async move {
                     done_captured.store(true, Ordering::SeqCst);
                 },
-                "test".to_string(),
+                "test",
                 runtime_clone,
             );
 
@@ -190,7 +190,7 @@ mod tests {
                 async move {
                     done_captured.wait().await;
                 },
-                "test".to_string(),
+                "test",
                 runtime_clone,
             );
 

--- a/components/future_ext/src/cancel.rs
+++ b/components/future_ext/src/cancel.rs
@@ -46,7 +46,7 @@ pub struct CancellationSafeFuture<F, T>
 where
     F: Future + Send + 'static,
     F::Output: Send,
-    T: AsRef<str> + 'static,
+    T: AsRef<str> + 'static + Send + Unpin,
 {
     /// Token for metrics
     token: T,
@@ -73,12 +73,12 @@ impl<F, T> Drop for CancellationSafeFuture<F, T>
 where
     F: Future + Send + 'static,
     F::Output: Send,
-    T: AsRef<str> + 'static,
+    T: AsRef<str> + 'static + Send + Unpin,
 {
     fn drop(&mut self) {
         if !self.done {
             FUTURE_CANCEL_COUNTER
-                .with_label_values(&[self.token.as_str()])
+                .with_label_values(&[self.token.as_ref()])
                 .inc();
 
             let inner = self.inner.take().unwrap();
@@ -92,7 +92,7 @@ impl<F, T> CancellationSafeFuture<F, T>
 where
     F: Future + Send,
     F::Output: Send,
-    T: AsRef<str> + 'static,
+    T: AsRef<str> + 'static + Send + Unpin,
 {
     /// Create new future that is protected from cancellation.
     ///
@@ -113,7 +113,7 @@ impl<F, T> Future for CancellationSafeFuture<F, T>
 where
     F: Future + Send,
     F::Output: Send,
-    T: AsRef<str> + 'static,
+    T: AsRef<str> + 'static + Send + Unpin,
 {
     type Output = F::Output;
 


### PR DESCRIPTION
## Rationale
Write path metrics about pending queue is not enough, improve it in this pr.

## Detailed Changes
+ Add time cost for pending queue wirter/waiter.
+ Add counter for related future cacellations.

## Test Plan
Test manually.