### PR TITLE
feat: infer timestamp constraint for single-timestamp column

### DIFF
--- a/query_frontend/src/parser.rs
+++ b/query_frontend/src/parser.rs
@@ -995,34 +995,52 @@ mod tests {
         expect_parse_ok(sql, expected).unwrap();
 
         // positive case, multiple columns
+        let columns = vec![
+            make_column_def("c1", DataType::Timestamp(None, TimezoneInfo::None)),
+            make_column_def("c2", DataType::Double),
+            make_column_def("c3", DataType::String),
+        ];
+
         let sql = "CREATE TABLE mytbl(c1 timestamp, c2 double, c3 string,) ENGINE = XX";
         let expected = Statement::Create(Box::new(CreateTable {
             if_not_exists: false,
             table_name: make_table_name("mytbl"),
-            columns: vec![
-                make_column_def("c1", DataType::Timestamp(None, TimezoneInfo::None)),
-                make_column_def("c2", DataType::Double),
-                make_column_def("c3", DataType::String),
-            ],
+            columns: columns.clone(),
             engine: "XX".to_string(),
-            constraints: vec![],
+            constraints: vec![TableConstraint::Unique {
+                name: Some(Ident {
+                    value: TS_KEY.to_owned(),
+                    quote_style: None,
+                }),
+                columns: vec![columns[0].name.clone()],
+                is_primary: false,
+            }],
             options: vec![],
             partition: None,
         }));
         expect_parse_ok(sql, expected).unwrap();
 
         // positive case, multiple columns with comment
+        let columns = vec![
+            make_column_def("c1", DataType::Timestamp(None, TimezoneInfo::None)),
+            make_comment_column_def("c2", DataType::Double, "id".to_string()),
+            make_comment_column_def("c3", DataType::String, "name".to_string()),
+        ];
+
         let sql = "CREATE TABLE mytbl(c1 timestamp, c2 double comment 'id', c3 string comment 'name',) ENGINE = XX";
         let expected = Statement::Create(Box::new(CreateTable {
             if_not_exists: false,
             table_name: make_table_name("mytbl"),
-            columns: vec![
-                make_column_def("c1", DataType::Timestamp(None, TimezoneInfo::None)),
-                make_comment_column_def("c2", DataType::Double, "id".to_string()),
-                make_comment_column_def("c3", DataType::String, "name".to_string()),
-            ],
+            columns: columns.clone(),
             engine: "XX".to_string(),
-            constraints: vec![],
+            constraints: vec![TableConstraint::Unique {
+                name: Some(Ident {
+                    value: TS_KEY.to_owned(),
+                    quote_style: None,
+                }),
+                columns: vec![columns[0].name.clone()],
+                is_primary: false,
+            }],
             options: vec![],
             partition: None,
         }));

--- a/query_frontend/src/parser.rs
+++ b/query_frontend/src/parser.rs
@@ -418,7 +418,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        build_and_check_timestamp_key_constraint(&columns, &mut constraints);
+        build_or_infer_timestamp_key_constraint(&columns, &mut constraints);
 
         Ok((columns, constraints))
     }
@@ -791,11 +791,11 @@ fn check_column_expr_validity_in_hash(column: &Ident, columns: &[ColumnDef]) -> 
     valid_column.is_some()
 }
 
-/// Builds and checks for the existence of a timestamp key constraint named
-/// __ts_key within the given list of table constraints. If such a constraint
-/// does not exist, the function searches for a unique timestamp column and
-/// creates a new constraint for it.
-fn build_and_check_timestamp_key_constraint(
+/// Builds for the existence of a timestamp key constraint named
+/// __ts_key within the given list of table constraints first. If such a
+/// constraint does not exist, the function will try to search for a unique
+/// timestamp column and create a new constraint for it.
+fn build_or_infer_timestamp_key_constraint(
     col_defs: &[ColumnDef],
     constraints: &mut Vec<TableConstraint>,
 ) {

--- a/query_frontend/src/parser.rs
+++ b/query_frontend/src/parser.rs
@@ -1046,6 +1046,34 @@ mod tests {
         }));
         expect_parse_ok(sql, expected).unwrap();
 
+        // Explicitly declare `c2` as timestamp key column
+        let columns = vec![
+            make_column_def("c1", DataType::Timestamp(None, TimezoneInfo::None)),
+            make_column_def("c2", DataType::Timestamp(None, TimezoneInfo::None)),
+            make_column_def("c3", DataType::String),
+            make_column_def("c4", DataType::Double),
+        ];
+
+        let sql =
+            "CREATE TABLE mytbl(c1 timestamp, c2 timestamp, c3 string, c4 double, timestamp key(c2),) ENGINE = XX";
+        let expected = Statement::Create(Box::new(CreateTable {
+            if_not_exists: false,
+            table_name: make_table_name("mytbl"),
+            columns: columns.clone(),
+            engine: "XX".to_string(),
+            constraints: vec![TableConstraint::Unique {
+                name: Some(Ident {
+                    value: TS_KEY.to_owned(),
+                    quote_style: None,
+                }),
+                columns: vec![columns[1].name.clone()],
+                is_primary: false,
+            }],
+            options: vec![],
+            partition: None,
+        }));
+        expect_parse_ok(sql, expected).unwrap();
+
         // Error cases: Invalid sql
         let sql = "CREATE TABLE t(c1 timestamp) AS";
         expect_parse_error(


### PR DESCRIPTION
## Rationale

This PR aims to resolve issue #1144 by simplifying the process of table creation with timestamp constraints. Specifically, the system will automatically infer and set the timestamp constraint under the following conditions:

1. No timestamp constraint has been previously set.
2. There exists exactly one column with a timestamp data type(`DataType::Timestamp`).

By introducing this automatic inference, we reduce the complexity for users who otherwise would have to manually set this constraint.

## Detailed Changes

- **Automatic Inference of Timestamp Constraint**: The system now detects if there is only a single timestamp column during table creation and automatically sets it as the timestamp constraint.
  - Added a function `build_and_check_timestamp_key_constraint` for checking and inference.
  - Modified the `create_table` function to call the new function.

- **Updated Test Expectations for `create_table`**:
  - Refactored test cases for `create_table` in `parser.rs` to align with the latest timestamp inference changes.
  - Updated the expected statements to include unique constraints for timestamp columns.

## Test Plan

Utilized the default CI Action for testing. The result was a [pass](https://github.com/Dennis40816/ceresdb/actions/runs/6545705109).

## Remarks

- Made modifications to a particular section of the code. Would appreciate it if experienced team members could review and confirm whether any changes or corrections are needed.