### PR TITLE
feat: optimize memtable iter

### DIFF
--- a/analytic_engine/src/instance/reorder_memtable.rs
+++ b/analytic_engine/src/instance/reorder_memtable.rs
@@ -39,7 +39,7 @@ use datafusion::{
         execute_stream, DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
         RecordBatchStream as DfRecordBatchStream, SendableRecordBatchStream, Statistics,
     },
-    prelude::{col, Expr, SessionConfig, SessionContext},
+    prelude::{col, ident, Expr, SessionConfig, SessionContext},
     sql::TableReference,
 };
 use futures::{Stream, StreamExt};
@@ -244,7 +244,7 @@ impl Reorder {
         let columns = schema.columns();
         let sort_exprs = sort_by_col_idx
             .iter()
-            .map(|i| col(&columns[*i].name).sort(true, true))
+            .map(|i| ident(&columns[*i].name).sort(true, true))
             .collect::<Vec<_>>();
         let df_plan = LogicalPlanBuilder::scan(DUMMY_TABLE_NAME, source, None)?
             .sort(sort_exprs)?


### PR DESCRIPTION
## Rationale
Currently memtable's design is very unfriendly for query latest data, it will scan entirely whole data, this maybe worse when table has very wide columns.

## Detailed Changes


## Test Plan

