### PR TITLE
ci: setup golang in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal
@@ -246,6 +249,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.21
       - run: |
           rustup set auto-self-update disable
           rustup toolchain install ${RUST_VERSION} --profile minimal

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -26,7 +26,7 @@ export CLUSTER_CERESDB_STDOUT_FILE_1 ?= /tmp/ceresdb-stdout-1.log
 export RUST_BACKTRACE=1
 
 # Whether update related repos
-# We don't want to rebuild the binarie and data on sometimes(e.g. debugging in local),
+# We don't want to rebuild the binaries and data on sometimes(e.g. debugging in local),
 # and we can set it to false.
 export UPDATE_REPOS_TO_LATEST ?= true
 


### PR DESCRIPTION
We may use `go-version-file` instead to avoid manually maintain the `go-version` field.

But the approach we currently clone ceresmeta and build is a bit complex to change; so I'd prefer to postpone it to a follow-up nice-to-have task.