### PR TITLE
chore: remove default features in analytic_engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ build:
 	ls -alh
 	cd $(DIR); cargo build --release $(CARGO_FEATURE_FLAGS)
 
+build-wal-table-kv:
+	ls -alh
+	cd $(DIR); cargo build --release --no-default-features --features wal-table-kv
+
+build-wal-message-queue:
+	ls -alh
+	cd $(DIR); cargo build --release --no-default-features --features wal-message-queue
+
 build-slim:
 	ls -alh
 	cd $(DIR); cargo build --profile release-slim $(CARGO_FEATURE_FLAGS)

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ build:
 
 build-wal-table-kv:
 	ls -alh
-	cd $(DIR); cargo build --release --no-default-features --features wal-table-kv
+	cd $(DIR)/src/ceresdb; cargo build --release --no-default-features --features wal-table-kv
 
 build-wal-message-queue:
 	ls -alh
-	cd $(DIR); cargo build --release --no-default-features --features wal-message-queue
+	cd $(DIR)/src/ceresdb; cargo build --release --no-default-features --features wal-message-queue
 
 build-slim:
 	ls -alh

--- a/analytic_engine/Cargo.toml
+++ b/analytic_engine/Cargo.toml
@@ -25,7 +25,6 @@ workspace = true
 workspace = true
 
 [features]
-default = ["wal-rocksdb", "wal-table-kv", "wal-message-queue"]
 test = ["tempfile"]
 wal-table-kv = ["wal/wal-table-kv"]
 wal-message-queue = ["wal/wal-message-queue"]

--- a/src/ceresdb/Cargo.toml
+++ b/src/ceresdb/Cargo.toml
@@ -26,9 +26,9 @@ workspace = true
 
 [features]
 default = ["wal-rocksdb", "wal-table-kv", "wal-message-queue"]
-wal-table-kv = ["wal/wal-table-kv"]
-wal-message-queue = ["wal/wal-message-queue"]
-wal-rocksdb = ["wal/wal-rocksdb"]
+wal-table-kv = ["wal/wal-table-kv", "analytic_engine/wal-table-kv"]
+wal-message-queue = ["wal/wal-message-queue", "analytic_engine/wal-message-queue"]
+wal-rocksdb = ["wal/wal-rocksdb", "analytic_engine/wal-rocksdb"]
 
 [dependencies]
 analytic_engine = { workspace = true }


### PR DESCRIPTION
## Rationale
Currently although wal is gated by different features,  we can't disable a wal implementation.

## Detailed Changes
- Remove default default in analytic_engine, and let upper layer to choose which wal to use.

## Test Plan
Manually.

