### PR TITLE
fix: log third party crates

### DIFF
--- a/components/logger/src/lib.rs
+++ b/components/logger/src/lib.rs
@@ -117,12 +117,13 @@ where
 
     fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
         let tag = record.tag();
-        if tag.is_empty() {
+        if tag == DEFAULT_TAG {
             self.normal.log(record, values)
         } else if self.slow.is_some() && tag == SLOW_QUERY_TAG {
             self.slow.as_ref().unwrap().log(record, values)
         } else {
-            Ok(())
+            // For crates outside ceresdb
+            self.normal.log(record, values)
         }
     }
 }


### PR DESCRIPTION
## Rationale
Currently we set tag to empty string to tell it from slow log, this works for crates within ceresdb,
but for crates outside ceresdb, it will discard log.

## Detailed Changes

## Test Plan

