### PR TITLE
fix: ensure primary key order

### DIFF
--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -673,6 +673,7 @@ mod tests {
         let schema = SchemaBuilder::new()
             .add_key_column(column_schema)
             .unwrap()
+            .primary_key_indexes(vec![0])
             .build()
             .unwrap();
         let row_group = RowGroupBuilder::with_rows(schema, rows).unwrap().build();

--- a/analytic_engine/src/manifest/details.rs
+++ b/analytic_engine/src/manifest/details.rs
@@ -766,6 +766,7 @@ mod tests {
 
     fn build_altered_schema(schema: &Schema) -> Schema {
         let mut builder = schema::Builder::new().auto_increment_column_id(true);
+        let old_pk_indexes = schema.primary_key_indexes();
         for column_schema in schema.key_columns() {
             builder = builder
                 .add_key_column(column_schema.clone())
@@ -783,6 +784,7 @@ mod tests {
                     .expect("should succeed build column schema"),
             )
             .unwrap()
+            .primary_key_indexes(old_pk_indexes.to_vec())
             .build()
             .unwrap()
     }

--- a/analytic_engine/src/sst/meta_data/cache.rs
+++ b/analytic_engine/src/sst/meta_data/cache.rs
@@ -307,6 +307,7 @@ mod tests {
                 .unwrap()
                 .add_key_column(timestamp_column_schema)
                 .unwrap()
+                .primary_key_indexes(vec![0, 1])
                 .build()
                 .unwrap()
         };

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -637,6 +637,7 @@ mod tests {
     ) -> WriteRequest {
         let schema = FixedSchemaTable::default_schema_builder()
             .version(schema_version)
+            .primary_key_indexes(vec![0, 1])
             .build()
             .unwrap();
         let mut schema_rows = Vec::with_capacity(num_rows);

--- a/analytic_engine/src/tests/alter_test.rs
+++ b/analytic_engine/src/tests/alter_test.rs
@@ -132,7 +132,10 @@ async fn alter_schema_same_schema_version_case<T: WalsOpener>(
 
     let mut schema_builder = FixedSchemaTable::default_schema_builder();
     schema_builder = add_columns(schema_builder);
-    let new_schema = schema_builder.build().unwrap();
+    let new_schema = schema_builder
+        .primary_key_indexes(vec![0, 1])
+        .build()
+        .unwrap();
 
     let table = test_ctx.table(table_name);
     let old_schema = table.schema();
@@ -160,6 +163,7 @@ async fn alter_schema_old_pre_version_case<T: WalsOpener>(
 
     let new_schema = schema_builder
         .version(old_schema.version() + 1)
+        .primary_key_indexes(old_schema.primary_key_indexes().to_vec())
         .build()
         .unwrap();
 
@@ -190,6 +194,7 @@ async fn alter_schema_add_column_case<T: WalsOpener>(
 
     let new_schema = schema_builder
         .version(old_schema.version() + 1)
+        .primary_key_indexes(old_schema.primary_key_indexes().to_vec())
         .build()
         .unwrap();
 

--- a/analytic_engine/src/tests/drop_test.rs
+++ b/analytic_engine/src/tests/drop_test.rs
@@ -278,8 +278,10 @@ fn test_alter_schema_drop_create<T: EngineBuildContext>(engine_context: T) {
                     .unwrap(),
             )
             .unwrap();
+
         let new_schema = schema_builder
             .version(old_schema.version() + 1)
+            .primary_key_indexes(old_schema.primary_key_indexes().to_vec())
             .build()
             .unwrap();
         let request = AlterSchemaRequest {

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -336,7 +336,8 @@ pub fn create_schema_builder(
     assert!(!key_tuples.is_empty());
 
     let mut schema_builder = schema::Builder::with_capacity(key_tuples.len() + normal_tuples.len())
-        .auto_increment_column_id(true);
+        .auto_increment_column_id(true)
+        .primary_key_indexes((0..key_tuples.len()).collect());
 
     for tuple in key_tuples {
         // Key column is not nullable.

--- a/common_types/src/schema.rs
+++ b/common_types/src/schema.rs
@@ -981,7 +981,7 @@ impl TryFrom<schema_pb::TableSchema> for Schema {
             .collect::<Result<Vec<_>>>()?;
         builder = builder.primary_key_indexes(primary_key_indexes);
 
-        for column_schema_pb in schema.columns.into_iter() {
+        for column_schema_pb in schema.columns {
             let column =
                 ColumnSchema::try_from(column_schema_pb).context(ColumnSchemaDeserializeFailed)?;
             if primary_key_ids.contains(&column.id) {

--- a/common_types/src/tests.rs
+++ b/common_types/src/tests.rs
@@ -73,11 +73,13 @@ fn base_schema_builder() -> schema::Builder {
                 .expect("should succeed build column schema"),
         )
         .unwrap()
+        .primary_key_indexes(vec![0, 1])
 }
 
 fn default_value_schema_builder() -> schema::Builder {
     schema::Builder::new()
         .auto_increment_column_id(true)
+        .primary_key_indexes(vec![0, 1])
         .add_key_column(
             column_schema::Builder::new("key1".to_string(), DatumKind::Varbinary)
                 .build()
@@ -233,7 +235,7 @@ pub fn build_schema_for_cpu() -> Schema {
         )
         .unwrap();
 
-    builder.build().unwrap()
+    builder.primary_key_indexes(vec![0, 1]).build().unwrap()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/interpreters/src/alter_table.rs
+++ b/interpreters/src/alter_table.rs
@@ -94,6 +94,7 @@ fn build_new_schema(current_schema: &Schema, column_schemas: Vec<ColumnSchema>) 
 
     let mut builder =
         schema::Builder::with_capacity(current_schema.num_columns() + column_schemas.len())
+            .primary_key_indexes(current_schema.primary_key_indexes().to_vec())
             // Increment the schema version.
             .version(current_version + 1);
     for (idx, column) in current_schema.columns().iter().enumerate() {

--- a/proxy/src/grpc/prom_query.rs
+++ b/proxy/src/grpc/prom_query.rs
@@ -390,6 +390,7 @@ mod tests {
                     .unwrap(),
             )
             .unwrap()
+            .primary_key_indexes(vec![0, 1])
             .build()
             .unwrap()
     }

--- a/proxy/src/http/prom.rs
+++ b/proxy/src/http/prom.rs
@@ -605,6 +605,7 @@ mod tests {
                     .unwrap(),
             )
             .unwrap()
+            .primary_key_indexes(vec![0, 1])
             .build()
             .unwrap()
     }

--- a/proxy/src/influxdb/types.rs
+++ b/proxy/src/influxdb/types.rs
@@ -796,6 +796,7 @@ mod tests {
                     .expect("should succeed build column schema"),
             )
             .unwrap()
+            .primary_key_indexes(vec![0])
             .build()
             .unwrap();
 

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -1112,6 +1112,7 @@ mod test {
                     .unwrap(),
             )
             .unwrap()
+            .primary_key_indexes(vec![0, 1, 2])
             .build()
             .unwrap()
     }

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -534,7 +534,10 @@ pub fn build_schema_from_write_table_request(
             .context(BuildTableSchema {})?;
     }
 
-    schema_builder.build().context(BuildTableSchema {})
+    schema_builder
+        .primary_key_indexes(vec![0, 1])
+        .build()
+        .context(BuildTableSchema {})
 }
 
 fn ensure_data_type_compatible(
@@ -647,6 +650,10 @@ impl<'a, P: MetaProvider> PlannerDelegate<'a, P> {
             schema::Builder::with_capacity(columns_by_name.len()).auto_increment_column_id(true);
 
         // Collect the key columns.
+        // TODO: Here we put key column in front of all columns, this may change column
+        // order defined by users.
+        let primary_key_indexes = (0..primary_key_columns.len()).collect();
+        schema_builder = schema_builder.primary_key_indexes(primary_key_indexes);
         for key_col in primary_key_columns {
             let col_name = key_col.value.as_str();
             let col = columns_by_name

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -724,6 +724,7 @@ fn new_sys_catalog_schema() -> schema::Result<Schema> {
                 .build()
                 .expect("Should succeed to build column schema of catalog"),
         )?
+        .primary_key_indexes(vec![0, 1])
         .build()
 }
 

--- a/system_catalog/src/tables.rs
+++ b/system_catalog/src/tables.rs
@@ -91,6 +91,7 @@ fn tables_schema() -> Schema {
                 .unwrap(),
         )
         .unwrap()
+        .primary_key_indexes(vec![0, 1, 2])
         .build()
         .unwrap()
 }

--- a/table_engine/src/partition/rule/df_adapter/mod.rs
+++ b/table_engine/src/partition/rule/df_adapter/mod.rs
@@ -286,6 +286,7 @@ mod tests {
                     .expect("should succeed build column schema"),
             )
             .unwrap()
+            .primary_key_indexes(vec![0, 1])
             .build()
             .expect("should succeed to build schema")
     }


### PR DESCRIPTION
## Rationale
Current schema builder set `primary_key_index` inside `add_key_column`, which means key_indexes could only be in ascending order.

## Detailed Changes
- Remove nullable limit for pk
- Refactor `primary_key_index`, user need to set it explicitly

## Test Plan
Existing tests.

