### PR TITLE
refactor: remove unused min/max timestamp in the RowGroup

### DIFF
--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -712,7 +712,7 @@ mod tests {
     use common_types::{
         column_schema::Builder as ColumnSchemaBuilder,
         datum::{Datum, DatumKind},
-        row::{Row, RowGroupBuilder},
+        row::Row,
         schema::Builder as SchemaBuilder,
         time::Timestamp,
     };
@@ -737,7 +737,7 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        let row_group = RowGroupBuilder::with_rows(schema, rows).unwrap().build();
+        let row_group = RowGroup::new_checked(schema, rows).unwrap();
 
         (encoded_rows, row_group)
     }

--- a/analytic_engine/src/instance/write.rs
+++ b/analytic_engine/src/instance/write.rs
@@ -737,7 +737,7 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        let row_group = RowGroup::new_checked(schema, rows).unwrap();
+        let row_group = RowGroup::try_new(schema, rows).unwrap();
 
         (encoded_rows, row_group)
     }

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -22,7 +22,7 @@ use std::{
 
 use async_trait::async_trait;
 use common_types::{
-    row::{Row, RowGroupBuilder},
+    row::{Row, RowGroup},
     schema::Schema,
     time::TimeRange,
 };
@@ -251,20 +251,19 @@ fn merge_pending_write_requests(
     assert!(!pending_writes.is_empty());
 
     let mut last_req = pending_writes.pop().unwrap();
-    let last_rows = last_req.row_group.take_rows();
-    let schema = last_req.row_group.into_schema();
-    let mut row_group_builder = RowGroupBuilder::with_capacity(schema, num_pending_rows);
-
-    for mut pending_req in pending_writes {
-        let rows = pending_req.row_group.take_rows();
-        for row in rows {
-            row_group_builder.push_checked_row(row)
+    let total_rows = {
+        let mut rows = Vec::with_capacity(num_pending_rows);
+        for mut pending_req in pending_writes {
+            let mut pending_rows = pending_req.row_group.take_rows();
+            rows.append(&mut pending_rows);
         }
-    }
-    for row in last_rows {
-        row_group_builder.push_checked_row(row);
-    }
-    let row_group = row_group_builder.build();
+        let mut last_rows = last_req.row_group.take_rows();
+        rows.append(&mut last_rows);
+        rows
+    };
+
+    let schema = last_req.row_group.into_schema();
+    let row_group = RowGroup::new_unchecked(schema, total_rows);
     WriteRequest { row_group }
 }
 
@@ -652,7 +651,7 @@ mod tests {
             schema_rows.push(row);
         }
         let rows = row_util::new_rows_6(&schema_rows);
-        let row_group = RowGroupBuilder::with_rows(schema, rows).unwrap().build();
+        let row_group = RowGroup::new_checked(schema, rows).unwrap();
         WriteRequest { row_group }
     }
 

--- a/analytic_engine/src/table/mod.rs
+++ b/analytic_engine/src/table/mod.rs
@@ -651,7 +651,7 @@ mod tests {
             schema_rows.push(row);
         }
         let rows = row_util::new_rows_6(&schema_rows);
-        let row_group = RowGroup::new_checked(schema, rows).unwrap();
+        let row_group = RowGroup::try_new(schema, rows).unwrap();
         WriteRequest { row_group }
     }
 

--- a/analytic_engine/src/tests/alter_test.rs
+++ b/analytic_engine/src/tests/alter_test.rs
@@ -227,7 +227,7 @@ async fn alter_schema_add_column_case<T: WalsOpener>(
         ),
     ];
     let rows_vec = row_util::new_rows_8(&rows);
-    let row_group = RowGroup::new_checked(new_schema.clone(), rows_vec).unwrap();
+    let row_group = RowGroup::try_new(new_schema.clone(), rows_vec).unwrap();
 
     // Write data with new schema.
     test_ctx.write_to_table(table_name, row_group).await;
@@ -281,7 +281,7 @@ async fn alter_schema_add_column_case<T: WalsOpener>(
         )),
     ];
     let new_schema_row_group =
-        RowGroup::new_checked(new_schema.clone(), new_schema_rows.to_vec()).unwrap();
+        RowGroup::try_new(new_schema.clone(), new_schema_rows.to_vec()).unwrap();
 
     // Read data using new schema.
     check_read_row_group(
@@ -328,8 +328,7 @@ async fn alter_schema_add_column_case<T: WalsOpener>(
         ),
     ];
     let old_schema_rows_vec = row_util::new_rows_6(&old_schema_rows);
-    let old_schema_row_group =
-        RowGroup::new_checked(old_schema.clone(), old_schema_rows_vec).unwrap();
+    let old_schema_row_group = RowGroup::try_new(old_schema.clone(), old_schema_rows_vec).unwrap();
 
     // Read data using old schema.
     check_read_row_group(

--- a/analytic_engine/src/tests/alter_test.rs
+++ b/analytic_engine/src/tests/alter_test.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, HashMap};
 use common_types::{
     column_schema,
     datum::DatumKind,
-    row::{RowGroup, RowGroupBuilder},
+    row::RowGroup,
     schema::{self, Schema},
     time::Timestamp,
 };
@@ -227,9 +227,7 @@ async fn alter_schema_add_column_case<T: WalsOpener>(
         ),
     ];
     let rows_vec = row_util::new_rows_8(&rows);
-    let row_group = RowGroupBuilder::with_rows(new_schema.clone(), rows_vec)
-        .unwrap()
-        .build();
+    let row_group = RowGroup::new_checked(new_schema.clone(), rows_vec).unwrap();
 
     // Write data with new schema.
     test_ctx.write_to_table(table_name, row_group).await;
@@ -283,9 +281,7 @@ async fn alter_schema_add_column_case<T: WalsOpener>(
         )),
     ];
     let new_schema_row_group =
-        RowGroupBuilder::with_rows(new_schema.clone(), new_schema_rows.to_vec())
-            .unwrap()
-            .build();
+        RowGroup::new_checked(new_schema.clone(), new_schema_rows.to_vec()).unwrap();
 
     // Read data using new schema.
     check_read_row_group(
@@ -332,9 +328,8 @@ async fn alter_schema_add_column_case<T: WalsOpener>(
         ),
     ];
     let old_schema_rows_vec = row_util::new_rows_6(&old_schema_rows);
-    let old_schema_row_group = RowGroupBuilder::with_rows(old_schema.clone(), old_schema_rows_vec)
-        .unwrap()
-        .build();
+    let old_schema_row_group =
+        RowGroup::new_checked(old_schema.clone(), old_schema_rows_vec).unwrap();
 
     // Read data using old schema.
     check_read_row_group(

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -22,7 +22,7 @@ use common_types::{
     projected_schema::ProjectedSchema,
     record_batch::RecordBatch,
     request_id::RequestId,
-    row::{Row, RowGroup, RowGroupBuilder},
+    row::{Row, RowGroup},
     schema::{self, Schema},
     table::DEFAULT_SHARD_ID,
     time::Timestamp,
@@ -122,9 +122,7 @@ impl FixedSchemaTable {
     }
 
     fn new_row_group(&self, rows: Vec<Row>) -> RowGroup {
-        RowGroupBuilder::with_rows(self.create_request.params.table_schema.clone(), rows)
-            .unwrap()
-            .build()
+        RowGroup::new_checked(self.create_request.params.table_schema.clone(), rows).unwrap()
     }
 
     fn new_row_opt(data: RowTupleOpt) -> Row {

--- a/analytic_engine/src/tests/table.rs
+++ b/analytic_engine/src/tests/table.rs
@@ -122,7 +122,7 @@ impl FixedSchemaTable {
     }
 
     fn new_row_group(&self, rows: Vec<Row>) -> RowGroup {
-        RowGroup::new_checked(self.create_request.params.table_schema.clone(), rows).unwrap()
+        RowGroup::try_new(self.create_request.params.table_schema.clone(), rows).unwrap()
     }
 
     fn new_row_opt(data: RowTupleOpt) -> Row {

--- a/common_types/src/row/mod.rs
+++ b/common_types/src/row/mod.rs
@@ -268,7 +268,7 @@ impl RowGroup {
     /// [None] will be thrown if the rows have different schema from the
     /// provided one.
     #[inline]
-    pub fn new_checked(schema: Schema, rows: Vec<Row>) -> Result<Self> {
+    pub fn try_new(schema: Schema, rows: Vec<Row>) -> Result<Self> {
         rows.iter()
             .try_for_each(|row| check_row_schema(row, &schema))?;
 

--- a/common_types/src/row/mod.rs
+++ b/common_types/src/row/mod.rs
@@ -15,7 +15,6 @@
 //! Row type
 
 use std::{
-    cmp,
     collections::HashMap,
     ops::{Index, IndexMut},
 };
@@ -252,14 +251,30 @@ pub struct RowGroup {
     schema: Schema,
     /// Rows in the row group
     rows: Vec<Row>,
-    // TODO(yingwen): Maybe remove min/max timestamp
-    /// Min timestamp of all the rows
-    min_timestamp: Timestamp,
-    /// Max timestamp of all the rows
-    max_timestamp: Timestamp,
 }
 
 impl RowGroup {
+    /// Create [RowGroup] without any check.
+    ///
+    /// The caller should ensure all the rows share the same schema as the
+    /// provided one.
+    #[inline]
+    pub fn new_unchecked(schema: Schema, rows: Vec<Row>) -> Self {
+        Self { schema, rows }
+    }
+
+    /// Check and create row group.
+    ///
+    /// [None] will be thrown if the rows have different schema from the
+    /// provided one.
+    #[inline]
+    pub fn new_checked(schema: Schema, rows: Vec<Row>) -> Result<Self> {
+        rows.iter()
+            .try_for_each(|row| check_row_schema(row, &schema))?;
+
+        Ok(Self { schema, rows })
+    }
+
     /// Returns true if the row group is empty
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -317,18 +332,6 @@ impl RowGroup {
         IterRow {
             iter: self.rows.iter(),
         }
-    }
-
-    /// Get the min timestamp of rows
-    #[inline]
-    pub fn min_timestamp(&self) -> Timestamp {
-        self.min_timestamp
-    }
-
-    /// Get the max timestamp of rows
-    #[inline]
-    pub fn max_timestamp(&self) -> Timestamp {
-        self.max_timestamp
     }
 }
 
@@ -433,8 +436,6 @@ impl RowGroupBuilderFromColumn {
             return RowGroup {
                 schema: self.schema,
                 rows: vec![],
-                min_timestamp: Timestamp::new(0),
-                max_timestamp: Timestamp::new(0),
             };
         };
 
@@ -470,124 +471,15 @@ impl RowGroupBuilderFromColumn {
             }
         }
 
-        let rows = rows.into_iter().map(Row::from_datums).collect::<Vec<_>>();
-
-        let (min_timestamp, max_timestamp) = self
-            .collect_minmax_timestamps(&rows)
-            .unwrap_or_else(|| (Timestamp::default(), Timestamp::default()));
-
         RowGroup {
             schema: self.schema,
-            rows,
-            min_timestamp,
-            max_timestamp,
+            rows: rows.into_iter().map(Row::from_datums).collect::<Vec<_>>(),
         }
     }
 
     #[inline]
     fn num_rows(&self) -> Option<usize> {
         self.cols.iter().next().map(|(_, v)| v.len())
-    }
-
-    fn collect_minmax_timestamps(&self, rows: &[Row]) -> Option<(Timestamp, Timestamp)> {
-        let timestamp_idx = self.schema.timestamp_index();
-        if rows.is_empty() {
-            return None;
-        }
-
-        rows.iter()
-            .fold(None, |prev: Option<(Timestamp, Timestamp)>, row| {
-                let timestamp = row[timestamp_idx].as_timestamp()?;
-                match prev {
-                    None => Some((timestamp, timestamp)),
-                    Some((min_ts, max_ts)) => Some((min_ts.min(timestamp), max_ts.max(timestamp))),
-                }
-            })
-    }
-}
-
-/// RowGroup builder
-#[derive(Debug)]
-pub struct RowGroupBuilder {
-    schema: Schema,
-    rows: Vec<Row>,
-    min_timestamp: Option<Timestamp>,
-    max_timestamp: Timestamp,
-}
-
-impl RowGroupBuilder {
-    /// Create a new builder
-    pub fn new(schema: Schema) -> Self {
-        Self::with_capacity(schema, 0)
-    }
-
-    /// Create a new builder with given capacity
-    pub fn with_capacity(schema: Schema, capacity: usize) -> Self {
-        Self {
-            schema,
-            rows: Vec::with_capacity(capacity),
-            min_timestamp: None,
-            max_timestamp: Timestamp::new(0),
-        }
-    }
-
-    /// Create a new builder with schema and rows
-    ///
-    /// Return error if the `rows` do not matched the `schema`
-    pub fn with_rows(schema: Schema, rows: Vec<Row>) -> Result<Self> {
-        let mut row_group = Self::new(schema);
-
-        // Check schema and update min/max timestamp
-        for row in &rows {
-            check_row_schema(row, &row_group.schema)?;
-            row_group.update_timestamps(row);
-        }
-
-        row_group.rows = rows;
-
-        Ok(row_group)
-    }
-
-    /// Add a schema checked row
-    ///
-    /// REQUIRE: Caller should ensure the schema of row must equal to the schema
-    /// of this builder
-    pub fn push_checked_row(&mut self, row: Row) {
-        self.update_timestamps(&row);
-
-        self.rows.push(row);
-    }
-
-    /// Acquire builder to build next row of the row group
-    pub fn row_builder(&mut self) -> RowBuilder {
-        RowBuilder {
-            // schema: &self.schema,
-            cols: Vec::with_capacity(self.schema.num_columns()),
-            // rows: &mut self.rows,
-            group_builder: self,
-        }
-    }
-
-    /// Build the row group
-    pub fn build(self) -> RowGroup {
-        RowGroup {
-            schema: self.schema,
-            rows: self.rows,
-            min_timestamp: self.min_timestamp.unwrap_or_else(|| Timestamp::new(0)),
-            max_timestamp: self.max_timestamp,
-        }
-    }
-
-    /// Update min/max timestamp of the row group
-    fn update_timestamps(&mut self, row: &Row) {
-        // check_row_schema() ensures this datum is a timestamp, so we just unwrap here
-        let row_timestamp = row.timestamp(&self.schema).unwrap();
-
-        self.min_timestamp = match self.min_timestamp {
-            Some(min_timestamp) => Some(cmp::min(min_timestamp, row_timestamp)),
-            None => Some(row_timestamp),
-        };
-        self.max_timestamp = cmp::max(self.max_timestamp, row_timestamp);
     }
 }
 
@@ -615,16 +507,21 @@ pub fn check_datum_type(datum: &Datum, column_schema: &ColumnSchema) -> Result<(
     Ok(())
 }
 
-// TODO(yingwen): This builder is used to build RowGroup, need to provide a
-// builder to build one row
 /// Row builder for the row group
 #[derive(Debug)]
 pub struct RowBuilder<'a> {
-    group_builder: &'a mut RowGroupBuilder,
+    schema: &'a Schema,
     cols: Vec<Datum>,
 }
 
 impl<'a> RowBuilder<'a> {
+    pub fn new(schema: &'a Schema) -> RowBuilder<'a> {
+        Self {
+            schema,
+            cols: Vec::with_capacity(schema.num_columns()),
+        }
+    }
+
     /// Append a datum into the row
     pub fn append_datum(mut self, datum: Datum) -> Result<Self> {
         self.check_datum(&datum)?;
@@ -637,28 +534,23 @@ impl<'a> RowBuilder<'a> {
     /// Check whether the datum is valid
     fn check_datum(&self, datum: &Datum) -> Result<()> {
         let index = self.cols.len();
-        let schema = &self.group_builder.schema;
         ensure!(
-            index < schema.num_columns(),
+            index < self.schema.num_columns(),
             ColumnOutOfBound {
-                len: schema.num_columns(),
+                len: self.schema.num_columns(),
                 given: index,
             }
         );
 
-        let column = schema.column(index);
+        let column = self.schema.column(index);
         check_datum_type(datum, column)
     }
 
     /// Finish building this row and append this row into the row group
-    pub fn finish(self) -> Result<()> {
-        ensure!(
-            self.cols.len() == self.group_builder.schema.num_columns(),
-            MissingColumns
-        );
+    pub fn finish(self) -> Result<Row> {
+        ensure!(self.cols.len() == self.schema.num_columns(), MissingColumns);
 
-        self.group_builder.push_checked_row(Row { cols: self.cols });
-        Ok(())
+        Ok(Row { cols: self.cols })
     }
 }
 

--- a/proxy/src/write.rs
+++ b/proxy/src/write.rs
@@ -821,7 +821,7 @@ fn write_table_request_to_insert_plan(
         total_rows.append(&mut rows);
     }
     // The row group builder will checks nullable.
-    let row_group = RowGroup::new_checked(schema, total_rows)
+    let row_group = RowGroup::try_new(schema, total_rows)
         .box_err()
         .with_context(|| ErrWithCause {
             code: StatusCode::INTERNAL_SERVER_ERROR,

--- a/query_engine/src/datafusion_impl/physical_plan.rs
+++ b/query_engine/src/datafusion_impl/physical_plan.rs
@@ -112,7 +112,7 @@ impl PhysicalPlan for DataFusionPhysicalPlanAdapter {
         info!(
             "DatafusionExecutorImpl get the executable plan, request_id:{}, physical_plan:{}",
             df_task_ctx.ctx.request_id,
-            displayable(executable.as_ref()).indent(true).to_string()
+            displayable(executable.as_ref()).indent(true)
         );
 
         // Kept the executed plan.

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -35,7 +35,7 @@ use common_types::{
     column_schema::{self, ColumnSchema},
     datum::{Datum, DatumKind},
     request_id::RequestId,
-    row::{RowGroup, RowGroupBuilder},
+    row::{RowBuilder, RowGroup},
     schema::{self, Builder as SchemaBuilder, Schema, TSID_COLUMN},
 };
 use datafusion::{
@@ -1138,12 +1138,12 @@ fn build_row_group(
     match *source.body {
         SetExpr::Values(Values {
             explicit_row: _,
-            rows,
+            rows: expr_rows,
         }) => {
-            let mut row_group_builder = RowGroupBuilder::with_capacity(schema.clone(), rows.len());
-            for mut exprs in rows {
+            let mut rows = Vec::with_capacity(expr_rows.len());
+            for mut exprs in expr_rows {
                 // Try to build row
-                let mut row_builder = row_group_builder.row_builder();
+                let mut row_builder = RowBuilder::new(&schema);
 
                 // For each column in schema, append datum into row builder
                 for (index_opt, column_schema) in
@@ -1176,11 +1176,12 @@ fn build_row_group(
                 }
 
                 // Finish this row and append into row group
-                row_builder.finish().context(BuildRow)?;
+                let row = row_builder.finish().context(BuildRow)?;
+                rows.push(row);
             }
 
             // Build the whole row group
-            Ok(row_group_builder.build())
+            Ok(RowGroup::new_unchecked(schema, rows))
         }
         _ => InsertSourceBodyNotSet.fail(),
     }

--- a/query_frontend/src/planner.rs
+++ b/query_frontend/src/planner.rs
@@ -1892,12 +1892,6 @@ mod tests {
                     ],
                 },
             ],
-            min_timestamp: Timestamp(
-                1638428434000,
-            ),
-            max_timestamp: Timestamp(
-                1638428434000,
-            ),
         },
         default_value_map: {},
     },

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -875,7 +875,7 @@ impl CreateCatalogRequest {
             .finish()
             .context(BuildRow)?;
 
-        RowGroup::new_checked(schema, vec![row]).context(BuildRowGroup)
+        RowGroup::try_new(schema, vec![row]).context(BuildRowGroup)
     }
 
     fn to_key(&self) -> Result<Bytes> {

--- a/system_catalog/src/sys_catalog_table.rs
+++ b/system_catalog/src/sys_catalog_table.rs
@@ -27,7 +27,7 @@ use common_types::{
     projected_schema::ProjectedSchema,
     record_batch::RecordBatch,
     request_id::RequestId,
-    row::{Row, RowGroup, RowGroupBuilder},
+    row::{Row, RowBuilder, RowGroup},
     schema::{self, Schema},
     table::DEFAULT_SHARD_ID,
     time::Timestamp,
@@ -152,8 +152,11 @@ pub enum Error {
         backtrace: Backtrace,
     },
 
-    #[snafu(display("Failed to build row for entry, err:{}", source))]
+    #[snafu(display("Failed to build row for entry, err:{source}"))]
     BuildRow { source: common_types::row::Error },
+
+    #[snafu(display("Failed to build row group, err:{source}"))]
+    BuildRowGroup { source: common_types::row::Error },
 
     #[snafu(display(
         "Failed to decode protobuf for entry, err:{}.\nBacktrace:\n{}",
@@ -859,9 +862,7 @@ impl CreateCatalogRequest {
     fn into_row_group(self, schema: Schema) -> Result<RowGroup> {
         let key = self.to_key()?;
         let value = self.into_bytes();
-        let mut builder = RowGroupBuilder::new(schema);
-        builder
-            .row_builder()
+        let row = RowBuilder::new(&schema)
             // key
             .append_datum(Datum::Varbinary(key))
             .context(BuildRow)?
@@ -874,7 +875,7 @@ impl CreateCatalogRequest {
             .finish()
             .context(BuildRow)?;
 
-        Ok(builder.build())
+        RowGroup::new_checked(schema, vec![row]).context(BuildRowGroup)
     }
 
     fn to_key(&self) -> Result<Bytes> {
@@ -921,9 +922,7 @@ impl CreateSchemaRequest {
     fn into_row_group(self, schema: Schema) -> Result<RowGroup> {
         let key = self.to_key()?;
         let value = self.into_bytes();
-        let mut builder = RowGroupBuilder::new(schema);
-        builder
-            .row_builder()
+        let row = RowBuilder::new(&schema)
             // key
             .append_datum(Datum::Varbinary(key))
             .context(BuildRow)?
@@ -936,7 +935,7 @@ impl CreateSchemaRequest {
             .finish()
             .context(BuildRow)?;
 
-        Ok(builder.build())
+        Ok(RowGroup::new_unchecked(schema, vec![row]))
     }
 
     fn to_key(&self) -> Result<Bytes> {
@@ -1008,7 +1007,7 @@ impl TableWriter {
 
     /// Convert the table to write into [common_types::row::RowGroup].
     fn convert_table_info_to_row_group(&self) -> Result<RowGroup> {
-        let mut builder = RowGroupBuilder::new(self.catalog_table.schema());
+        let schema = self.catalog_table.schema();
         let key = Self::build_create_table_key(&self.table_to_write)?;
         let value = Self::build_create_table_value(self.table_to_write.clone(), self.typ)?;
 
@@ -1017,14 +1016,14 @@ impl TableWriter {
             key, value
         );
 
-        Self::build_row(&mut builder, key, value)?;
+        let row = Self::build_table_info_row(&schema, key, value)?;
+        let row_group = RowGroup::new_unchecked(schema, vec![row]);
 
-        Ok(builder.build())
+        Ok(row_group)
     }
 
-    fn build_row(builder: &mut RowGroupBuilder, key: Bytes, value: Bytes) -> Result<()> {
-        builder
-            .row_builder()
+    fn build_table_info_row(schema: &Schema, key: Bytes, value: Bytes) -> Result<Row> {
+        RowBuilder::new(schema)
             // key
             .append_datum(Datum::Varbinary(key))
             .context(BuildRow)?
@@ -1035,8 +1034,7 @@ impl TableWriter {
             .append_datum(Datum::Varbinary(value))
             .context(BuildRow)?
             .finish()
-            .context(BuildRow)?;
-        Ok(())
+            .context(BuildRow)
     }
 
     fn build_create_table_key(table_info: &TableInfo) -> Result<Bytes> {

--- a/table_engine/src/partition/rule/df_adapter/mod.rs
+++ b/table_engine/src/partition/rule/df_adapter/mod.rs
@@ -78,7 +78,7 @@ mod tests {
     use common_types::{
         column_schema,
         datum::{Datum, DatumKind},
-        row::RowGroupBuilder,
+        row::RowBuilder,
         schema::{Builder, Schema, TSID_COLUMN},
         string::StringBytes,
         time::Timestamp,
@@ -199,9 +199,7 @@ mod tests {
             ],
         ];
 
-        let mut row_group_builder = RowGroupBuilder::new(schema.clone());
-        row_group_builder
-            .row_builder()
+        let row0 = RowBuilder::new(&schema)
             .append_datum(Datum::UInt64(0))
             .unwrap()
             .append_datum(Datum::Timestamp(Timestamp::new(0)))
@@ -214,8 +212,7 @@ mod tests {
             .unwrap()
             .finish()
             .unwrap();
-        row_group_builder
-            .row_builder()
+        let row1 = RowBuilder::new(&schema)
             .append_datum(Datum::UInt64(1))
             .unwrap()
             .append_datum(Datum::Timestamp(Timestamp::new(1)))
@@ -228,7 +225,7 @@ mod tests {
             .unwrap()
             .finish()
             .unwrap();
-        let row_group = row_group_builder.build();
+        let row_group = RowGroup::new_unchecked(schema.clone(), vec![row0, row1]);
 
         // Basic flow
         let key_rule_adapter =


### PR DESCRIPTION
## Rationale
The min/max timestamp in `RowGroup` is not used any more.

## Detailed Changes
- Remove the min/max timestamp from the `RowGroup`
- Remove the `RowGroupBuilder` because it's too simple without min/max timestamp updating

## Test Plan
All the tests in the CI should pass.