### PR TITLE
feat: support stack size of read threads configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "serde",
  "server",
  "signal-hook",
+ "size_ext",
  "table_engine",
  "toml 0.7.3",
  "toml_ext",

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -154,7 +154,7 @@ impl Default for WalEncodeConfig {
     fn default() -> Self {
         Self {
             num_bytes_compress_threshold: ReadableSize::kb(1),
-            format: WalEncodeFormat::RowWise,
+            format: WalEncodeFormat::Columnar,
         }
     }
 }

--- a/analytic_engine/src/lib.rs
+++ b/analytic_engine/src/lib.rs
@@ -154,7 +154,7 @@ impl Default for WalEncodeConfig {
     fn default() -> Self {
         Self {
             num_bytes_compress_threshold: ReadableSize::kb(1),
-            format: WalEncodeFormat::Columnar,
+            format: WalEncodeFormat::RowWise,
         }
     }
 }

--- a/components/runtime/src/lib.rs
+++ b/components/runtime/src/lib.rs
@@ -186,6 +186,15 @@ impl Builder {
         self
     }
 
+    /// Sets the size of the stack allocated to the worker threads the Runtime
+    /// will use.
+    ///
+    /// This can be any number above 0.
+    pub fn stack_size(&mut self, val: usize) -> &mut Self {
+        self.builder.thread_stack_size(val);
+        self
+    }
+
     /// Sets name of threads spawned by the Runtime thread pool
     pub fn thread_name(&mut self, val: impl Into<String>) -> &mut Self {
         self.thread_name = val.into();

--- a/src/ceresdb/Cargo.toml
+++ b/src/ceresdb/Cargo.toml
@@ -27,38 +27,48 @@ workspace = true
 [features]
 default = ["wal-rocksdb", "wal-table-kv", "wal-message-queue"]
 wal-table-kv = ["wal/wal-table-kv", "analytic_engine/wal-table-kv"]
-wal-message-queue = ["wal/wal-message-queue", "analytic_engine/wal-message-queue"]
+wal-message-queue = [
+    "wal/wal-message-queue",
+    "analytic_engine/wal-message-queue",
+]
 wal-rocksdb = ["wal/wal-rocksdb", "analytic_engine/wal-rocksdb"]
 
 [dependencies]
 analytic_engine = { workspace = true }
-catalog = { workspace = true }
-catalog_impls = { workspace = true }
-clap = { workspace = true }
-cluster = { workspace = true }
-datafusion = { workspace = true }
-df_operator = { workspace = true }
-etcd-client = { workspace = true }
-interpreters = { workspace = true }
-logger = { workspace = true }
-meta_client = { workspace = true }
-moka = { version = "0.10", features = ["future"] }
-panic_ext = { workspace = true }
-proxy = { workspace = true }
-query_engine = { workspace = true }
-router = { workspace = true }
-runtime = { workspace = true }
-serde = { workspace = true }
-server = { workspace = true }
-signal-hook = "0.3"
-table_engine = { workspace = true }
-toml = { workspace = true }
-toml_ext = { workspace = true }
-tracing_util = { workspace = true }
-wal = { workspace = true }
+catalog         = { workspace = true }
+catalog_impls   = { workspace = true }
+clap            = { workspace = true }
+cluster         = { workspace = true }
+datafusion      = { workspace = true }
+df_operator     = { workspace = true }
+etcd-client     = { workspace = true }
+interpreters    = { workspace = true }
+logger          = { workspace = true }
+meta_client     = { workspace = true }
+moka            = { version = "0.10", features = ["future"] }
+panic_ext       = { workspace = true }
+proxy           = { workspace = true }
+query_engine    = { workspace = true }
+router          = { workspace = true }
+runtime         = { workspace = true }
+serde           = { workspace = true }
+server          = { workspace = true }
+signal-hook     = "0.3"
+size_ext        = { workspace = true }
+table_engine    = { workspace = true }
+toml            = { workspace = true }
+toml_ext        = { workspace = true }
+tracing_util    = { workspace = true }
+wal             = { workspace = true }
 
 [build-dependencies]
-vergen = { version = "8", default-features = false, features = ["build", "cargo", "git", "gitcl", "rustc"] }
+vergen = { version = "8", default-features = false, features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+] }
 
 [[bin]]
 name = "ceresdb-server"

--- a/src/ceresdb/src/config.rs
+++ b/src/ceresdb/src/config.rs
@@ -18,6 +18,7 @@ use cluster::config::ClusterConfig;
 use proxy::limiter::LimiterConfig;
 use serde::{Deserialize, Serialize};
 use server::config::{ServerConfig, StaticRouteConfig};
+use size_ext::ReadableSize;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(default)]
@@ -92,6 +93,10 @@ pub enum ClusterDeployment {
 pub struct RuntimeConfig {
     /// Runtime for reading data
     pub read_thread_num: usize,
+    /// The size of the stack used by the read thread
+    ///
+    /// The size should be a set as a large number if the complex query exists.
+    pub read_thread_stack_size: ReadableSize,
     /// Runtime for writing data
     pub write_thread_num: usize,
     /// Runtime for communicating with meta cluster
@@ -108,6 +113,7 @@ impl Default for RuntimeConfig {
     fn default() -> Self {
         Self {
             read_thread_num: 8,
+            read_thread_stack_size: ReadableSize::mb(16),
             write_thread_num: 8,
             meta_thread_num: 2,
             compact_thread_num: 4,

--- a/src/ceresdb/src/config.rs
+++ b/src/ceresdb/src/config.rs
@@ -96,6 +96,8 @@ pub struct RuntimeConfig {
     /// The size of the stack used by the read thread
     ///
     /// The size should be a set as a large number if the complex query exists.
+    /// TODO: this config may be removed in the future when the complex query
+    /// won't overflow the stack.
     pub read_thread_stack_size: ReadableSize,
     /// Runtime for writing data
     pub write_thread_num: usize,


### PR DESCRIPTION
## Rationale
Complex sqls, e.g. sql with massive condition in the where clause, may lead to stack overflow during query procedure. And currently, there is no a good to handle it in the query engine powered by datafusion so a simple way is just to enlarge the stack for the read threads.

## Detailed Changes
- Support the stack size of read threads confiugrable
- Make the columnar format as the default wal payload

## Test Plan
All the tests in the ci should pass.