### PR TITLE
chore: refactor build_meta.sh in integration-test

### DIFF
--- a/integration_tests/build_meta.sh
+++ b/integration_tests/build_meta.sh
@@ -4,12 +4,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-BIN_PATH=${BIN_PATH:-""}
+CERESMETA_BIN_PATH=${CERESMETA_BIN_PATH:-""}
 
-echo "Fetch and install ceresmeta-server..."
-go install -a github.com/CeresDB/ceresmeta/cmd/ceresmeta-server@main
-BIN_PATH="$(go env GOPATH)/bin/ceresmeta-server"
+if [[ -z "${CERESMETA_BIN_PATH}" ]]; then
+    echo "Fetch and install ceresmeta-server..."
+    go install -a github.com/CeresDB/ceresmeta/cmd/ceresmeta-server@main
+    CERESMETA_BIN_PATH="$(go env GOPATH)/bin/ceresmeta-server"
+fi
 
 TARGET=$(pwd)/ceresmeta
 mkdir -p ${TARGET}
-cp ${BIN_PATH} ${TARGET}/ceresmeta-server
+cp ${CERESMETA_BIN_PATH} ${TARGET}/ceresmeta-server


### PR DESCRIPTION
## Rationale
Support specifying the Ceresmeta binary path in integration test.

## Detailed Changes
Check CERESMETA_BIN_PATH in integration test.

## Test Plan
CI.